### PR TITLE
Add Snowflake Query worker tool example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -14,5 +14,5 @@ The [syncs](syncs/) directory includes one-way sync examples that bring data fro
 
 The [tools](tools/) directory includes agent tool examples that extend Notion agents with new capabilities:
 
-- **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results _(coming soon)_
+- **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results
 - **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_

--- a/examples/workers/tools/snowflake-query/README.md
+++ b/examples/workers/tools/snowflake-query/README.md
@@ -1,18 +1,111 @@
 # Worker Tool: Snowflake Query
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+A Notion agent tool that runs read-only SQL queries against a Snowflake warehouse and returns structured results. Auth is key-pair JWT against the Snowflake SQL REST API — no native Snowflake SDK is needed inside the worker sandbox.
 
-A Notion worker tool that lets a Notion agent query a Snowflake warehouse and return the results inline in a conversation.
+## Prerequisites
 
-## What this example will demonstrate
+- A Notion workspace where you can install workers.
+- A Snowflake account with a user you can authenticate as.
+- The Snowflake `ACCOUNTADMIN` role (or equivalent) to upload an RSA public key to your user.
+- A **read-only** Snowflake role for the tool to assume (recommended — limits blast radius if the agent is asked to run something unexpected).
+- Node.js ≥ 22 and the [`ntn` CLI](https://developers.notion.com/workers/get-started/quickstart) installed.
 
-- Defining a Notion agent tool that accepts a SQL query as input
-- Connecting to Snowflake from a Notion worker using the Snowflake SDK
-- Returning query results to the agent in a structured, easy-to-render format
-- Safely scoping queries via roles, warehouses, and row limits
+## Step 1 — Generate an RSA key pair
+
+```zsh
+# Private key (used by the worker)
+openssl genrsa -out snowflake_rsa.pem 2048
+
+# Public key (uploaded to Snowflake)
+openssl rsa -in snowflake_rsa.pem -pubout -out snowflake_rsa.pub
+```
+
+Keep `snowflake_rsa.pem` somewhere safe — anyone with it can authenticate as your Snowflake user.
+
+## Step 2 — Register the public key with your Snowflake user
+
+In a Snowflake worksheet, strip the PEM header/footer from `snowflake_rsa.pub` and run:
+
+```sql
+ALTER USER <your-user> SET RSA_PUBLIC_KEY = '<base64-body-of-public-key>';
+```
+
+Verify:
+
+```sql
+DESC USER <your-user>;
+-- Look for RSA_PUBLIC_KEY_FP and RSA_PUBLIC_KEY in the output.
+```
+
+## Step 3 — Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/tools/snowflake-query
+npm install
+ntn login
+```
+
+## Step 4 — Store the credentials
+
+```zsh
+ntn workers env set SNOWFLAKE_ACCOUNT=<account-locator>     # e.g. xy12345.us-east-1
+ntn workers env set SNOWFLAKE_USER=<your-user>
+ntn workers env set SNOWFLAKE_PRIVATE_KEY="$(cat snowflake_rsa.pem)"
+ntn workers env set SNOWFLAKE_WAREHOUSE=<warehouse>
+ntn workers env set SNOWFLAKE_ROLE=<read-only-role>
+
+# Optional — pin the default database/schema so queries don't need fully
+# qualified names.
+ntn workers env set SNOWFLAKE_DATABASE=<database>
+ntn workers env set SNOWFLAKE_SCHEMA=<schema>
+```
+
+Note the `"$(cat ...)"` wrapping for the private key — `ntn workers env set` accepts multi-line values when quoted this way.
+
+## Step 5 — Deploy
+
+```zsh
+ntn workers deploy --name snowflake-query
+```
+
+## Step 6 — Verify it works
+
+Hit the tool locally before connecting it to an agent:
+
+```zsh
+ntn workers exec runQuery --local -d '{"query":"SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_WAREHOUSE()"}'
+```
+
+You should see `columns`, `rows`, `rowCount: 1`, and `truncated: false`. If you do, connect the worker to a custom agent (**Tools and access → Add connection**) and ask it something like:
+
+> "Run a query in Snowflake to count how many rows are in `my_table`."
+
+## How the code is organized
+
+- `src/index.ts` — Worker entry. Registers one tool with a `j.object` input schema (`query`, `rowLimit`) and a structured output schema. `hints: { readOnlyHint: true }` lets the agent invoke the tool without confirmation.
+- `src/snowflake.ts` — All of the integration logic: JWT minting with `node:crypto`, the SQL REST API call, and the query safety checks (`SELECT`/`WITH` only, no semicolons, wrapping LIMIT).
+- `src/types.ts` — `SfStatementResponse` (the Snowflake API shape) and `QueryResult` (what we hand back to the agent).
+
+The JWT issuer string follows Snowflake's required format: `<ACCOUNT>.<USER>.SHA256:<public-key-fingerprint>`. The fingerprint is derived from the private key on every invocation, so you only need to store one secret.
+
+## Customizing
+
+- **Allow more query types** — `assertReadOnly` in `snowflake.ts` enforces `SELECT`/`WITH` only. Extend the regex (e.g. add `show|describe|explain`) if you want more shapes.
+- **Bump the row cap** — change the `cap` constant in `snowflake.ts`. Watch response sizes; very large results inflate the agent's context.
+- **Bypass the LIMIT wrap** — useful if you want the agent to control pagination via `OFFSET`. Remove the `SELECT * FROM (...) LIMIT N` wrap in `runQuery` and trust the user query.
+
+## Troubleshooting
+
+- **`JWT token is invalid`** — the user/account identifier in the JWT `iss` must match what Snowflake stores. Confirm `SNOWFLAKE_USER` matches `DESC USER`'s output (case-insensitive on Snowflake's side, but we upper-case it for safety).
+- **`Authentication token has expired`** — clock skew between Notion and Snowflake. The worker mints a fresh JWT per call, so this should self-resolve next request.
+- **`Object 'YOUR_TABLE' does not exist`** — make sure `SNOWFLAKE_ROLE` has `USAGE` on the schema and `SELECT` on the table.
+- **`Query took longer than the synchronous timeout`** — the tool only handles synchronous responses. Optimize the query (add a `WHERE`, pre-aggregate) or use Snowflake's async API for long-running analytics.
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Tools guide](https://developers.notion.com/workers/guides/tools)
+- [Snowflake SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/intro)
+- [Key-pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth)
 - [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/tools/snowflake-query/package.json
+++ b/examples/workers/tools/snowflake-query/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "snowflake-query",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/tools/snowflake-query/src/index.ts
+++ b/examples/workers/tools/snowflake-query/src/index.ts
@@ -1,0 +1,55 @@
+// Snowflake Query — read-only agent tool.
+//
+// Lets a Notion agent run a SELECT/WITH query against a Snowflake
+// warehouse and returns structured results. Auth is key-pair JWT against
+// the SQL REST API — no native Snowflake SDK needed inside the worker
+// sandbox.
+//
+// Safety:
+//   - Only SELECT and WITH statements are accepted.
+//   - Multi-statement input (`;`) is rejected.
+//   - The user's query is wrapped with a `LIMIT` so the warehouse caps
+//     the row count, not the worker.
+//   - The warehouse and role come from secrets, not user input — point
+//     them at a read-only role to harden further.
+
+import { Worker } from "@notionhq/workers"
+import { j } from "@notionhq/workers/schema-builder"
+import { runQuery } from "./snowflake.js"
+
+const worker = new Worker()
+export default worker
+
+worker.tool("runQuery", {
+  title: "Run Snowflake Query",
+  description:
+    "Run a read-only SQL query against Snowflake and return the rows. Only SELECT and WITH queries are permitted. Useful for asking questions like 'how many active customers do we have in EMEA?' when a Notion agent needs to look up live data from the warehouse.",
+  schema: j.object({
+    query: j
+      .string()
+      .describe(
+        "A single SQL SELECT or WITH statement. Do not include a trailing semicolon. The warehouse, role, database, and schema are fixed by the worker's configuration."
+      ),
+    rowLimit: j
+      .integer()
+      .nullable()
+      .describe("Maximum rows to return. Defaults to 100. Capped at 1000."),
+  }),
+  outputSchema: j.object({
+    columns: j
+      .array(j.string())
+      .describe("Column names in the order rows are arranged."),
+    rows: j
+      .array(j.array(j.string().nullable()))
+      .describe(
+        "Row data. Snowflake's SQL API returns all values as JSON strings (or null); the agent can parse numeric columns as needed."
+      ),
+    rowCount: j.integer().describe("Number of rows in `rows`."),
+    truncated: j
+      .boolean()
+      .describe(
+        "True if the original result set had more rows than `rowLimit`."
+      ),
+  }),
+  execute: ({ query, rowLimit }) => runQuery(query, rowLimit ?? null),
+})

--- a/examples/workers/tools/snowflake-query/src/snowflake.ts
+++ b/examples/workers/tools/snowflake-query/src/snowflake.ts
@@ -1,0 +1,153 @@
+import * as crypto from "node:crypto"
+import type { SfStatementResponse } from "./types.js"
+
+// Snowflake's SQL REST API authenticates via a short-lived JWT signed with
+// the user's private key. The corresponding public key must be uploaded
+// to the Snowflake user with `ALTER USER ... SET RSA_PUBLIC_KEY = '...'`.
+// See https://docs.snowflake.com/en/developer-guide/sql-api/authenticating
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Run \`ntn workers env set ${name}=...\`.`
+    )
+  }
+  return value
+}
+
+// Build the JWT Snowflake expects:
+//   iss = <ACCOUNT>.<USER>.SHA256:<public-key-fingerprint>
+//   sub = <ACCOUNT>.<USER>
+//   iat / exp — 1 hour validity
+//
+// The public key fingerprint is derived from the private key so the user
+// only has to provide one secret. Snowflake-identifier components are
+// upper-cased to match how the database stores them.
+function mintJwt(): string {
+  const account = requireEnv("SNOWFLAKE_ACCOUNT").toUpperCase()
+  const user = requireEnv("SNOWFLAKE_USER").toUpperCase()
+  const pem = requireEnv("SNOWFLAKE_PRIVATE_KEY")
+
+  const privateKey = crypto.createPrivateKey(pem)
+  const publicKeyDer = crypto
+    .createPublicKey(privateKey)
+    .export({ format: "der", type: "spki" })
+  const fingerprint = `SHA256:${crypto
+    .createHash("sha256")
+    .update(publicKeyDer)
+    .digest("base64")}`
+
+  const qualifiedUser = `${account}.${user}`
+  const now = Math.floor(Date.now() / 1000)
+
+  const header = base64UrlEncode(
+    Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+  )
+  const payload = base64UrlEncode(
+    Buffer.from(
+      JSON.stringify({
+        iss: `${qualifiedUser}.${fingerprint}`,
+        sub: qualifiedUser,
+        iat: now,
+        exp: now + 3600,
+      })
+    )
+  )
+
+  const signingInput = `${header}.${payload}`
+  const signature = crypto
+    .createSign("RSA-SHA256")
+    .update(signingInput)
+    .sign(privateKey)
+
+  return `${signingInput}.${base64UrlEncode(signature)}`
+}
+
+// Refuse anything that isn't a read-only SELECT/WITH query, and reject
+// multi-statement input to keep the tool safe to expose to an agent.
+function assertReadOnly(query: string): string {
+  const cleaned = query.trim().replace(/;\s*$/, "")
+  if (cleaned.includes(";")) {
+    throw new Error(
+      "Multi-statement queries are not allowed. Submit one SELECT or WITH statement."
+    )
+  }
+  if (!/^(select|with)\b/i.test(cleaned)) {
+    throw new Error("Only SELECT and WITH queries are permitted.")
+  }
+  return cleaned
+}
+
+export async function runQuery(
+  rawQuery: string,
+  requestedRowLimit: number | null
+) {
+  const safeQuery = assertReadOnly(rawQuery)
+
+  // Clamp the row limit. The agent can ask for fewer rows; we never
+  // return more than the hard cap to keep responses small.
+  const cap = 1000
+  const limit = Math.max(1, Math.min(cap, requestedRowLimit ?? 100))
+
+  // Wrap the user query so the warehouse enforces the cap — cheaper
+  // than fetching everything and slicing client-side.
+  const wrapped = `SELECT * FROM (${safeQuery}) LIMIT ${limit + 1}`
+
+  const account = requireEnv("SNOWFLAKE_ACCOUNT")
+  const warehouse = requireEnv("SNOWFLAKE_WAREHOUSE")
+  const role = requireEnv("SNOWFLAKE_ROLE")
+  const database = process.env.SNOWFLAKE_DATABASE
+  const schema = process.env.SNOWFLAKE_SCHEMA
+
+  const jwt = mintJwt()
+  const url = `https://${account}.snowflakecomputing.com/api/v2/statements`
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "X-Snowflake-Authorization-Token-Type": "KEYPAIR_JWT",
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      statement: wrapped,
+      warehouse,
+      role,
+      ...(database ? { database } : {}),
+      ...(schema ? { schema } : {}),
+    }),
+  })
+
+  // 202 = query still running. Polling would 2x the code; for an
+  // example, we tell the caller to optimize their query instead.
+  if (res.status === 202) {
+    throw new Error(
+      "Query took longer than the synchronous timeout. Run a smaller query or aggregate server-side."
+    )
+  }
+  if (!res.ok) {
+    throw new Error(`Snowflake API error: ${res.status} ${await res.text()}`)
+  }
+
+  const body = (await res.json()) as SfStatementResponse
+  const columns = body.resultSetMetaData?.rowType.map((c) => c.name) ?? []
+  const rawRows = body.data ?? []
+
+  // We requested `limit + 1` rows so we can detect truncation: if the
+  // warehouse returned the extra row, the user's result set has more
+  // data than the cap allowed us to return.
+  const truncated = rawRows.length > limit
+  const rows = truncated ? rawRows.slice(0, limit) : rawRows
+
+  return { columns, rows, rowCount: rows.length, truncated }
+}

--- a/examples/workers/tools/snowflake-query/src/types.ts
+++ b/examples/workers/tools/snowflake-query/src/types.ts
@@ -1,0 +1,12 @@
+// Shape of Snowflake's SQL REST API response in synchronous mode. We
+// surface a flattened view of the most-used fields; everything else on
+// the response (statementHandle, sqlState, etc.) is ignored.
+export interface SfStatementResponse {
+  resultSetMetaData?: {
+    rowType: { name: string; type: string }[]
+    numRows?: number
+  }
+  data?: (string | null)[][]
+  message?: string
+  code?: string
+}

--- a/examples/workers/tools/snowflake-query/tsconfig.json
+++ b/examples/workers/tools/snowflake-query/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder at `examples/workers/tools/snowflake-query/` with a working agent tool that runs **read-only** SQL against Snowflake and returns structured results.

- Single `runQuery` tool. Input: `query` + optional `rowLimit`. Output: `{ columns, rows, rowCount, truncated }`.
- **Key-pair JWT** auth against the Snowflake SQL REST API — no native SDK in the sandbox. Public-key fingerprint is derived from the private key so only `SNOWFLAKE_PRIVATE_KEY` needs to be set.
- **Safety rails**: only `SELECT`/`WITH` permitted, semicolons rejected (blocks multi-statement injection), and a server-side `LIMIT N+1` wrap that detects truncation cheaply.
- Warehouse / role / database / schema come from secrets, not user input — point them at a read-only role to harden further.

## Test plan

- [ ] `npm install && npm run check` in `examples/workers/tools/snowflake-query/`
- [ ] Generate keypair with `openssl genrsa ... && openssl rsa ...`
- [ ] `ALTER USER <user> SET RSA_PUBLIC_KEY = '...'` in Snowflake
- [ ] `ntn workers env set SNOWFLAKE_*` for account, user, private key, warehouse, role
- [ ] `ntn workers exec runQuery --local -d '{"query":"SELECT CURRENT_USER()"}'` returns expected structured output
- [ ] Try a query with a semicolon and confirm the tool refuses it
- [ ] Connect to a Notion agent and ask a natural-language data question

🤖 Generated with [Claude Code](https://claude.com/claude-code)