### PR TITLE
Add PPT Creator worker tool example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,12 @@ The [javascript](javascript/) directory includes examples built with Notion's of
 - **[parse-text-from-any-block-type](javascript/parse-text-from-any-block-type/)**: Extract text content from different block types
 - **[web-form-with-express](javascript/web-form-with-express/)**: Build a web form that submits data to Notion
 
+### Workers
+
+The [workers](workers/) directory includes examples built with the Notion Workers SDK:
+
+- **[ppt-creator](workers/tools/ppt-creator/)**: Read a Notion page and generate a PowerPoint presentation, uploaded as a page comment
+
 ## Running an example
 
 Each example has its own README with specific instructions. Generally you'll need to:

--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -1,0 +1,9 @@
+# Workers
+
+This directory contains example [Notion workers](https://developers.notion.com/docs/workers) — server-side code that extends Notion with custom capabilities.
+
+## Tools
+
+The [tools](tools/) directory includes agent tool examples:
+
+- **[ppt-creator](tools/ppt-creator/)**: Read a Notion page and generate a PowerPoint presentation, uploaded as a page comment

--- a/examples/workers/tools/ppt-creator/README.md
+++ b/examples/workers/tools/ppt-creator/README.md
@@ -1,0 +1,91 @@
+# Worker Tool: PPT Creator
+
+A Notion worker tool that reads a Notion page and generates a PowerPoint presentation from its content. Each heading becomes a new slide. The `.pptx` file is uploaded and attached as a comment on the page.
+
+## How it works
+
+1. **Reads** the page title and content via the [Notion Markdown API](https://developers.notion.com/reference/get-page-markdown)
+2. **Parses** the markdown into slides — headings start new slides, content underneath (paragraphs, bullets, numbered lists, to-dos, code, quotes) becomes slide body
+3. **Generates** a `.pptx` file using [pptxgenjs](https://github.com/gitbrent/PptxGenJS) with Notion-inspired styling
+4. **Uploads** the file via the [Notion File Upload API](https://developers.notion.com/reference/file-uploads) and attaches it as a page comment
+
+## Project structure
+
+```
+src/
+  index.ts          — Worker tool definition
+  types.ts          — Slide and content types
+  theme.ts          — Notion-inspired color and font theme
+  notion.ts         — Notion API helpers (read page, parse markdown, upload file)
+  presentation.ts   — pptxgenjs slide builder with slide masters
+```
+
+## Setup
+
+### 1. Install the Notion Workers CLI
+
+```zsh
+npm install -g @notionhq/workers-cli
+```
+
+### 2. Clone and install
+
+```zsh
+# Clone this repository
+git clone https://github.com/makenotion/notion-cookbook.git
+
+# Switch into this project
+cd notion-cookbook/examples/workers/tools/ppt-creator
+
+# Install dependencies
+npm install
+```
+
+### 3. Connect to a workspace
+
+```zsh
+ntn login
+```
+
+### 4. Deploy
+
+```zsh
+ntn workers deploy --name ppt-creator
+```
+
+After deploying, connect the worker to a custom agent in Notion via **Tools and access > Add connection**.
+
+## Usage
+
+Once connected to an agent, ask it to create a presentation from any page:
+
+> "Create a PowerPoint presentation from this page"
+
+The agent will call the `createPresentation` tool, which reads the page content, generates the slides, and adds the `.pptx` file as a comment.
+
+## Local testing
+
+```zsh
+ntn workers exec createPresentation --local -d '{"pageId": "<your-page-id>"}'
+```
+
+## Slide design
+
+The presentation uses Notion-inspired styling defined via `defineSlideMaster()`:
+
+- **Title slide** — dark background with large title and accent line
+- **Section slide** — warm gray background for headings without body content
+- **Content slide** — white background with heading, divider, body area, footer bar, and slide numbers
+
+Inline markdown formatting is preserved: `**bold**` renders as bold and `*italic*` renders as italic in the slides.
+
+## Reading page content
+
+Two approaches are included in `notion.ts`:
+
+| Approach | Functions | How it works |
+|---|---|---|
+| **Markdown API** (active) | `getPageMarkdown` + `groupMarkdownIntoSlides` | Single API call, parses markdown string |
+| **Block API** (available) | `getAllBlocks` + `groupBlocksIntoSlides` | Paginated block fetching, switches on block types |
+
+Switch between them by changing the imports in `index.ts`.

--- a/examples/workers/tools/ppt-creator/package.json
+++ b/examples/workers/tools/ppt-creator/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "ppt-creator",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"check": "tsc --noEmit"
+	},
+	"engines": {
+		"node": ">=22.0.0",
+		"npm": ">=10.9.2"
+	},
+	"devDependencies": {
+		"@types/node": "^22.9.0",
+		"tsx": "^4.20.6",
+		"typescript": "^5.8.0"
+	},
+	"dependencies": {
+		"@notionhq/workers": ">=0.0.0",
+		"pptxgenjs": "^4.0.1"
+	}
+}

--- a/examples/workers/tools/ppt-creator/src/index.ts
+++ b/examples/workers/tools/ppt-creator/src/index.ts
@@ -1,0 +1,46 @@
+import { Worker } from "@notionhq/workers";
+import { j } from "@notionhq/workers/schema-builder";
+import {
+	extractPageId,
+	getPageTitle,
+	getPageMarkdown,
+	groupMarkdownIntoSlides,
+	uploadToNotion,
+} from "./notion.js";
+import { buildPresentation } from "./presentation.js";
+
+const worker = new Worker();
+export default worker;
+
+worker.tool("createPresentation", {
+	title: "Create Presentation",
+	description:
+		"Reads a Notion page and creates a PowerPoint presentation from its content. Each heading becomes a new slide. The generated .pptx file is added as a comment on the page.",
+	schema: j.object({
+		pageId: j
+			.string()
+			.describe(
+				"The Notion page ID or URL to convert into a presentation",
+			),
+	}),
+	execute: async ({ pageId: rawPageId }, { notion }) => {
+		const pageId = extractPageId(rawPageId);
+
+		const pageTitle = await getPageTitle(notion, pageId);
+
+		// Fetch page content as markdown and parse into slides
+		const markdown = await getPageMarkdown(pageId);
+		const slides = groupMarkdownIntoSlides(markdown, pageTitle);
+
+		// Build the .pptx file
+		const filename = `${pageTitle}.pptx`;
+		const buffer = await buildPresentation(pageTitle, slides);
+
+		// Upload and attach as a page comment
+		const slideCount = slides.length + 1;
+		const message = `Generated presentation with ${slideCount} slides from this page.`;
+		await uploadToNotion(pageId, filename, buffer, message);
+
+		return `Created "${filename}" (${slideCount} slides) and added it as a comment on the page.`;
+	},
+});

--- a/examples/workers/tools/ppt-creator/src/notion.ts
+++ b/examples/workers/tools/ppt-creator/src/notion.ts
@@ -1,5 +1,5 @@
 import type { Client } from "@notionhq/client";
-import type { Slide, RichText } from "./types.js";
+import type { Slide } from "./types.js";
 
 export async function getPageTitle(notion: Client, pageId: string): Promise<string> {
 	const page = (await notion.pages.retrieve({ page_id: pageId })) as Record<
@@ -21,93 +21,6 @@ export function extractPageId(input: string): string {
 	const match = clean.match(/([a-f0-9]{32})/i);
 	return match ? match[1] : input;
 }
-
-export function plainText(richText: RichText[]): string {
-	return richText.map((t) => t.plain_text).join("");
-}
-
-export async function getAllBlocks(notion: Client, blockId: string) {
-	const blocks: Array<Record<string, any>> = [];
-	let cursor: string | undefined;
-	do {
-		const response = await notion.blocks.children.list({
-			block_id: blockId,
-			start_cursor: cursor,
-			page_size: 100,
-		});
-		blocks.push(...(response.results as Array<Record<string, any>>));
-		cursor = response.has_more
-			? (response.next_cursor ?? undefined)
-			: undefined;
-	} while (cursor);
-	return blocks;
-}
-
-export function groupBlocksIntoSlides(
-	blocks: Array<Record<string, any>>,
-	pageTitle: string,
-): Slide[] {
-	const slides: Slide[] = [];
-	let current: Slide | null = null;
-
-	for (const block of blocks) {
-		const type: string = block.type;
-		const data = block[type];
-
-		if (type === "heading_1" || type === "heading_2" || type === "heading_3") {
-			if (current) slides.push(current);
-			current = { title: plainText(data.rich_text), items: [] };
-			continue;
-		}
-
-		if (!current) {
-			current = { title: pageTitle, items: [] };
-		}
-
-		switch (type) {
-			case "paragraph": {
-				const text = plainText(data.rich_text);
-				if (text) current.items.push({ text, type: "text" });
-				break;
-			}
-			case "bulleted_list_item": {
-				const text = plainText(data.rich_text);
-				if (text) current.items.push({ text, type: "bullet" });
-				break;
-			}
-			case "numbered_list_item": {
-				const text = plainText(data.rich_text);
-				if (text) current.items.push({ text, type: "numbered" });
-				break;
-			}
-			case "to_do": {
-				const text = plainText(data.rich_text);
-				if (text)
-					current.items.push({
-						text,
-						type: "todo",
-						checked: data.checked,
-					});
-				break;
-			}
-			case "code": {
-				const text = plainText(data.rich_text);
-				if (text) current.items.push({ text, type: "code" });
-				break;
-			}
-			case "quote": {
-				const text = plainText(data.rich_text);
-				if (text) current.items.push({ text, type: "quote" });
-				break;
-			}
-		}
-	}
-
-	if (current) slides.push(current);
-	return slides;
-}
-
-// --- Markdown API approach (single call, no pagination) ---
 
 export async function getPageMarkdown(pageId: string): Promise<string> {
 	const baseUrl = process.env.NOTION_API_BASE_URL ?? "https://api.notion.com";

--- a/examples/workers/tools/ppt-creator/src/notion.ts
+++ b/examples/workers/tools/ppt-creator/src/notion.ts
@@ -1,0 +1,311 @@
+import type { Client } from "@notionhq/client";
+import type { Slide, RichText } from "./types.js";
+
+export async function getPageTitle(notion: Client, pageId: string): Promise<string> {
+	const page = (await notion.pages.retrieve({ page_id: pageId })) as Record<
+		string,
+		any
+	>;
+	const titleProp = Object.values(
+		page.properties as Record<string, any>,
+	).find((p: any) => p.type === "title") as any;
+	return (
+		titleProp?.title
+			?.map((rt: { plain_text: string }) => rt.plain_text)
+			.join("") ?? "Untitled"
+	);
+}
+
+export function extractPageId(input: string): string {
+	const clean = input.replace(/-/g, "");
+	const match = clean.match(/([a-f0-9]{32})/i);
+	return match ? match[1] : input;
+}
+
+export function plainText(richText: RichText[]): string {
+	return richText.map((t) => t.plain_text).join("");
+}
+
+export async function getAllBlocks(notion: Client, blockId: string) {
+	const blocks: Array<Record<string, any>> = [];
+	let cursor: string | undefined;
+	do {
+		const response = await notion.blocks.children.list({
+			block_id: blockId,
+			start_cursor: cursor,
+			page_size: 100,
+		});
+		blocks.push(...(response.results as Array<Record<string, any>>));
+		cursor = response.has_more
+			? (response.next_cursor ?? undefined)
+			: undefined;
+	} while (cursor);
+	return blocks;
+}
+
+export function groupBlocksIntoSlides(
+	blocks: Array<Record<string, any>>,
+	pageTitle: string,
+): Slide[] {
+	const slides: Slide[] = [];
+	let current: Slide | null = null;
+
+	for (const block of blocks) {
+		const type: string = block.type;
+		const data = block[type];
+
+		if (type === "heading_1" || type === "heading_2" || type === "heading_3") {
+			if (current) slides.push(current);
+			current = { title: plainText(data.rich_text), items: [] };
+			continue;
+		}
+
+		if (!current) {
+			current = { title: pageTitle, items: [] };
+		}
+
+		switch (type) {
+			case "paragraph": {
+				const text = plainText(data.rich_text);
+				if (text) current.items.push({ text, type: "text" });
+				break;
+			}
+			case "bulleted_list_item": {
+				const text = plainText(data.rich_text);
+				if (text) current.items.push({ text, type: "bullet" });
+				break;
+			}
+			case "numbered_list_item": {
+				const text = plainText(data.rich_text);
+				if (text) current.items.push({ text, type: "numbered" });
+				break;
+			}
+			case "to_do": {
+				const text = plainText(data.rich_text);
+				if (text)
+					current.items.push({
+						text,
+						type: "todo",
+						checked: data.checked,
+					});
+				break;
+			}
+			case "code": {
+				const text = plainText(data.rich_text);
+				if (text) current.items.push({ text, type: "code" });
+				break;
+			}
+			case "quote": {
+				const text = plainText(data.rich_text);
+				if (text) current.items.push({ text, type: "quote" });
+				break;
+			}
+		}
+	}
+
+	if (current) slides.push(current);
+	return slides;
+}
+
+// --- Markdown API approach (single call, no pagination) ---
+
+export async function getPageMarkdown(pageId: string): Promise<string> {
+	const baseUrl = process.env.NOTION_API_BASE_URL ?? "https://api.notion.com";
+	const token = process.env.NOTION_API_TOKEN;
+
+	const res = await fetch(`${baseUrl}/v1/pages/${pageId}/markdown`, {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Notion-Version": "2026-03-11",
+		},
+	});
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`Failed to fetch page markdown: ${res.status} ${body}`);
+	}
+
+	const data = (await res.json()) as { markdown: string };
+	return data.markdown;
+}
+
+function cleanText(text: string): string {
+	return text
+		.replace(/\\([^\\])/g, "$1")
+		.replace(/<br\s*\/?>/gi, "\n")
+		.replace(/<[^>]+>/g, "")
+		.trim();
+}
+
+export function groupMarkdownIntoSlides(
+	markdown: string,
+	pageTitle: string,
+): Slide[] {
+	const lines = markdown.split("\n");
+	const slides: Slide[] = [];
+	let current: Slide | null = null;
+	let inCodeBlock = false;
+	let codeBuffer: string[] = [];
+
+	for (const line of lines) {
+		if (line.startsWith("```")) {
+			if (inCodeBlock) {
+				if (current && codeBuffer.length > 0) {
+					current.items.push({
+						text: codeBuffer.join("\n"),
+						type: "code",
+					});
+				}
+				codeBuffer = [];
+			}
+			inCodeBlock = !inCodeBlock;
+			continue;
+		}
+
+		if (inCodeBlock) {
+			codeBuffer.push(line);
+			continue;
+		}
+
+		// Skip lines that are just HTML/Notion tags (callout, file, etc.)
+		if (/^\s*<\/?[a-z][^>]*>\s*$/i.test(line)) continue;
+
+		// Headings start new slides
+		const headingMatch = line.match(/^(#{1,3})\s+(.+)/);
+		if (headingMatch) {
+			if (current) slides.push(current);
+			current = {
+				title: cleanText(headingMatch[2].trim()),
+				items: [],
+			};
+			continue;
+		}
+
+		// Skip horizontal rules / dividers
+		if (/^[-*_]{3,}\s*$/.test(line.trim())) continue;
+
+		if (!current) {
+			current = { title: pageTitle, items: [] };
+		}
+
+		// To-do items (must check before bullets)
+		const todoMatch = line.match(/^[-*]\s+\[([ xX])\]\s+(.*)/);
+		if (todoMatch) {
+			const text = cleanText(todoMatch[2].trim());
+			if (text)
+				current.items.push({
+					text,
+					type: "todo",
+					checked: todoMatch[1] !== " ",
+				});
+			continue;
+		}
+
+		// Bullet lists
+		const bulletMatch = line.match(/^[-*]\s+(.*)/);
+		if (bulletMatch) {
+			const text = cleanText(bulletMatch[1].trim());
+			if (text) current.items.push({ text, type: "bullet" });
+			continue;
+		}
+
+		// Numbered lists
+		const numberedMatch = line.match(/^\d+\.\s+(.*)/);
+		if (numberedMatch) {
+			const text = cleanText(numberedMatch[1].trim());
+			if (text) current.items.push({ text, type: "numbered" });
+			continue;
+		}
+
+		// Quotes
+		const quoteMatch = line.match(/^>\s+(.*)/);
+		if (quoteMatch) {
+			const text = cleanText(quoteMatch[1].trim());
+			if (text) current.items.push({ text, type: "quote" });
+			continue;
+		}
+
+		// Regular text (skip empty lines)
+		const text = cleanText(line.trim());
+		if (text) current.items.push({ text, type: "text" });
+	}
+
+	if (current) slides.push(current);
+	return slides;
+}
+
+// --- Upload ---
+
+export async function uploadToNotion(
+	pageId: string,
+	filename: string,
+	buffer: Buffer,
+	message: string,
+): Promise<void> {
+	const baseUrl = process.env.NOTION_API_BASE_URL ?? "https://api.notion.com";
+	const token = process.env.NOTION_API_TOKEN;
+	const version = "2026-03-11";
+
+	// Step 1: Create file upload
+	const createRes = await fetch(`${baseUrl}/v1/file_uploads`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Notion-Version": version,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			filename,
+			content_type:
+				"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		}),
+	});
+	if (!createRes.ok) {
+		const body = await createRes.text();
+		throw new Error(`Failed to create file upload: ${createRes.status} ${body}`);
+	}
+	const { id: uploadId } = (await createRes.json()) as { id: string };
+
+	// Step 2: Send file bytes
+	const formData = new FormData();
+	const mimeType =
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation";
+	formData.append(
+		"file",
+		new Blob([new Uint8Array(buffer)], { type: mimeType }),
+		filename,
+	);
+
+	const sendRes = await fetch(`${baseUrl}/v1/file_uploads/${uploadId}/send`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Notion-Version": version,
+		},
+		body: formData,
+	});
+	if (!sendRes.ok) {
+		const body = await sendRes.text();
+		throw new Error(`Failed to upload file: ${sendRes.status} ${body}`);
+	}
+
+	// Step 3: Add as a page comment with the file attached
+	const commentRes = await fetch(`${baseUrl}/v1/comments`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Notion-Version": version,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			parent: { page_id: pageId },
+			rich_text: [{ text: { content: message } }],
+			attachments: [
+				{ type: "file_upload", file_upload_id: uploadId },
+			],
+		}),
+	});
+	if (!commentRes.ok) {
+		const body = await commentRes.text();
+		throw new Error(`Failed to create comment: ${commentRes.status} ${body}`);
+	}
+}

--- a/examples/workers/tools/ppt-creator/src/presentation.ts
+++ b/examples/workers/tools/ppt-creator/src/presentation.ts
@@ -1,0 +1,295 @@
+import pptxgen from "pptxgenjs";
+import { THEME } from "./theme.js";
+import type { Slide, SlideItem } from "./types.js";
+
+function parseItalic(
+	text: string,
+	baseOptions: pptxgen.TextPropsOptions,
+): pptxgen.TextProps[] {
+	const runs: pptxgen.TextProps[] = [];
+	const parts = text.split(/(\*[^*]+\*)/g);
+
+	for (const part of parts) {
+		if (!part) continue;
+		if (part.startsWith("*") && part.endsWith("*")) {
+			runs.push({
+				text: part.slice(1, -1),
+				options: { ...baseOptions, italic: true },
+			});
+		} else {
+			runs.push({ text: part, options: { ...baseOptions } });
+		}
+	}
+
+	return runs;
+}
+
+function parseInlineMarkdown(
+	text: string,
+	baseOptions: pptxgen.TextPropsOptions,
+): pptxgen.TextProps[] {
+	const runs: pptxgen.TextProps[] = [];
+	const parts = text.split(/(\*\*[^*]+\*\*)/g);
+
+	for (const part of parts) {
+		if (!part) continue;
+		if (part.startsWith("**") && part.endsWith("**")) {
+			runs.push({
+				text: part.slice(2, -2),
+				options: { ...baseOptions, bold: true },
+			});
+		} else {
+			runs.push(...parseItalic(part, baseOptions));
+		}
+	}
+
+	if (runs.length === 0) {
+		runs.push({ text, options: { ...baseOptions } });
+	}
+
+	return runs;
+}
+
+function itemToTextRuns(item: SlideItem): pptxgen.TextProps[] {
+	const baseFont: pptxgen.TextPropsOptions = {
+		fontFace: THEME.font,
+		fontSize: 15,
+		color: THEME.text,
+	};
+
+	const paraOptions: pptxgen.TextPropsOptions = {
+		paraSpaceAfter: 6,
+	};
+
+	let text = item.text;
+
+	switch (item.type) {
+		case "bullet":
+			paraOptions.bullet = true;
+			paraOptions.indentLevel = 0;
+			break;
+		case "numbered":
+			paraOptions.bullet = { type: "number" };
+			paraOptions.indentLevel = 0;
+			break;
+		case "todo":
+			text = `${item.checked ? "☑" : "☐"}  ${text}`;
+			break;
+		case "quote":
+			baseFont.italic = true;
+			baseFont.color = THEME.textLight;
+			paraOptions.paraSpaceAfter = 10;
+			break;
+		case "code":
+			baseFont.fontFace = THEME.monoFont;
+			baseFont.fontSize = 12;
+			baseFont.color = THEME.textLight;
+			baseFont.highlight = THEME.codeBg;
+			break;
+		case "text":
+			paraOptions.paraSpaceAfter = 12;
+			break;
+	}
+
+	const runs = parseInlineMarkdown(text, baseFont);
+
+	runs[0].options = { ...runs[0].options, ...paraOptions };
+	runs[runs.length - 1].options = {
+		...runs[runs.length - 1].options,
+		breakLine: true,
+	};
+
+	return runs;
+}
+
+function defineMasters(pres: pptxgen): void {
+	pres.defineSlideMaster({
+		title: "TITLE_SLIDE",
+		background: { color: THEME.titleBg },
+		objects: [
+			{
+				rect: {
+					x: 0.8,
+					y: 3.6,
+					w: 1.2,
+					h: 0.05,
+					fill: { color: THEME.accent },
+				},
+			},
+			{
+				placeholder: {
+					options: {
+						name: "title",
+						type: "title",
+						x: 0.8,
+						y: 1.2,
+						w: 8.4,
+						h: 2.2,
+						fontFace: THEME.font,
+						fontSize: 40,
+						color: THEME.bg,
+						bold: true,
+						align: "left",
+						valign: "bottom",
+					},
+				},
+			},
+			{
+				placeholder: {
+					options: {
+						name: "subtitle",
+						type: "body",
+						x: 0.8,
+						y: 3.9,
+						w: 8.4,
+						h: 0.6,
+						fontFace: THEME.font,
+						fontSize: 16,
+						color: THEME.textLight,
+						align: "left",
+					},
+				},
+			},
+		],
+	});
+
+	pres.defineSlideMaster({
+		title: "SECTION_SLIDE",
+		background: { color: THEME.bgWarm },
+		objects: [
+			{
+				rect: {
+					x: 0,
+					y: 0,
+					w: 0.06,
+					h: "100%",
+					fill: { color: THEME.accent },
+				},
+			},
+			{
+				placeholder: {
+					options: {
+						name: "title",
+						type: "title",
+						x: 0.8,
+						y: 1.8,
+						w: 8.4,
+						h: 1.5,
+						fontFace: THEME.font,
+						fontSize: 32,
+						color: THEME.text,
+						bold: true,
+						align: "left",
+						valign: "middle",
+					},
+				},
+			},
+		],
+	});
+
+	pres.defineSlideMaster({
+		title: "CONTENT_SLIDE",
+		background: { color: THEME.bg },
+		objects: [
+			{
+				rect: {
+					x: 0,
+					y: 0,
+					w: 0.06,
+					h: "100%",
+					fill: { color: THEME.accent },
+				},
+			},
+			{
+				rect: {
+					x: 0.6,
+					y: 1.05,
+					w: 8.9,
+					h: 0.01,
+					fill: { color: THEME.divider },
+				},
+			},
+			{
+				rect: {
+					x: 0,
+					y: 5.1,
+					w: "100%",
+					h: 0.525,
+					fill: { color: THEME.bgWarm },
+				},
+			},
+			{
+				placeholder: {
+					options: {
+						name: "header",
+						type: "title",
+						x: 0.6,
+						y: 0.2,
+						w: 8.9,
+						h: 0.75,
+						fontFace: THEME.font,
+						fontSize: 24,
+						color: THEME.text,
+						bold: true,
+						valign: "bottom",
+					},
+				},
+			},
+			{
+				placeholder: {
+					options: {
+						name: "body",
+						type: "body",
+						x: 0.6,
+						y: 1.2,
+						w: 8.9,
+						h: 3.7,
+						fontFace: THEME.font,
+						fontSize: 15,
+						color: THEME.text,
+						valign: "top",
+					},
+				},
+			},
+		],
+		slideNumber: {
+			x: 9.2,
+			y: 5.2,
+			color: THEME.textLight,
+			fontSize: 9,
+			fontFace: THEME.font,
+		},
+	});
+}
+
+export async function buildPresentation(
+	title: string,
+	slides: Slide[],
+): Promise<Buffer> {
+	const pres = new pptxgen();
+	pres.title = title;
+	pres.layout = "LAYOUT_16x9";
+
+	defineMasters(pres);
+
+	// Title slide
+	const titleSlide = pres.addSlide({ masterName: "TITLE_SLIDE" });
+	titleSlide.addText(title, { placeholder: "title" });
+
+	// Content slides
+	for (const slide of slides) {
+		if (slide.items.length === 0) {
+			// Section break slide for headings with no content
+			const s = pres.addSlide({ masterName: "SECTION_SLIDE" });
+			s.addText(slide.title, { placeholder: "title" });
+		} else {
+			const s = pres.addSlide({ masterName: "CONTENT_SLIDE" });
+			s.addText(slide.title, { placeholder: "header" });
+			s.addText(slide.items.flatMap(itemToTextRuns), {
+				placeholder: "body",
+			});
+		}
+	}
+
+	return (await pres.write({ outputType: "nodebuffer" })) as Buffer;
+}

--- a/examples/workers/tools/ppt-creator/src/theme.ts
+++ b/examples/workers/tools/ppt-creator/src/theme.ts
@@ -1,0 +1,12 @@
+export const THEME = {
+	text: "37352F",
+	textLight: "787774",
+	accent: "2EAADC",
+	bg: "FFFFFF",
+	bgWarm: "F7F6F3",
+	codeBg: "F1F1EF",
+	divider: "E3E2DE",
+	titleBg: "191919",
+	font: "Inter",
+	monoFont: "Courier New",
+};

--- a/examples/workers/tools/ppt-creator/src/types.ts
+++ b/examples/workers/tools/ppt-creator/src/types.ts
@@ -8,7 +8,3 @@ export interface Slide {
 	title: string;
 	items: SlideItem[];
 }
-
-export interface RichText {
-	plain_text: string;
-}

--- a/examples/workers/tools/ppt-creator/src/types.ts
+++ b/examples/workers/tools/ppt-creator/src/types.ts
@@ -1,0 +1,14 @@
+export interface SlideItem {
+	text: string;
+	type: "text" | "bullet" | "numbered" | "todo" | "code" | "quote";
+	checked?: boolean;
+}
+
+export interface Slide {
+	title: string;
+	items: SlideItem[];
+}
+
+export interface RichText {
+	plain_text: string;
+}

--- a/examples/workers/tools/ppt-creator/tsconfig.json
+++ b/examples/workers/tools/ppt-creator/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "nodenext",
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"moduleResolution": "nodenext"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a new `examples/workers/` directory structure for Notion Workers SDK examples, organized by capability type (`tools/`, with room for `syncs/`, `automations/`, etc.)
- First example: **ppt-creator** — a worker tool that reads a Notion page and generates a `.pptx` presentation, uploaded as a page comment
- Updates the examples README to include a Workers section

## What the tool does

1. Reads the page via the Notion Markdown API (`GET /v1/pages/{id}/markdown`)
2. Parses headings into slides with typed content items (bullets, numbered lists, quotes, code, to-dos)
3. Generates a `.pptx` using pptxgenjs with Notion-inspired slide masters (`defineSlideMaster()`)
4. Uploads the file and attaches it as a page comment via the File Upload + Comments APIs

## File structure

```
examples/workers/
  README.md
  tools/
    ppt-creator/
      src/
        index.ts          — Worker tool definition
        types.ts          — Slide and content types
        theme.ts          — Notion-inspired color/font theme
        notion.ts         — Notion API helpers (markdown, blocks, upload)
        presentation.ts   — pptxgenjs slide builder
      package.json
      tsconfig.json
      README.md
```

## Test plan

- [ ] `npm install` and `npm run check` pass in the example directory
- [ ] `ntn workers deploy --name ppt-creator` deploys successfully
- [ ] Running against a Notion page with headings, bullets, and text produces a well-formatted `.pptx` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)