### PR TITLE
Port change to example project re: Place property

### DIFF
--- a/examples/javascript/database-email-update/package.json
+++ b/examples/javascript/database-email-update/package.json
@@ -11,7 +11,7 @@
     "ts-run": "node --loader ts-node/esm index.ts"
   },
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "@sendgrid/mail": "^8.1.5",
     "dotenv": "^16.0.1",
     "ts-node": "^10.8.2"

--- a/examples/javascript/generate-random-data/index.ts
+++ b/examples/javascript/generate-random-data/index.ts
@@ -228,14 +228,13 @@ function extractPropertyItemValueToString(
       }`
     case "verification":
       return property.verification?.state ?? ""
-    // Note: "place" property type is not yet available in published SDK version
-    // case "place":
-    //   if (!property.place) {
-    //     return ""
-    //   }
-    //   return (
-    //     property.place.name ?? `${property.place.lat}, ${property.place.lon}`
-    //   )
+    case "place":
+      if (!property.place) {
+        return ""
+      }
+      return (
+        property.place.name ?? `${property.place.lat}, ${property.place.lon}`
+      )
   }
   return assertUnreachable(property)
 }

--- a/examples/javascript/generate-random-data/package.json
+++ b/examples/javascript/generate-random-data/package.json
@@ -9,7 +9,7 @@
   "author": "David Blackman",
   "license": "MIT",
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "@types/faker": "^5.5.5",
     "@types/lodash": "^4.14.170",
     "dotenv": "^8.2.0",

--- a/examples/javascript/intro-to-notion-api/package.json
+++ b/examples/javascript/intro-to-notion-api/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/makenotion/notion-sdk-js/issues"
   },
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/javascript/notion-github-sync/package.json
+++ b/examples/javascript/notion-github-sync/package.json
@@ -13,7 +13,7 @@
   "author": "Aman Gupta",
   "license": "MIT",
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "dotenv": "^16.0.1",
     "lodash": "^4.17.21",
     "octokit": "^3.2.1"

--- a/examples/javascript/notion-task-github-pr-sync/package.json
+++ b/examples/javascript/notion-task-github-pr-sync/package.json
@@ -13,7 +13,7 @@
   "author": "Sid Verma",
   "license": "MIT",
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "dotenv": "^16.0.1",
     "lodash": "^4.17.21",
     "octokit": "^3.2.1"

--- a/examples/javascript/parse-text-from-any-block-type/package.json
+++ b/examples/javascript/parse-text-from-any-block-type/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/makenotion/notion-sdk-js/issues"
   },
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "dotenv": "^17.2.1"
   },
   "devDependencies": {

--- a/examples/javascript/web-form-with-express/package.json
+++ b/examples/javascript/web-form-with-express/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node server.ts"
   },
   "dependencies": {
-    "@notionhq/client": "^5.3.0",
+    "@notionhq/client": "^5.4.0",
     "dotenv": "^16.3.1",
     "express": "^4.21.2"
   },


### PR DESCRIPTION
This PR adds a change that existed in the `notion-sdk-js` repo but not yet ported to this newer source of truth for `examples/` -- namely, adding support for `place` properties in `examples/javascript/generate-random-data/index.ts`, alongside an upgrade of the `notion-sdk-js` version from `5.3.0` to `5.4.0`.