### PR TITLE
Add Spotify Control worker tool example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -15,4 +15,4 @@ The [syncs](syncs/) directory includes one-way sync examples that bring data fro
 The [tools](tools/) directory includes agent tool examples that extend Notion agents with new capabilities:
 
 - **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results _(coming soon)_
-- **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_
+- **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent

--- a/examples/workers/tools/spotify-control/README.md
+++ b/examples/workers/tools/spotify-control/README.md
@@ -1,18 +1,92 @@
 # Worker Tool: Spotify Control
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+Five Notion agent tools that let an agent control the calling user's Spotify playback — `play`, `pause`, `skip`, `queue`, and `nowPlaying`. Auth is per-user OAuth, so each Notion user who invokes the agent authorizes their own Spotify account.
 
-A Notion worker tool that lets a Notion agent start and control Spotify playback — play a track, pause, skip, or queue music — from a Notion conversation.
+## Prerequisites
 
-## What this example will demonstrate
+- A Notion workspace where you can install workers.
+- A [Spotify Developer account](https://developer.spotify.com/) (free).
+- Spotify open and playing on a device (phone, desktop app, or [web player](https://open.spotify.com)) when you test — the Web API can't talk to a device that isn't currently active.
+- Node.js ≥ 22 and the [`ntn` CLI](https://developers.notion.com/workers/get-started/quickstart) installed.
 
-- Defining Notion agent tools for play, pause, skip, and queue actions
-- Authenticating to the Spotify Web API via OAuth from a Notion worker
-- Searching the Spotify catalog and resolving natural-language requests to track URIs
-- Persisting per-user Spotify tokens so each agent user controls their own playback
+## Step 1 — Create a Spotify app
+
+1. Open the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) and click **Create app**.
+2. Fill in **App name** and **App description**.
+3. Get your worker's callback URL:
+   ```zsh
+   ntn workers oauth show-redirect-url
+   ```
+   Paste it into **Redirect URIs**. Click **Add**, then **Save**.
+4. Under **Which API/SDKs are you planning to use?**, tick **Web API**.
+5. Open **Settings** on the new app to reveal **Client ID** and **Client secret**.
+
+## Step 2 — Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/tools/spotify-control
+npm install
+ntn login
+```
+
+## Step 3 — Store the credentials
+
+```zsh
+ntn workers env set SPOTIFY_CLIENT_ID=<client-id>
+ntn workers env set SPOTIFY_CLIENT_SECRET=<client-secret>
+```
+
+## Step 4 — Deploy
+
+```zsh
+ntn workers deploy --name spotify-control
+```
+
+## Step 5 — Authorize (one-time, per user)
+
+```zsh
+ntn workers oauth start spotifyAuth
+```
+
+A browser opens to Spotify's consent screen. Approve the requested scopes (`user-read-playback-state`, `user-modify-playback-state`, `user-read-currently-playing`).
+
+> Every Notion user who runs the worker's tools will be prompted to authorize their own Spotify account the first time they invoke one — the runtime stores per-user tokens.
+
+## Step 6 — Verify it works
+
+1. Open Spotify on a device and start any track (the Web API will respond with "No active device" otherwise).
+2. Connect the worker to a custom agent in Notion: **Settings → Connections → Add custom agent → Add tools**.
+3. Ask the agent:
+   > "Play Bohemian Rhapsody by Queen on Spotify."
+
+The agent calls the `play` tool, which searches the catalog and starts playback. You'll hear the track switch on your device within a second.
+
+## How the code is organized
+
+- `src/index.ts` — Worker entry. Declares the OAuth provider and the five tools. A shared `resolveTrackUri` helper lets `play` and `queue` accept either a search query or an explicit URI.
+- `src/spotify.ts` — Web API client. Centralizes the `Authorization: Bearer` header and translates Spotify's "no active device" 404 into an actionable error message.
+- `src/types.ts` — Minimal Spotify response shapes (`SpotifyTrack`, `SpotifySearchResponse`, `CurrentlyPlayingResponse`).
+
+OAuth is per-user — `accessToken()` returns the calling user's token, scoped to their authorized account, so no user-ID plumbing is needed in our code.
+
+## Customizing
+
+- **Resolve albums and playlists** — `playTrack` always sends `{ uris: [uri] }`. To support album/playlist URIs, switch to `{ context_uri: uri }` when the URI doesn't start with `spotify:track:`.
+- **Add `transferPlayback`** — wrap `PUT /v1/me/player` to push playback onto a specific device. Useful when a user has multiple Spotify clients open.
+- **Search multiple results** — change `searchTopTrack` to return the top N tracks and let the agent pick. Requires adjusting the `play` and `queue` schemas to accept an `index` argument.
+
+## Troubleshooting
+
+- **`No active Spotify device`** — open Spotify on any device first. The Web API can only control devices Spotify already knows are online.
+- **OAuth consent screen says "Insufficient client scope"** — re-deploy after editing the `scope` string, then re-run `ntn workers oauth start spotifyAuth`. New scopes require re-consent.
+- **`invalid_grant` during `oauth start`** — the redirect URI in the Spotify Dashboard doesn't match the worker's. Run `ntn workers oauth show-redirect-url` again and paste exactly (including trailing slash, if any).
+- **Playback doesn't switch** — Spotify Free accounts can't be controlled by the Web API. The user needs Spotify Premium.
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Tools guide](https://developers.notion.com/workers/guides/tools)
+- [OAuth guide](https://developers.notion.com/workers/guides/oauth)
+- [Spotify Web API reference](https://developer.spotify.com/documentation/web-api)
 - [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/tools/spotify-control/package.json
+++ b/examples/workers/tools/spotify-control/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "spotify-control",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/tools/spotify-control/src/index.ts
+++ b/examples/workers/tools/spotify-control/src/index.ts
@@ -1,0 +1,170 @@
+// Spotify Control — agent tools for Spotify playback.
+//
+// Five tools that wrap the Spotify Web API:
+//
+//   - play(query?, uri?) — start playback; resolves a natural-language
+//     query to a track URI via the search API when needed.
+//   - pause() — pause playback.
+//   - skip(direction) — skip to the next or previous track.
+//   - queue(query?, uri?) — append to the queue.
+//   - nowPlaying() — return the currently playing track.
+//
+// Auth is OAuth 2.0 Authorization Code Flow. Each Notion user authorizes
+// their own Spotify account; `accessToken()` returns the calling user's
+// token, so the controls always act on whoever invoked the agent.
+
+import { Worker } from "@notionhq/workers"
+import { j } from "@notionhq/workers/schema-builder"
+import {
+  nowPlaying,
+  pause,
+  playTrack,
+  queueTrack,
+  searchTopTrack,
+  skip,
+} from "./spotify.js"
+
+const worker = new Worker()
+export default worker
+
+const spotifyAuth = worker.oauth("spotifyAuth", {
+  name: "spotify",
+  authorizationEndpoint: "https://accounts.spotify.com/authorize",
+  tokenEndpoint: "https://accounts.spotify.com/api/token",
+  scope:
+    "user-read-playback-state user-modify-playback-state user-read-currently-playing",
+  clientId: process.env.SPOTIFY_CLIENT_ID ?? "",
+  clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? "",
+})
+
+// Resolve a (query|uri) pair to a concrete Spotify track URI. Shared by
+// `play` and `queue` so the two tools behave consistently.
+async function resolveTrackUri(
+  token: string,
+  query: string | null,
+  uri: string | null
+) {
+  if (uri) {
+    return { uri, resolved: null as { name: string; artist: string } | null }
+  }
+  if (!query) {
+    throw new Error(
+      "Provide either `query` (natural language) or `uri` (a Spotify track URI)."
+    )
+  }
+  const top = await searchTopTrack(token, query)
+  return {
+    uri: top.uri,
+    resolved: {
+      name: top.name,
+      artist: top.artists[0]?.name ?? "",
+    },
+  }
+}
+
+worker.tool("play", {
+  title: "Play music on Spotify",
+  description:
+    "Start Spotify playback. Provide either a natural-language search query (e.g. 'Bohemian Rhapsody by Queen') or an explicit Spotify track URI. The user must have Spotify open on a device (phone, desktop, or web player).",
+  schema: j.object({
+    query: j
+      .string()
+      .nullable()
+      .describe(
+        "Natural-language search query. Used when `uri` is not provided; the top search result plays."
+      ),
+    uri: j
+      .string()
+      .nullable()
+      .describe(
+        "A Spotify track URI of the form `spotify:track:<id>`. Skips the search step."
+      ),
+  }),
+  execute: async ({ query, uri }) => {
+    const token = await spotifyAuth.accessToken()
+    const { uri: trackUri, resolved } = await resolveTrackUri(token, query, uri)
+    await playTrack(token, trackUri)
+    return {
+      uri: trackUri,
+      name: resolved?.name ?? null,
+      artist: resolved?.artist ?? null,
+    }
+  },
+})
+
+worker.tool("pause", {
+  title: "Pause Spotify",
+  description: "Pause the user's Spotify playback.",
+  schema: j.object({}),
+  execute: async () => {
+    const token = await spotifyAuth.accessToken()
+    await pause(token)
+    return { paused: true }
+  },
+})
+
+worker.tool("skip", {
+  title: "Skip Spotify track",
+  description:
+    "Skip to the next or previous track in the user's Spotify queue.",
+  schema: j.object({
+    direction: j
+      .enum("next", "previous")
+      .nullable()
+      .describe("Direction to skip. Defaults to `next`."),
+  }),
+  execute: async ({ direction }) => {
+    const token = await spotifyAuth.accessToken()
+    const dir = direction ?? "next"
+    await skip(token, dir)
+    return { skipped: dir }
+  },
+})
+
+worker.tool("queue", {
+  title: "Queue a Spotify track",
+  description:
+    "Append a track to the user's Spotify queue. Like `play`, accepts either a search query or a track URI.",
+  schema: j.object({
+    query: j.string().nullable().describe("Natural-language search query."),
+    uri: j.string().nullable().describe("Spotify track URI."),
+  }),
+  execute: async ({ query, uri }) => {
+    const token = await spotifyAuth.accessToken()
+    const { uri: trackUri, resolved } = await resolveTrackUri(token, query, uri)
+    await queueTrack(token, trackUri)
+    return {
+      uri: trackUri,
+      name: resolved?.name ?? null,
+      artist: resolved?.artist ?? null,
+    }
+  },
+})
+
+worker.tool("nowPlaying", {
+  title: "What's playing on Spotify",
+  description: "Return the user's currently playing track, if any.",
+  schema: j.object({}),
+  execute: async () => {
+    const token = await spotifyAuth.accessToken()
+    const current = await nowPlaying(token)
+    if (!current?.item) {
+      return {
+        playing: false,
+        name: null,
+        artist: null,
+        album: null,
+        progressMs: null,
+        durationMs: null,
+      }
+    }
+    return {
+      playing: current.is_playing,
+      name: current.item.name,
+      artist: current.item.artists[0]?.name ?? "",
+      album: current.item.album.name,
+      progressMs: current.progress_ms ?? 0,
+      durationMs: current.item.duration_ms,
+    }
+  },
+})

--- a/examples/workers/tools/spotify-control/src/spotify.ts
+++ b/examples/workers/tools/spotify-control/src/spotify.ts
@@ -1,0 +1,98 @@
+import type {
+  CurrentlyPlayingResponse,
+  SpotifySearchResponse,
+  SpotifyTrack,
+} from "./types.js"
+
+const SPOTIFY_API = "https://api.spotify.com"
+
+// Spotify returns this error reason when there's no Spotify client open
+// on any of the user's devices. We translate it to a clearer message so
+// the agent can tell the user what to do.
+const NO_ACTIVE_DEVICE = "NO_ACTIVE_DEVICE"
+
+async function spotifyFetch(
+  token: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<Response> {
+  const res = await fetch(`${SPOTIFY_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  })
+
+  if (res.status === 404) {
+    // Spotify returns 404 both for missing resources and for "no
+    // active device." Inspect the body to disambiguate.
+    const body = await res.clone().text()
+    if (body.includes(NO_ACTIVE_DEVICE)) {
+      throw new Error(
+        "No active Spotify device. Open Spotify on your phone, desktop, or web player and try again."
+      )
+    }
+  }
+
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`Spotify API error: ${res.status} ${await res.text()}`)
+  }
+
+  return res
+}
+
+export async function searchTopTrack(
+  token: string,
+  query: string
+): Promise<SpotifyTrack> {
+  const params = new URLSearchParams({
+    q: query,
+    type: "track",
+    limit: "1",
+  })
+  const res = await spotifyFetch(token, `/v1/search?${params.toString()}`)
+  const data = (await res.json()) as SpotifySearchResponse
+  const top = data.tracks.items[0]
+  if (!top) {
+    throw new Error(`No Spotify track found for "${query}".`)
+  }
+  return top
+}
+
+export async function playTrack(token: string, uri: string): Promise<void> {
+  await spotifyFetch(token, "/v1/me/player/play", {
+    method: "PUT",
+    body: JSON.stringify({ uris: [uri] }),
+  })
+}
+
+export async function pause(token: string): Promise<void> {
+  await spotifyFetch(token, "/v1/me/player/pause", { method: "PUT" })
+}
+
+export async function skip(
+  token: string,
+  direction: "next" | "previous"
+): Promise<void> {
+  await spotifyFetch(token, `/v1/me/player/${direction}`, {
+    method: "POST",
+  })
+}
+
+export async function queueTrack(token: string, uri: string): Promise<void> {
+  const params = new URLSearchParams({ uri })
+  await spotifyFetch(token, `/v1/me/player/queue?${params.toString()}`, {
+    method: "POST",
+  })
+}
+
+export async function nowPlaying(
+  token: string
+): Promise<CurrentlyPlayingResponse | null> {
+  const res = await spotifyFetch(token, "/v1/me/player/currently-playing")
+  // 204 = no track currently active for the user.
+  if (res.status === 204) return null
+  return (await res.json()) as CurrentlyPlayingResponse
+}

--- a/examples/workers/tools/spotify-control/src/types.ts
+++ b/examples/workers/tools/spotify-control/src/types.ts
@@ -1,0 +1,28 @@
+// Minimal Spotify Web API response shapes we depend on. Full schemas at
+// https://developer.spotify.com/documentation/web-api/reference
+
+export interface SpotifyArtist {
+  name: string
+}
+
+export interface SpotifyAlbum {
+  name: string
+}
+
+export interface SpotifyTrack {
+  uri: string
+  name: string
+  artists: SpotifyArtist[]
+  album: SpotifyAlbum
+  duration_ms: number
+}
+
+export interface SpotifySearchResponse {
+  tracks: { items: SpotifyTrack[] }
+}
+
+export interface CurrentlyPlayingResponse {
+  is_playing: boolean
+  progress_ms: number | null
+  item: SpotifyTrack | null
+}

--- a/examples/workers/tools/spotify-control/tsconfig.json
+++ b/examples/workers/tools/spotify-control/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder at `examples/workers/tools/spotify-control/` with five agent tools that let an agent control the calling user's Spotify playback.

- **Five tools** — `play`, `pause`, `skip`, `queue`, `nowPlaying`. `play` and `queue` accept either a natural-language search query (resolved via `/v1/search`) or an explicit `spotify:track:...` URI.
- **OAuth Authorization Code Flow** via `worker.oauth("spotifyAuth")`. Per-user identity is implicit — every Notion user authorizes their own Spotify account on first invoke.
- **No-active-device handling** — Spotify's 404 + `NO_ACTIVE_DEVICE` body is translated into "Open Spotify on your phone, desktop, or web player and try again."
- **JSON-safe `nowPlaying`** — returns a normalized shape with `null` fields when nothing is playing.

## Test plan

- [ ] `npm install && npm run check` in `examples/workers/tools/spotify-control/`
- [ ] Create a Spotify app in the Developer Dashboard with the redirect URL from `ntn workers oauth show-redirect-url`
- [ ] `ntn workers env set SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=...`
- [ ] `ntn workers deploy --name spotify-control`
- [ ] `ntn workers oauth start spotifyAuth`
- [ ] Open Spotify on a device, connect the worker to a custom agent, ask "Play Bohemian Rhapsody by Queen"
- [ ] Confirm `pause`, `skip`, `queue`, and `nowPlaying` all behave as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)