### PR TITLE
Add Linear worker sync example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -8,7 +8,7 @@ The [syncs](syncs/) directory includes one-way sync examples that bring data fro
 
 - **[zendesk](syncs/zendesk/)**: One-way sync from Zendesk tickets into a Notion database _(coming soon)_
 - **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
-- **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_
+- **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database
 
 ## Tools
 

--- a/examples/workers/syncs/linear/README.md
+++ b/examples/workers/syncs/linear/README.md
@@ -1,18 +1,88 @@
 # Worker Sync: Linear
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+A Notion worker that one-way syncs issues from a [Linear](https://linear.app) workspace into a managed Notion database. After deploy, Notion will hold a row per Linear issue, refreshed every 5 minutes via Linear's GraphQL API.
 
-A Notion worker sync that pulls Linear issues into a Notion database, keeping the database up to date as issues are created and updated in Linear.
+## Prerequisites
 
-## What this example will demonstrate
+- A Notion workspace where you can install workers.
+- A Linear workspace and a [personal API key](https://linear.app/settings/account/security) (Settings → Security & access → New API key).
+- Node.js ≥ 22 and the [`ntn` CLI](https://developers.notion.com/workers/get-started/quickstart) installed.
 
-- One-way sync from Linear issues into a Notion database
-- Webhook-driven updates from Linear into Notion using Linear's webhook events
-- Mapping Linear fields (state, priority, assignee, labels, project) to Notion properties
-- Querying Linear's GraphQL API from a Notion worker
+## Step 1 — Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/syncs/linear
+npm install
+ntn login
+```
+
+## Step 2 — Store your Linear API key
+
+```zsh
+ntn workers env set LINEAR_API_KEY=<your-key>
+```
+
+Linear personal API keys go in the `Authorization` header **without** a `Bearer` prefix — `linear.ts` handles this.
+
+## Step 3 — Deploy
+
+```zsh
+ntn workers deploy --name linear-sync
+```
+
+The deploy creates a managed database titled **Linear Issues** in your workspace. You can move it into any page after the first sync runs.
+
+## Step 4 — Run the first backfill
+
+The delta sync runs every 5 minutes, but it only catches issues updated _after_ it first runs. To populate the database from your existing Linear workspace, trigger the backfill once:
+
+```zsh
+ntn workers sync trigger issuesBackfill
+```
+
+Watch its progress:
+
+```zsh
+ntn workers sync status
+```
+
+When it finishes, open the **Linear Issues** database — every issue in your workspace should now have a row.
+
+## Step 5 — Verify the delta sync
+
+Create a new issue in Linear (or edit an existing one). Within 5 minutes:
+
+```zsh
+ntn workers sync trigger issuesDelta   # or just wait for the schedule
+```
+
+The row appears (or its fields update) in Notion.
+
+## How the code is organized
+
+- `src/index.ts` — Worker entry. Declares the managed database, the shared rate-limit pacer, and both syncs (`issuesBackfill` and `issuesDelta`).
+- `src/linear.ts` — GraphQL helpers. `fetchAllIssuesPage` (no filter, used by backfill) and `fetchIssuesUpdatedSince` (filtered by `updatedAt`, used by delta).
+- `src/types.ts` — `LinearIssue` field shape and the `IssuePage` pagination wrapper.
+
+The delta sync's state shape is `{ since, after, maxSeen }` — `since` is the `updatedAt` watermark, `after` is the within-cycle page cursor, and `maxSeen` is the running maximum across pages of the current cycle. The 15-second consistency buffer (`CONSISTENCY_BUFFER_MS`) prevents the cursor from running ahead of Linear's eventually-consistent index.
+
+## Customizing
+
+- **Add a property** — extend `ISSUE_FIELDS` in `linear.ts`, the `LinearIssue` type in `types.ts`, the schema in `index.ts`, and `toUpsert` in `index.ts`.
+- **Change the sync frequency** — adjust `schedule: "5m"` on `issuesDelta` (allowed values: `5m`, `15m`, `1h`, `1d`).
+- **Sync only one team** — add a `team: { id: { eq: "<team-id>" } }` filter to the GraphQL query in `linear.ts`.
+
+## Troubleshooting
+
+- **"LINEAR_API_KEY is not set"** — run `ntn workers env set LINEAR_API_KEY=...` and redeploy.
+- **`401 Unauthorized` from Linear** — your key was revoked or copied with a leading/trailing space. Generate a new one.
+- **Issues stop appearing after a while** — the delta cursor may have run ahead. Run `ntn workers sync state reset issuesDelta` then `ntn workers sync trigger issuesBackfill` to re-reconcile.
+- **A row was deleted in Linear but is still in Notion** — the delta sync doesn't propagate hard-deletes. Trigger `issuesBackfill` to clean up.
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Syncs guide](https://developers.notion.com/workers/guides/syncs)
+- [Linear GraphQL API](https://linear.app/developers/graphql)
 - [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/linear/package.json
+++ b/examples/workers/syncs/linear/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "linear-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/linear/src/index.ts
+++ b/examples/workers/syncs/linear/src/index.ts
@@ -1,0 +1,177 @@
+// Linear → Notion sync.
+//
+// Two syncs share a single managed database:
+//
+//   - `issuesBackfill` (replace mode, manual) — paginates every issue in
+//     the workspace. Run it once on first deploy and any time you need to
+//     reconcile (e.g. you suspect drift, or an issue was deleted in Linear).
+//
+//   - `issuesDelta` (incremental mode, every 5 minutes) — pulls only issues
+//     whose `updatedAt` is newer than the last cursor. This is what keeps
+//     Notion in sync day-to-day.
+//
+// This backfill+delta pattern is the recommended shape for any API that
+// supports change tracking. See
+// https://developers.notion.com/workers/guides/syncs for the full design.
+
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+import { fetchAllIssuesPage, fetchIssuesUpdatedSince } from "./linear.js"
+import type { LinearIssue } from "./types.js"
+
+const worker = new Worker()
+export default worker
+
+// Linear's GraphQL API allows up to 1500 requests/hour (~25/sec) for
+// personal API keys. We stay well under that with a conservative pacer
+// that both syncs share — the runtime apportions the budget between them.
+const linearApi = worker.pacer("linearApi", {
+  allowedRequests: 5,
+  intervalMs: 1000,
+})
+
+// Lag the delta cursor 15 seconds behind real time. Linear is eventually
+// consistent, so a write that happened ~now might not be queryable yet.
+// Without this buffer, we risk advancing the cursor past records that
+// haven't been indexed — and missing them forever.
+const CONSISTENCY_BUFFER_MS = 15_000
+
+const issues = worker.database("issues", {
+  type: "managed",
+  initialTitle: "Linear Issues",
+  primaryKeyProperty: "Issue ID",
+  schema: {
+    properties: {
+      Title: Schema.title(),
+      "Issue ID": Schema.richText(),
+      URL: Schema.url(),
+      // Workspace-specific values — use richText so we don't have to
+      // enumerate every possible state and label.
+      State: Schema.richText(),
+      Assignee: Schema.richText(),
+      Labels: Schema.richText(),
+      // Linear's five fixed priority labels — safe to enumerate.
+      Priority: Schema.select([
+        { name: "No priority" },
+        { name: "Urgent", color: "red" },
+        { name: "High", color: "orange" },
+        { name: "Medium", color: "yellow" },
+        { name: "Low", color: "blue" },
+      ]),
+      Updated: Schema.date(),
+    },
+  },
+})
+
+function toUpsert(issue: LinearIssue) {
+  const labels = issue.labels.nodes.map((l) => l.name).join(", ")
+  return {
+    type: "upsert" as const,
+    key: issue.id,
+    properties: {
+      Title: Builder.title(`${issue.identifier} — ${issue.title}`),
+      "Issue ID": Builder.richText(issue.identifier),
+      URL: Builder.url(issue.url),
+      State: Builder.richText(issue.state?.name ?? ""),
+      Assignee: Builder.richText(issue.assignee?.name ?? ""),
+      Labels: Builder.richText(labels),
+      Priority: Builder.select(issue.priorityLabel),
+      Updated: Builder.dateTime(issue.updatedAt),
+    },
+  }
+}
+
+// --- Backfill sync (replace mode) ---
+//
+// Walks the entire `issues` connection one page at a time. At the end of
+// the cycle, the runtime deletes any rows we didn't touch — so if an issue
+// was hard-deleted in Linear, it disappears from Notion on the next backfill.
+//
+// `schedule: "manual"` means it only runs when triggered:
+//   ntn workers sync trigger issuesBackfill
+type BackfillState = { after: string | null }
+
+worker.sync("issuesBackfill", {
+  database: issues,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state: BackfillState | undefined) => {
+    const after = state?.after ?? null
+    await linearApi.wait()
+    const page = await fetchAllIssuesPage(after)
+
+    return {
+      changes: page.nodes.map(toUpsert),
+      hasMore: page.hasNextPage,
+      nextState: page.hasNextPage ? { after: page.endCursor } : undefined,
+    }
+  },
+})
+
+// --- Delta sync (incremental mode) ---
+//
+// The cursor is a `(since, after, maxSeen)` triple:
+//   - `since`   — the `updatedAt` watermark. Only issues newer than this
+//                 are fetched in the current cycle.
+//   - `after`   — within-cycle page cursor while sweeping the current
+//                 watermark's result set. Resets to null at end of cycle.
+//   - `maxSeen` — the largest `updatedAt` observed during the current
+//                 cycle. At end-of-cycle, this becomes the new `since`
+//                 (clamped to "now − buffer" for consistency).
+//
+// State must survive across multiple `execute` calls inside one cycle
+// because we paginate within a cycle when there's a backlog.
+type DeltaState = {
+  since: string
+  after: string | null
+  maxSeen: string
+}
+
+worker.sync("issuesDelta", {
+  database: issues,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state: DeltaState | undefined) => {
+    const since = state?.since ?? new Date(0).toISOString()
+    const after = state?.after ?? null
+    const maxSeenSoFar = state?.maxSeen ?? since
+
+    await linearApi.wait()
+    const page = await fetchIssuesUpdatedSince(since, after)
+
+    const maxSeen = page.nodes.reduce(
+      (max, n) => (n.updatedAt > max ? n.updatedAt : max),
+      maxSeenSoFar
+    )
+
+    // Mid-cycle: still pages to fetch. Keep `since` pinned, advance
+    // `after`, carry the running `maxSeen`.
+    if (page.hasNextPage) {
+      return {
+        changes: page.nodes.map(toUpsert),
+        hasMore: true,
+        nextState: {
+          since,
+          after: page.endCursor,
+          maxSeen,
+        },
+      }
+    }
+
+    // End of cycle: advance the watermark, clamped by the buffer so we
+    // don't run ahead of Linear's index.
+    const bufferTs = new Date(Date.now() - CONSISTENCY_BUFFER_MS).toISOString()
+    const newSince = maxSeen < bufferTs ? maxSeen : bufferTs
+
+    return {
+      changes: page.nodes.map(toUpsert),
+      hasMore: false,
+      nextState: {
+        since: newSince,
+        after: null,
+        maxSeen: newSince,
+      },
+    }
+  },
+})

--- a/examples/workers/syncs/linear/src/linear.ts
+++ b/examples/workers/syncs/linear/src/linear.ts
@@ -1,0 +1,111 @@
+import type { IssuePage, LinearIssue } from "./types.js"
+
+// Linear exposes a single GraphQL endpoint. Personal API keys go in the
+// `Authorization` header **without** a "Bearer" prefix. See:
+// https://linear.app/developers/graphql
+const LINEAR_ENDPOINT = "https://api.linear.app/graphql"
+
+const ISSUE_FIELDS = `
+	id
+	identifier
+	title
+	url
+	priority
+	priorityLabel
+	updatedAt
+	state { name }
+	assignee { name }
+	labels { nodes { name } }
+`
+
+async function graphql<T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const apiKey = process.env.LINEAR_API_KEY
+  if (!apiKey) {
+    throw new Error(
+      "LINEAR_API_KEY is not set. Run `ntn workers env set LINEAR_API_KEY=...`."
+    )
+  }
+
+  const res = await fetch(LINEAR_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  })
+
+  if (!res.ok) {
+    throw new Error(`Linear API error: ${res.status} ${await res.text()}`)
+  }
+
+  const body = (await res.json()) as { data?: T; errors?: unknown }
+  if (body.errors) {
+    throw new Error(`Linear GraphQL errors: ${JSON.stringify(body.errors)}`)
+  }
+  if (!body.data) {
+    throw new Error("Linear GraphQL response missing `data`")
+  }
+  return body.data
+}
+
+// Backfill: fetch every issue, page by page, with no time filter.
+// Used by the manual replace-mode sync to populate or fully refresh the
+// Notion database.
+export async function fetchAllIssuesPage(
+  after: string | null
+): Promise<IssuePage> {
+  const query = `
+		query Backfill($after: String) {
+			issues(first: 100, after: $after) {
+				nodes { ${ISSUE_FIELDS} }
+				pageInfo { hasNextPage endCursor }
+			}
+		}
+	`
+  const data = await graphql<{
+    issues: {
+      nodes: LinearIssue[]
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    }
+  }>(query, { after })
+  return {
+    nodes: data.issues.nodes,
+    hasNextPage: data.issues.pageInfo.hasNextPage,
+    endCursor: data.issues.pageInfo.endCursor,
+  }
+}
+
+// Delta: fetch only issues updated after a given timestamp. Paginated so
+// catch-up cycles after a backlog work correctly.
+export async function fetchIssuesUpdatedSince(
+  since: string,
+  after: string | null
+): Promise<IssuePage> {
+  const query = `
+		query Delta($since: DateTimeOrDuration!, $after: String) {
+			issues(
+				first: 100
+				after: $after
+				filter: { updatedAt: { gt: $since } }
+			) {
+				nodes { ${ISSUE_FIELDS} }
+				pageInfo { hasNextPage endCursor }
+			}
+		}
+	`
+  const data = await graphql<{
+    issues: {
+      nodes: LinearIssue[]
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    }
+  }>(query, { since, after })
+  return {
+    nodes: data.issues.nodes,
+    hasNextPage: data.issues.pageInfo.hasNextPage,
+    endCursor: data.issues.pageInfo.endCursor,
+  }
+}

--- a/examples/workers/syncs/linear/src/types.ts
+++ b/examples/workers/syncs/linear/src/types.ts
@@ -1,0 +1,22 @@
+// Fields we pull from Linear's GraphQL `issues` connection. Extend this if
+// you need more columns in the Notion database — remember to add the field
+// to the GraphQL query in `linear.ts` and to the schema/mapping in `index.ts`.
+export interface LinearIssue {
+  id: string
+  identifier: string // e.g. "ENG-123"
+  title: string
+  url: string
+  priority: number // 0 = none, 1 = urgent, 2 = high, 3 = medium, 4 = low
+  priorityLabel: string
+  updatedAt: string // ISO 8601
+  state: { name: string } | null
+  assignee: { name: string } | null
+  labels: { nodes: { name: string }[] }
+}
+
+// A single page of issues returned by Linear's Relay-style pagination.
+export interface IssuePage {
+  nodes: LinearIssue[]
+  hasNextPage: boolean
+  endCursor: string | null
+}

--- a/examples/workers/syncs/linear/tsconfig.json
+++ b/examples/workers/syncs/linear/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder at `examples/workers/syncs/linear/` with a working Notion worker that one-way syncs Linear issues into a managed Notion database.

- **Two syncs share one database** — `issuesBackfill` (replace, manual) reconciles by mark-and-sweep; `issuesDelta` (incremental, every 5m) advances an `updatedAt` watermark with a 15s consistency buffer.
- **Robust delta cursor** — state shape is `{ since, after, maxSeen }` so multi-page catch-up cycles never lose records.
- **No webhooks needed** — Linear's GraphQL `updatedAt` filter handles change detection cleanly.

## Test plan

- [ ] `npm install && npm run check` in `examples/workers/syncs/linear/`
- [ ] `ntn workers env set LINEAR_API_KEY=...`
- [ ] `ntn workers deploy --name linear-sync`
- [ ] `ntn workers sync trigger issuesBackfill` and confirm rows appear in the auto-created "Linear Issues" database
- [ ] Edit an issue in Linear, wait 5m (or trigger `issuesDelta` manually), confirm Notion row updates
- [ ] Re-read the README top-to-bottom in a fresh shell and walk every step

🤖 Generated with [Claude Code](https://claude.com/claude-code)