### PR TITLE
Add Salesforce worker sync example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -7,7 +7,7 @@ This directory contains example [Notion workers](https://developers.notion.com/d
 The [syncs](syncs/) directory includes one-way sync examples that bring data from external systems into Notion databases:
 
 - **[zendesk](syncs/zendesk/)**: One-way sync from Zendesk tickets into a Notion database _(coming soon)_
-- **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
+- **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce Accounts and Opportunities into Notion databases with a two-way relation
 - **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_
 
 ## Tools

--- a/examples/workers/syncs/salesforce/README.md
+++ b/examples/workers/syncs/salesforce/README.md
@@ -1,18 +1,108 @@
 # Worker Sync: Salesforce
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+A Notion worker that one-way syncs Salesforce **Accounts** and **Opportunities** into two related managed Notion databases. Auth is via OAuth 2.0 against a Salesforce Connected App; the runtime stores and refreshes the token automatically.
 
-A Notion worker sync that pulls Salesforce records into a Notion database, keeping the database up to date as records are created and updated in Salesforce.
+## Prerequisites
 
-## What this example will demonstrate
+- A Notion workspace where you can install workers.
+- A Salesforce org you can sign in to (Developer Edition is free at <https://developer.salesforce.com/signup>).
+- Salesforce **System Administrator** permission so you can create a Connected App.
+- Node.js ≥ 22 and the [`ntn` CLI](https://developers.notion.com/workers/get-started/quickstart) installed.
 
-- One-way sync from Salesforce records into a Notion database
-- Webhook- or polling-driven updates from Salesforce into Notion
-- Mapping Salesforce standard and custom fields to Notion properties
-- Authenticating to Salesforce via OAuth from a Notion worker
+## Step 1 — Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/syncs/salesforce
+npm install
+ntn login
+```
+
+## Step 2 — Create a Salesforce Connected App
+
+1. In Salesforce, open **Setup → App Manager → New Connected App** → **Create a Connected App**.
+2. Fill in **Name**, **API Name**, **Contact Email**.
+3. Under **API (Enable OAuth Settings)**, check **Enable OAuth Settings**.
+4. Get your worker's callback URL by running:
+   ```zsh
+   ntn workers oauth show-redirect-url
+   ```
+   Paste it into the **Callback URL** field.
+5. Move these scopes into **Selected OAuth Scopes**:
+   - `Manage user data via APIs (api)`
+   - `Perform requests at any time (refresh_token, offline_access)`
+6. Click **Save**, wait ~10 minutes for the app to propagate, then open **Manage Consumer Details** to reveal the **Consumer Key** and **Consumer Secret**.
+
+## Step 3 — Store the credentials
+
+```zsh
+ntn workers env set SF_CLIENT_ID=<consumer-key>
+ntn workers env set SF_CLIENT_SECRET=<consumer-secret>
+```
+
+## Step 4 — Deploy
+
+```zsh
+ntn workers deploy --name salesforce-sync
+```
+
+This creates two managed databases — **Salesforce Accounts** and **Salesforce Opportunities** — linked by a two-way relation (the Accounts database gets an auto-created **Opportunities** column).
+
+## Step 5 — Authorize and backfill
+
+Authorize the worker against your Salesforce org:
+
+```zsh
+ntn workers oauth start salesforceAuth
+```
+
+A browser window opens; sign in and approve the requested scopes.
+
+Now run the initial backfill for both objects:
+
+```zsh
+ntn workers sync trigger accountsBackfill
+ntn workers sync trigger opportunitiesBackfill
+```
+
+Within a few seconds Notion fills with rows. Each Opportunity automatically links to its Account via the relation.
+
+## Step 6 — Verify the delta syncs
+
+`accountsDelta` and `opportunitiesDelta` run automatically every 30 minutes. To see one happen now, edit an Account in Salesforce, then:
+
+```zsh
+ntn workers sync trigger accountsDelta
+```
+
+The row updates in Notion.
+
+## How the code is organized
+
+- `src/index.ts` — Worker entry. Declares OAuth, the two managed databases (with the Account ↔ Opportunities relation), a shared rate-limit pacer, and four syncs.
+- `src/salesforce.ts` — REST client. Discovers the org's instance URL via `/services/oauth2/userinfo` (since `accessToken()` only returns the bearer), then exposes `soql()` and `next()` for pagination.
+- `src/mapping.ts` — Pure transformation functions (`accountToUpsert`, `opportunityToUpsert`) that convert SOQL rows into Notion change records.
+- `src/types.ts` — `SfAccount`, `SfOpportunity`, and the generic `SfQueryResponse<T>` shape.
+
+The delta cycle keeps `{ since, nextRecordsUrl, maxSeen }` in state — `since` is the `LastModifiedDate` watermark, `nextRecordsUrl` paginates within a cycle, and `maxSeen` tracks the running max so the watermark advances correctly. A 30-second consistency buffer keeps us safely behind Salesforce's index.
+
+## Customizing
+
+- **Sync a different object** — duplicate the Opportunity-related blocks (database, SOQL fields constant, two syncs) and change the SOQL `FROM` clause and the mapper.
+- **Add a custom field** — append it to the corresponding `*_FIELDS` constant in `index.ts`, extend the type in `types.ts`, and map it in `mapping.ts`. Custom field API names end in `__c` (e.g. `Account_Tier__c`).
+- **Switch the API version** — bump `API_VERSION` in `salesforce.ts`.
+
+## Troubleshooting
+
+- **"Salesforce userinfo lookup failed: 401"** — your OAuth session is invalid. Re-run `ntn workers oauth start salesforceAuth`.
+- **Backfill returns 0 records** — the Connected App user lacks read access to the object. Grant the user a profile/permission set that includes Read on Account and Opportunity.
+- **Relation appears unlinked on a fresh sync** — the Opportunity's Account row hasn't been written yet. Once `accountsBackfill` completes, the relation resolves automatically; trigger `opportunitiesBackfill` once both are done if needed.
+- **"invalid_grant" during oauth start** — your callback URL doesn't match. Re-copy from `ntn workers oauth show-redirect-url` into Salesforce.
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [OAuth guide](https://developers.notion.com/workers/guides/oauth)
+- [Syncs guide](https://developers.notion.com/workers/guides/syncs)
+- [Salesforce REST API reference](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/)
 - [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/salesforce/package.json
+++ b/examples/workers/syncs/salesforce/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "salesforce-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/salesforce/src/index.ts
+++ b/examples/workers/syncs/salesforce/src/index.ts
@@ -1,0 +1,240 @@
+// Salesforce → Notion sync.
+//
+// Syncs two related objects from a Salesforce org into Notion:
+//
+//   Accounts ── related to ──> Opportunities
+//
+// Each object gets the recommended backfill+delta pair:
+//
+//   - `accountsBackfill` / `opportunitiesBackfill` (replace, manual)
+//     Walk the entire object via SOQL on demand. Run after first deploy
+//     and any time you need to reconcile (handles hard-deletes since the
+//     runtime mark-and-sweeps any record not returned).
+//
+//   - `accountsDelta` / `opportunitiesDelta` (incremental, every 30 min)
+//     Pull only records whose `LastModifiedDate` is newer than the
+//     watermark. Day-to-day this is what keeps Notion fresh.
+//
+// Auth is OAuth 2.0 Web Server Flow against your Salesforce Connected App.
+// The runtime stores and refreshes the token; we just call `accessToken()`.
+
+import { Worker } from "@notionhq/workers"
+import * as Schema from "@notionhq/workers/schema"
+import { getSalesforceClient, toSoqlDateTime } from "./salesforce.js"
+import { accountToUpsert, opportunityToUpsert } from "./mapping.js"
+import type { SfAccount, SfOpportunity, SfQueryResponse } from "./types.js"
+
+const worker = new Worker()
+export default worker
+
+// --- OAuth ---
+// Get the Connected App's Consumer Key / Secret from Salesforce Setup
+// (App Manager → New Connected App → Enable OAuth Settings). Paste the
+// output of `ntn workers oauth show-redirect-url` into the Callback URL
+// field there.
+const salesforceAuth = worker.oauth("salesforceAuth", {
+  name: "salesforce",
+  authorizationEndpoint:
+    "https://login.salesforce.com/services/oauth2/authorize",
+  tokenEndpoint: "https://login.salesforce.com/services/oauth2/token",
+  scope: "api refresh_token offline_access",
+  clientId: process.env.SF_CLIENT_ID ?? "",
+  clientSecret: process.env.SF_CLIENT_SECRET ?? "",
+})
+
+// Salesforce API limits depend on org edition, but ~10 req/sec is safe
+// even for low-tier orgs. All four syncs share this budget.
+const sfApi = worker.pacer("salesforceApi", {
+  allowedRequests: 8,
+  intervalMs: 1000,
+})
+
+// Salesforce indexes LastModifiedDate eventually-consistently. Keep the
+// delta cursor a beat behind real time so we don't skip a record that
+// was written just before our query ran.
+const CONSISTENCY_BUFFER_MS = 30_000
+
+// --- Databases ---
+
+const accounts = worker.database("accounts", {
+  type: "managed",
+  initialTitle: "Salesforce Accounts",
+  primaryKeyProperty: "Account ID",
+  schema: {
+    properties: {
+      Name: Schema.title(),
+      "Account ID": Schema.richText(),
+      Industry: Schema.richText(),
+      Type: Schema.richText(),
+      Website: Schema.richText(),
+      Owner: Schema.richText(),
+      Updated: Schema.date(),
+    },
+  },
+})
+
+const opportunities = worker.database("opportunities", {
+  type: "managed",
+  initialTitle: "Salesforce Opportunities",
+  primaryKeyProperty: "Opportunity ID",
+  schema: {
+    properties: {
+      Name: Schema.title(),
+      "Opportunity ID": Schema.richText(),
+      Stage: Schema.richText(),
+      Amount: Schema.number("dollar"),
+      "Close Date": Schema.date(),
+      Owner: Schema.richText(),
+      Updated: Schema.date(),
+      // Two-way relation back into the Accounts database. The other
+      // side of the link is auto-created on the Accounts schema as
+      // a property called "Opportunities".
+      Account: Schema.relation("accounts", {
+        twoWay: true,
+        relatedPropertyName: "Opportunities",
+      }),
+    },
+  },
+})
+
+// --- SOQL queries ---
+
+const ACCOUNT_FIELDS =
+  "Id, Name, Industry, Type, Website, Owner.Name, LastModifiedDate"
+const OPPORTUNITY_FIELDS =
+  "Id, Name, AccountId, StageName, Amount, CloseDate, Owner.Name, LastModifiedDate"
+
+// --- Sync helpers ---
+//
+// Backfill and delta differ only in their initial SOQL. Both then walk
+// the same pagination shape (`nextRecordsUrl` until `done: true`), so we
+// share a single runner.
+
+type BackfillState = { nextRecordsUrl: string | null }
+
+type DeltaState = {
+  since: string
+  nextRecordsUrl: string | null
+  maxSeen: string
+}
+
+async function runBackfillCycle<T extends { LastModifiedDate: string }>(
+  state: BackfillState | undefined,
+  initialQuery: string,
+  toUpsert: (record: T) => { type: "upsert"; key: string; properties: any }
+) {
+  const client = await getSalesforceClient(() => salesforceAuth.accessToken())
+  await sfApi.wait()
+  const response: SfQueryResponse<T> = state?.nextRecordsUrl
+    ? await client.next<T>(state.nextRecordsUrl)
+    : await client.soql<T>(initialQuery)
+
+  const changes = response.records.map(toUpsert)
+  if (response.done) {
+    return { changes, hasMore: false, nextState: undefined }
+  }
+  return {
+    changes,
+    hasMore: true,
+    nextState: { nextRecordsUrl: response.nextRecordsUrl ?? null },
+  }
+}
+
+async function runDeltaCycle<T extends { LastModifiedDate: string }>(
+  state: DeltaState | undefined,
+  fields: string,
+  objectName: string,
+  toUpsert: (record: T) => { type: "upsert"; key: string; properties: any }
+) {
+  const since = state?.since ?? new Date(0).toISOString()
+  const maxSeenSoFar = state?.maxSeen ?? since
+
+  const client = await getSalesforceClient(() => salesforceAuth.accessToken())
+  await sfApi.wait()
+
+  let response: SfQueryResponse<T>
+  if (state?.nextRecordsUrl) {
+    response = await client.next<T>(state.nextRecordsUrl)
+  } else {
+    const soql = `SELECT ${fields} FROM ${objectName} WHERE LastModifiedDate > ${toSoqlDateTime(since)} ORDER BY LastModifiedDate ASC`
+    response = await client.soql<T>(soql)
+  }
+
+  const maxSeen = response.records.reduce(
+    (m, r) => (r.LastModifiedDate > m ? r.LastModifiedDate : m),
+    maxSeenSoFar
+  )
+
+  const changes = response.records.map(toUpsert)
+
+  // Mid-cycle: keep `since` pinned, follow the pagination URL next call.
+  if (!response.done) {
+    return {
+      changes,
+      hasMore: true,
+      nextState: {
+        since,
+        nextRecordsUrl: response.nextRecordsUrl ?? null,
+        maxSeen,
+      },
+    }
+  }
+
+  // End of cycle: advance the watermark, clamped behind the buffer.
+  const bufferTs = new Date(Date.now() - CONSISTENCY_BUFFER_MS).toISOString()
+  const newSince = maxSeen < bufferTs ? maxSeen : bufferTs
+  return {
+    changes,
+    hasMore: false,
+    nextState: { since: newSince, nextRecordsUrl: null, maxSeen: newSince },
+  }
+}
+
+// --- Account syncs ---
+
+worker.sync("accountsBackfill", {
+  database: accounts,
+  mode: "replace",
+  schedule: "manual",
+  execute: (state: BackfillState | undefined) =>
+    runBackfillCycle<SfAccount>(
+      state,
+      `SELECT ${ACCOUNT_FIELDS} FROM Account ORDER BY Id`,
+      accountToUpsert
+    ),
+})
+
+worker.sync("accountsDelta", {
+  database: accounts,
+  mode: "incremental",
+  schedule: "30m",
+  execute: (state: DeltaState | undefined) =>
+    runDeltaCycle<SfAccount>(state, ACCOUNT_FIELDS, "Account", accountToUpsert),
+})
+
+// --- Opportunity syncs ---
+
+worker.sync("opportunitiesBackfill", {
+  database: opportunities,
+  mode: "replace",
+  schedule: "manual",
+  execute: (state: BackfillState | undefined) =>
+    runBackfillCycle<SfOpportunity>(
+      state,
+      `SELECT ${OPPORTUNITY_FIELDS} FROM Opportunity ORDER BY Id`,
+      opportunityToUpsert
+    ),
+})
+
+worker.sync("opportunitiesDelta", {
+  database: opportunities,
+  mode: "incremental",
+  schedule: "30m",
+  execute: (state: DeltaState | undefined) =>
+    runDeltaCycle<SfOpportunity>(
+      state,
+      OPPORTUNITY_FIELDS,
+      "Opportunity",
+      opportunityToUpsert
+    ),
+})

--- a/examples/workers/syncs/salesforce/src/mapping.ts
+++ b/examples/workers/syncs/salesforce/src/mapping.ts
@@ -1,0 +1,51 @@
+import * as Builder from "@notionhq/workers/builder"
+import type { SfAccount, SfOpportunity } from "./types.js"
+
+// Salesforce → Notion field maps live here so `index.ts` stays focused on
+// the worker shape. To add a field: extend the type in `types.ts`, add it
+// to the SOQL SELECT in `index.ts`, and map it here.
+
+export function accountToUpsert(account: SfAccount) {
+  return {
+    type: "upsert" as const,
+    key: account.Id,
+    properties: {
+      Name: Builder.title(account.Name),
+      "Account ID": Builder.richText(account.Id),
+      Industry: Builder.richText(account.Industry ?? ""),
+      Type: Builder.richText(account.Type ?? ""),
+      Website: Builder.richText(account.Website ?? ""),
+      Owner: Builder.richText(account.Owner?.Name ?? ""),
+      Updated: Builder.dateTime(account.LastModifiedDate),
+    },
+  }
+}
+
+export function opportunityToUpsert(opp: SfOpportunity) {
+  // Salesforce returns `null` for empty number fields; Notion's number
+  // builder doesn't accept null, so fall back to 0 and let users tell
+  // the difference via the Stage column.
+  const amount = opp.Amount ?? 0
+
+  return {
+    type: "upsert" as const,
+    key: opp.Id,
+    properties: {
+      Name: Builder.title(opp.Name),
+      "Opportunity ID": Builder.richText(opp.Id),
+      Stage: Builder.richText(opp.StageName ?? ""),
+      Amount: Builder.number(amount),
+      "Close Date": opp.CloseDate
+        ? Builder.date(opp.CloseDate)
+        : Builder.richText(""),
+      Owner: Builder.richText(opp.Owner?.Name ?? ""),
+      Updated: Builder.dateTime(opp.LastModifiedDate),
+      // The relation key is the Salesforce Account ID — same value
+      // used as the primary key of the `accounts` database. Notion
+      // resolves the link once both rows exist; on first sync an
+      // opportunity might briefly show an unresolved relation if
+      // it arrives before its parent account.
+      Account: opp.AccountId ? [Builder.relation(opp.AccountId)] : [],
+    },
+  }
+}

--- a/examples/workers/syncs/salesforce/src/salesforce.ts
+++ b/examples/workers/syncs/salesforce/src/salesforce.ts
@@ -1,0 +1,78 @@
+import type { SfQueryResponse } from "./types.js"
+
+// Salesforce REST API version. Bump when you need newer SOQL features.
+// See https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_versions.htm
+const API_VERSION = "v59.0"
+
+// Salesforce's OAuth token endpoint returns an `instance_url`, but
+// `worker.oauth(...).accessToken()` only exposes the bearer token. We
+// derive the instance URL by calling `/services/oauth2/userinfo` against
+// the global login host — that endpoint accepts tokens from any instance
+// and reports the user's URLs in the response.
+//
+// One lookup per worker invocation is cheap; we cache it in module scope
+// so multiple API calls in the same `execute` share it.
+let cachedInstanceUrl: string | null = null
+
+async function discoverInstanceUrl(accessToken: string): Promise<string> {
+  if (cachedInstanceUrl) return cachedInstanceUrl
+
+  const res = await fetch(
+    "https://login.salesforce.com/services/oauth2/userinfo",
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  )
+  if (!res.ok) {
+    throw new Error(
+      `Salesforce userinfo lookup failed: ${res.status} ${await res.text()}`
+    )
+  }
+  const data = (await res.json()) as { urls?: { rest?: string } }
+  const restUrl = data.urls?.rest
+  if (!restUrl) {
+    throw new Error("Salesforce userinfo response did not include `urls.rest`")
+  }
+  // `urls.rest` looks like `https://acme.my.salesforce.com/services/data/v{version}/`.
+  cachedInstanceUrl = restUrl.split("/services/")[0]
+  return cachedInstanceUrl
+}
+
+interface SalesforceClient {
+  soql<T>(query: string): Promise<SfQueryResponse<T>>
+  next<T>(nextRecordsUrl: string): Promise<SfQueryResponse<T>>
+}
+
+export async function getSalesforceClient(
+  getToken: () => Promise<string>
+): Promise<SalesforceClient> {
+  const token = await getToken()
+  const instanceUrl = await discoverInstanceUrl(token)
+
+  async function sfFetch<T>(path: string): Promise<SfQueryResponse<T>> {
+    // Always re-read the token in case it was refreshed since we cached
+    // the instance URL.
+    const currentToken = await getToken()
+    const res = await fetch(`${instanceUrl}${path}`, {
+      headers: { Authorization: `Bearer ${currentToken}` },
+    })
+    if (!res.ok) {
+      throw new Error(`Salesforce API error: ${res.status} ${await res.text()}`)
+    }
+    return (await res.json()) as SfQueryResponse<T>
+  }
+
+  return {
+    soql: (query) =>
+      sfFetch(
+        `/services/data/${API_VERSION}/query?q=${encodeURIComponent(query)}`
+      ),
+    next: (nextRecordsUrl) => sfFetch(nextRecordsUrl),
+  }
+}
+
+// Format a JS Date / ISO string as a SOQL datetime literal. SOQL accepts
+// `YYYY-MM-DDTHH:MM:SSZ` (ISO 8601) for datetime comparisons, without
+// surrounding quotes (unlike string fields).
+export function toSoqlDateTime(iso: string): string {
+  // Trim milliseconds if present — `2024-01-15T10:30:00.123Z` → `2024-01-15T10:30:00Z`.
+  return iso.replace(/\.\d{3}Z$/, "Z")
+}

--- a/examples/workers/syncs/salesforce/src/types.ts
+++ b/examples/workers/syncs/salesforce/src/types.ts
@@ -1,0 +1,31 @@
+// We only pull the columns we display in Notion. Add a field here and
+// extend the SOQL SELECT in `salesforce.ts` plus the mapper in `mapping.ts`.
+
+export interface SfAccount {
+  Id: string
+  Name: string
+  Industry: string | null
+  Type: string | null
+  Website: string | null
+  Owner: { Name: string | null } | null
+  LastModifiedDate: string // ISO 8601
+}
+
+export interface SfOpportunity {
+  Id: string
+  Name: string
+  AccountId: string | null
+  StageName: string | null
+  Amount: number | null
+  CloseDate: string | null // YYYY-MM-DD
+  Owner: { Name: string | null } | null
+  LastModifiedDate: string
+}
+
+// Generic shape of a Salesforce REST query response.
+export interface SfQueryResponse<T> {
+  totalSize: number
+  done: boolean
+  records: T[]
+  nextRecordsUrl?: string
+}

--- a/examples/workers/syncs/salesforce/tsconfig.json
+++ b/examples/workers/syncs/salesforce/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder at `examples/workers/syncs/salesforce/` with a working Notion worker that one-way syncs **Accounts** and **Opportunities** from Salesforce into Notion via OAuth.

- `worker.oauth("salesforceAuth")` (Web Server Flow) — the runtime stores and refreshes tokens.
- Two managed databases joined by a **two-way relation** (`Schema.relation("accounts", { twoWay: true, relatedPropertyName: "Opportunities" })`).
- Backfill + delta sync pair per object (4 syncs total) reuses the helpers `runBackfillCycle` / `runDeltaCycle` so each registration is ~6 lines.
- `accessToken()` only returns the bearer, so `salesforce.ts` calls `/services/oauth2/userinfo` once per invocation to discover the org's instance URL.

## Test plan

- [ ] `npm install && npm run check` in `examples/workers/syncs/salesforce/`
- [ ] Create a Connected App with the redirect URL from `ntn workers oauth show-redirect-url`
- [ ] `ntn workers env set SF_CLIENT_ID=... SF_CLIENT_SECRET=...`
- [ ] `ntn workers deploy --name salesforce-sync`
- [ ] `ntn workers oauth start salesforceAuth`
- [ ] `ntn workers sync trigger accountsBackfill && ntn workers sync trigger opportunitiesBackfill`
- [ ] Confirm both databases populate and each Opportunity row links to its Account via the relation column
- [ ] Edit an Account and an Opportunity in Salesforce; trigger the deltas and confirm updates flow through

🤖 Generated with [Claude Code](https://claude.com/claude-code)