### PR TITLE
Add snowflake-query worker tool example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -14,5 +14,5 @@ The [syncs](syncs/) directory includes one-way sync examples that bring data fro
 
 The [tools](tools/) directory includes agent tool examples that extend Notion agents with new capabilities:
 
-- **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results _(coming soon)_
+- **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results
 - **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_

--- a/examples/workers/tools/snowflake-query/.env.example
+++ b/examples/workers/tools/snowflake-query/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Required
+SNOWFLAKE_ACCOUNT=
+SNOWFLAKE_USER=
+SNOWFLAKE_WAREHOUSE=
+# Paste the full PEM. Newlines may be written as literal \n — the worker normalizes them.
+SNOWFLAKE_PRIVATE_KEY=
+
+# Optional
+# SNOWFLAKE_PRIVATE_KEY_PASS=
+# SNOWFLAKE_DATABASE=
+# SNOWFLAKE_SCHEMA=
+# SNOWFLAKE_ROLE=
+# Default row cap for the `query` tool (capped at 1000).
+# SNOWFLAKE_MAX_ROWS=100
+# Statement timeout in seconds (capped at 300).
+# SNOWFLAKE_QUERY_TIMEOUT_SECONDS=60

--- a/examples/workers/tools/snowflake-query/.gitignore
+++ b/examples/workers/tools/snowflake-query/.gitignore
@@ -1,0 +1,11 @@
+# Secrets — never commit these
+.env
+workers.json
+
+# Private keys — never commit these
+*.p8
+rsa_key*
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/tools/snowflake-query/README.md
+++ b/examples/workers/tools/snowflake-query/README.md
@@ -1,18 +1,145 @@
-# Worker Tool: Snowflake Query
+# Worker tool: Snowflake query
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+A Notion worker that lets a custom agent query your Snowflake warehouse and get the rows back in the conversation. It registers three tools:
 
-A Notion worker tool that lets a Notion agent query a Snowflake warehouse and return the results inline in a conversation.
+- `listTables` runs `SHOW TABLES`, optionally scoped to a database/schema or filtered with a `LIKE` pattern.
+- `describeTable` runs `DESCRIBE TABLE` and returns a table's columns and types.
+- `query` runs a single read-only `SELECT` (or `WITH ... SELECT`) and returns the rows.
 
-## What this example will demonstrate
+Together they let the agent find a table, check its columns, and query it without anyone writing SQL by hand. Everything runs on Notion Workers against your warehouse, so there's no separate service to host.
 
-- Defining a Notion agent tool that accepts a SQL query as input
-- Connecting to Snowflake from a Notion worker using the Snowflake SDK
-- Returning query results to the agent in a structured, easy-to-render format
-- Safely scoping queries via roles, warehouses, and row limits
+## Project structure
+
+```
+src/
+  index.ts       Worker definition and the three tools
+  sql.ts         Read-only SQL validation and the SHOW/DESCRIBE builders
+  snowflake.ts   Connection, query execution, and result normalization
+```
+
+## Set up Snowflake
+
+The worker connects as a Snowflake user, so give it a dedicated read-only one scoped to just the data the agent should see. That read-only role, not the SQL check in the code, is what actually keeps the agent from writing.
+
+Run this in a worksheet, replacing `MY_DB` with your database:
+
+```sql
+USE ROLE SECURITYADMIN;
+CREATE ROLE IF NOT EXISTS NOTION_AGENT_READONLY;
+
+CREATE WAREHOUSE IF NOT EXISTS NOTION_AGENT_WH
+  WITH WAREHOUSE_SIZE = 'XSMALL'
+  AUTO_SUSPEND = 60
+  AUTO_RESUME = TRUE
+  INITIALLY_SUSPENDED = TRUE;
+GRANT USAGE ON WAREHOUSE NOTION_AGENT_WH TO ROLE NOTION_AGENT_READONLY;
+
+GRANT USAGE ON DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+GRANT USAGE ON ALL SCHEMAS IN DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+GRANT SELECT ON ALL TABLES IN DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+GRANT SELECT ON FUTURE TABLES IN DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+GRANT SELECT ON ALL VIEWS IN DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+GRANT SELECT ON FUTURE VIEWS IN DATABASE MY_DB TO ROLE NOTION_AGENT_READONLY;
+
+USE ROLE USERADMIN;
+CREATE USER IF NOT EXISTS NOTION_AGENT_SVC
+  DEFAULT_ROLE = NOTION_AGENT_READONLY
+  DEFAULT_WAREHOUSE = NOTION_AGENT_WH;
+GRANT ROLE NOTION_AGENT_READONLY TO USER NOTION_AGENT_SVC;
+```
+
+### Key-pair authentication
+
+The worker authenticates with an RSA key pair rather than a password. Generate one:
+
+```zsh
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Attach the public key to the service user. Paste the body of `rsa_key.pub` without the `BEGIN`/`END` lines:
+
+```sql
+ALTER USER NOTION_AGENT_SVC SET RSA_PUBLIC_KEY='MIIBIjANBgkqh...';
+```
+
+`rsa_key.p8` stays on your machine and is only ever passed to the worker as a secret. The `.gitignore` here ignores `*.p8` and `rsa_key*` so it won't get committed by accident.
+
+## Setup
+
+### 1. Install the Notion Workers CLI
+
+```zsh
+npm install -g @notionhq/workers-cli
+```
+
+### 2. Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/tools/snowflake-query
+npm install
+```
+
+### 3. Connect to your workspace
+
+```zsh
+ntn login
+```
+
+### 4. Deploy
+
+```zsh
+ntn workers deploy --name snowflake-query
+```
+
+### 5. Set the connection secrets
+
+These are worker secrets and never live in the repo (`.env` and `workers.json` are gitignored):
+
+```zsh
+ntn workers env set SNOWFLAKE_ACCOUNT=your_org-your_account
+ntn workers env set SNOWFLAKE_USER=NOTION_AGENT_SVC
+ntn workers env set SNOWFLAKE_WAREHOUSE=NOTION_AGENT_WH
+ntn workers env set SNOWFLAKE_PRIVATE_KEY="$(cat rsa_key.p8)"
+
+# Optional, so the agent doesn't have to fully qualify every name:
+ntn workers env set SNOWFLAKE_DATABASE=MY_DB
+ntn workers env set SNOWFLAKE_SCHEMA=PUBLIC
+ntn workers env set SNOWFLAKE_ROLE=NOTION_AGENT_READONLY
+```
+
+`SNOWFLAKE_ACCOUNT` is the `orgname-account_name` identifier ([docs](https://docs.snowflake.com/en/user-guide/admin-account-identifier)). Other optional secrets: `SNOWFLAKE_PRIVATE_KEY_PASS` if the key is encrypted, `SNOWFLAKE_MAX_ROWS` (default 100, capped at 1000), and `SNOWFLAKE_QUERY_TIMEOUT_SECONDS` (default 60, capped at 300).
+
+## Connect it to an agent
+
+Once deployed, add the worker to a custom agent under **Tools and access > Add connection**. The agent can then call `listTables`, `describeTable`, and `query`.
+
+A prompt like:
+
+> What were total orders by month this year? Find the right table first.
+
+usually has the agent list tables, describe the likely one, then run a query and summarize what comes back.
+
+## Test locally
+
+Copy `.env.example` to `.env`, fill in your values, and run a tool without deploying:
+
+```zsh
+ntn workers exec listTables --local -d '{}'
+ntn workers exec describeTable --local -d '{"table": "MY_DB.PUBLIC.ORDERS"}'
+ntn workers exec query --local -d '{"sql": "SELECT CURRENT_DATE() AS ds", "maxRows": 10}'
+```
+
+## Notes on safety
+
+`query` parses each statement and only allows a single `SELECT`/`WITH ... SELECT`; writes, DDL, and multiple statements are rejected, and the discovery tools build their SQL from validated identifiers. Treat that as a guardrail, not a guarantee: the read-only role above is what enforces it at the warehouse. Results are also capped (`SNOWFLAKE_MAX_ROWS`, max 1000) and run under a statement timeout, so this is meant for answering questions inline, not bulk export.
+
+The row cap is applied with an outer `LIMIT`, which doesn't preserve a top-level `ORDER BY` on its own. If order matters, have the query sort and bound its own rows (`ORDER BY ... LIMIT`), or sort the returned rows in the agent.
 
 ## Learn more
 
 - [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
+- [Snowflake key-pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth)
 - [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/tools/snowflake-query/README.md
+++ b/examples/workers/tools/snowflake-query/README.md
@@ -138,6 +138,8 @@ ntn workers exec query --local -d '{"sql": "SELECT CURRENT_DATE() AS ds", "maxRo
 
 The row cap is applied with an outer `LIMIT`, which doesn't preserve a top-level `ORDER BY` on its own. If order matters, have the query sort and bound its own rows (`ORDER BY ... LIMIT`), or sort the returned rows in the agent.
 
+The read-only check uses `node-sql-parser`'s Snowflake dialect, which fails closed: it rejects anything it can't parse as a single `SELECT`. That's safe, but it also means a few valid read-only queries it doesn't fully support yet (e.g. `SAMPLE`) get bounced. The authoritative guardrail is still the read-only role, so you can loosen the parser check if your use case needs those.
+
 ## Learn more
 
 - [Notion Workers documentation](https://developers.notion.com/docs/workers)

--- a/examples/workers/tools/snowflake-query/package.json
+++ b/examples/workers/tools/snowflake-query/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "snowflake-query",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0",
+    "node-sql-parser": "^5.4.0",
+    "snowflake-sdk": "^2.4.3"
+  }
+}

--- a/examples/workers/tools/snowflake-query/package.json
+++ b/examples/workers/tools/snowflake-query/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/examples/workers/tools/snowflake-query/src/index.ts
+++ b/examples/workers/tools/snowflake-query/src/index.ts
@@ -1,0 +1,83 @@
+import { Worker } from "@notionhq/workers"
+import { j } from "@notionhq/workers/schema-builder"
+
+import { runCommand, runQuery } from "./snowflake.js"
+import { assertSelectOnly, buildDescribeTable, buildShowTables } from "./sql.js"
+
+const worker = new Worker()
+export default worker
+
+// Three tools an agent can chain to answer questions about a warehouse:
+// find a table, check its columns, then query it.
+
+worker.tool("listTables", {
+  title: "List Tables",
+  description:
+    "List tables in the Snowflake warehouse. Optionally scope to a database and schema, or filter names with a SQL LIKE pattern (e.g. '%ORDERS%'). Use this to discover what data is available before querying.",
+  schema: j.object({
+    database: j
+      .string()
+      .nullable()
+      .describe(
+        "Database to list from. Defaults to the worker's configured database."
+      ),
+    schema: j
+      .string()
+      .nullable()
+      .describe(
+        "Schema to list from. Defaults to the worker's configured schema."
+      ),
+    like: j
+      .string()
+      .nullable()
+      .describe(
+        "Case-insensitive LIKE pattern to filter table names, e.g. '%ORDER%'."
+      ),
+  }),
+  execute: async ({ database, schema, like }) =>
+    safely(() => runCommand(buildShowTables({ database, schema, like }))),
+})
+
+worker.tool("describeTable", {
+  title: "Describe Table",
+  description:
+    "Describe a table's columns (name, type, nullability) so you know its shape before querying. Pass a fully qualified name like DATABASE.SCHEMA.TABLE.",
+  schema: j.object({
+    table: j
+      .string()
+      .describe(
+        "Table to describe, ideally fully qualified as DATABASE.SCHEMA.TABLE."
+      ),
+  }),
+  execute: async ({ table }) =>
+    safely(() => runCommand(buildDescribeTable(table))),
+})
+
+worker.tool("query", {
+  title: "Query Snowflake",
+  description:
+    "Run a read-only SQL SELECT against Snowflake and return the rows. Only a single SELECT (or WITH ... SELECT) is allowed; writes and other statements are rejected. Results are capped at maxRows.",
+  schema: j.object({
+    sql: j
+      .string()
+      .describe("A single read-only SELECT or WITH ... SELECT statement."),
+    maxRows: j
+      .number()
+      .nullable()
+      .describe("Maximum rows to return. Defaults to 100; capped at 1000."),
+  }),
+  execute: async ({ sql, maxRows }) =>
+    safely(() => {
+      assertSelectOnly(sql)
+      return runQuery(sql, maxRows)
+    }),
+})
+
+// Hand the agent a readable error instead of throwing, so it can correct itself.
+async function safely<T>(fn: () => Promise<T>): Promise<T | { error: string }> {
+  try {
+    return await fn()
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/examples/workers/tools/snowflake-query/src/snowflake.ts
+++ b/examples/workers/tools/snowflake-query/src/snowflake.ts
@@ -171,8 +171,10 @@ function normalizeValue(value: unknown): JsonValue {
 }
 
 function clamp(value: number | null, fallback: number, max: number): number {
-  if (value == null || !Number.isFinite(value) || value <= 0) return fallback
-  return Math.min(Math.floor(value), max)
+  if (value == null) return fallback
+  const n = Math.floor(value)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  return Math.min(n, max)
 }
 
 function readPositiveInt(name: string, fallback: number): number {

--- a/examples/workers/tools/snowflake-query/src/snowflake.ts
+++ b/examples/workers/tools/snowflake-query/src/snowflake.ts
@@ -121,6 +121,9 @@ function executeSql(
   return new Promise((resolve, reject) => {
     conn.execute({
       sqlText,
+      // Rename duplicate column names (e.g. two `id`s from a join) instead of
+      // silently dropping one when rows are keyed by column name.
+      rowMode: "object_with_renamed_duplicated_columns",
       complete: (err, stmt, rows) => {
         if (err) {
           reject(err)

--- a/examples/workers/tools/snowflake-query/src/snowflake.ts
+++ b/examples/workers/tools/snowflake-query/src/snowflake.ts
@@ -1,0 +1,183 @@
+import snowflake from "snowflake-sdk"
+
+import { buildBoundedQuery } from "./sql.js"
+
+snowflake.configure({ logLevel: "ERROR" })
+
+const HARD_MAX_ROWS = 1000
+const DEFAULT_MAX_ROWS = Math.min(
+  readPositiveInt("SNOWFLAKE_MAX_ROWS", 100),
+  HARD_MAX_ROWS
+)
+const TIMEOUT_SECONDS = Math.min(
+  readPositiveInt("SNOWFLAKE_QUERY_TIMEOUT_SECONDS", 60),
+  300
+)
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type ColumnInfo = {
+  name: string
+  type: string | null
+  nullable: boolean | null
+}
+
+export type QueryResult = {
+  rows: Record<string, JsonValue>[]
+  columns: ColumnInfo[]
+  rowCount: number
+  truncated: boolean
+}
+
+export async function runQuery(
+  sql: string,
+  requestedMaxRows: number | null
+): Promise<QueryResult> {
+  const maxRows = clamp(requestedMaxRows, DEFAULT_MAX_ROWS, HARD_MAX_ROWS)
+  // The wrapper fetches one extra row so we can report truncation.
+  const result = await execute(buildBoundedQuery(sql, maxRows))
+  return capRows(result, maxRows)
+}
+
+// SHOW / DESCRIBE can't be wrapped in a subquery, so cap the rows in memory.
+export async function runCommand(sql: string): Promise<QueryResult> {
+  const result = await execute(sql)
+  return capRows(result, HARD_MAX_ROWS)
+}
+
+function capRows(result: QueryResult, maxRows: number): QueryResult {
+  const truncated = result.rows.length > maxRows
+  const rows = truncated ? result.rows.slice(0, maxRows) : result.rows
+  return { ...result, rows, rowCount: rows.length, truncated }
+}
+
+async function execute(sqlText: string): Promise<QueryResult> {
+  const conn = createConnection()
+  await connect(conn)
+  try {
+    await executeSql(
+      conn,
+      `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${TIMEOUT_SECONDS}`
+    )
+    return await executeSql(conn, sqlText)
+  } finally {
+    // Don't let a teardown error mask the real query error.
+    await destroy(conn).catch(() => {})
+  }
+}
+
+function createConnection(): snowflake.Connection {
+  const account = process.env.SNOWFLAKE_ACCOUNT ?? ""
+  const username = process.env.SNOWFLAKE_USER ?? ""
+  const warehouse = process.env.SNOWFLAKE_WAREHOUSE ?? ""
+  const privateKey = process.env.SNOWFLAKE_PRIVATE_KEY ?? ""
+  const privateKeyPass = process.env.SNOWFLAKE_PRIVATE_KEY_PASS
+  const database = process.env.SNOWFLAKE_DATABASE
+  const schema = process.env.SNOWFLAKE_SCHEMA
+  const role = process.env.SNOWFLAKE_ROLE
+
+  if (!account || !username || !warehouse || !privateKey) {
+    throw new Error(
+      "Missing Snowflake configuration. Set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_WAREHOUSE, and SNOWFLAKE_PRIVATE_KEY."
+    )
+  }
+
+  return snowflake.createConnection({
+    account,
+    username,
+    warehouse,
+    authenticator: "SNOWFLAKE_JWT",
+    // A key stored as a one-line secret often has its newlines escaped.
+    privateKey: privateKey.replace(/\\n/g, "\n"),
+    ...(privateKeyPass ? { privateKeyPass } : {}),
+    ...(database ? { database } : {}),
+    ...(schema ? { schema } : {}),
+    ...(role ? { role } : {}),
+  })
+}
+
+function connect(conn: snowflake.Connection): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn.connect((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+function destroy(conn: snowflake.Connection): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn.destroy((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+function executeSql(
+  conn: snowflake.Connection,
+  sqlText: string
+): Promise<QueryResult> {
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText,
+      complete: (err, stmt, rows) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        const rawRows = (rows ?? []) as Record<string, unknown>[]
+        const columns = (stmt.getColumns?.() ?? []).map((column) => ({
+          name: column.getName?.() ?? "",
+          type: column.getType?.() ?? null,
+          nullable: column.isNullable?.() ?? null,
+        }))
+        resolve({
+          rows: rawRows.map(normalizeRow),
+          columns,
+          rowCount: rawRows.length,
+          truncated: false,
+        })
+      },
+    })
+  })
+}
+
+function normalizeRow(row: Record<string, unknown>): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, normalizeValue(value)])
+  )
+}
+
+function normalizeValue(value: unknown): JsonValue {
+  if (value == null) return null
+  if (typeof value === "string") return value
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : String(value)
+  if (typeof value === "boolean") return value
+  if (typeof value === "bigint") return value.toString()
+  if (value instanceof Date) return value.toISOString()
+  if (Buffer.isBuffer(value)) return value.toString("base64")
+  if (Array.isArray(value)) return value.map(normalizeValue)
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        normalizeValue(nested),
+      ])
+    )
+  }
+  return String(value)
+}
+
+function clamp(value: number | null, fallback: number, max: number): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) return fallback
+  return Math.min(Math.floor(value), max)
+}
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/examples/workers/tools/snowflake-query/src/sql.ts
+++ b/examples/workers/tools/snowflake-query/src/sql.ts
@@ -25,15 +25,24 @@ export function assertSelectOnly(sql: string): void {
     throw new Error("Only one SQL statement is allowed.")
   }
   // WITH ... SELECT parses as a select node with a .with clause.
-  if (list[0]?.type !== "select") {
+  const statement = list[0]
+  if (statement?.type !== "select") {
+    throw new Error("Only read-only SELECT queries are allowed.")
+  }
+  // `SELECT ... INTO <target>` parses as a select but writes; reject it.
+  // A normal select has `into: { position: null }`; an INTO clause sets `expr`.
+  const into = (statement as { into?: { expr?: unknown } }).into
+  if (into?.expr != null) {
     throw new Error("Only read-only SELECT queries are allowed.")
   }
 }
 
-// Cap the result set and grab one extra row to detect truncation.
+// Cap the result set and grab one extra row to detect truncation. The inner
+// query sits on its own line so a trailing line comment (-- ...) can't swallow
+// the closing paren and LIMIT.
 export function buildBoundedQuery(sql: string, maxRows: number): string {
   const inner = stripTrailingSemicolon(sql)
-  return `SELECT * FROM (${inner}) AS query_result LIMIT ${maxRows + 1}`
+  return `SELECT * FROM (\n${inner}\n) AS query_result LIMIT ${maxRows + 1}`
 }
 
 export function buildShowTables(input: {

--- a/examples/workers/tools/snowflake-query/src/sql.ts
+++ b/examples/workers/tools/snowflake-query/src/sql.ts
@@ -1,0 +1,83 @@
+import { Parser } from "node-sql-parser"
+
+const parser = new Parser()
+
+// We parse the statement instead of pattern-matching on keywords so comments
+// and string literals can't smuggle in a write. This is a convenience check,
+// not the security boundary -- that's the read-only Snowflake role (see README).
+export function assertSelectOnly(sql: string): void {
+  if (!sql.trim()) {
+    throw new Error("sql must be a non-empty string.")
+  }
+
+  let statements
+  try {
+    statements = parser.astify(sql, { database: "Snowflake" })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Could not parse SQL as a read-only SELECT query: ${detail}`
+    )
+  }
+
+  const list = Array.isArray(statements) ? statements : [statements]
+  if (list.length !== 1) {
+    throw new Error("Only one SQL statement is allowed.")
+  }
+  // WITH ... SELECT parses as a select node with a .with clause.
+  if (list[0]?.type !== "select") {
+    throw new Error("Only read-only SELECT queries are allowed.")
+  }
+}
+
+// Cap the result set and grab one extra row to detect truncation.
+export function buildBoundedQuery(sql: string, maxRows: number): string {
+  const inner = stripTrailingSemicolon(sql)
+  return `SELECT * FROM (${inner}) AS query_result LIMIT ${maxRows + 1}`
+}
+
+export function buildShowTables(input: {
+  database?: string | null
+  schema?: string | null
+  like?: string | null
+}): string {
+  let sql = "SHOW TABLES"
+
+  if (input.like) {
+    sql += ` LIKE '${input.like.replace(/'/g, "''")}'`
+  }
+
+  if (input.database && input.schema) {
+    sql += ` IN SCHEMA ${ident(input.database, "database")}.${ident(input.schema, "schema")}`
+  } else if (input.database) {
+    sql += ` IN DATABASE ${ident(input.database, "database")}`
+  } else if (input.schema) {
+    sql += ` IN SCHEMA ${ident(input.schema, "schema")}`
+  }
+
+  return sql
+}
+
+export function buildDescribeTable(table: string): string {
+  const parts = table.trim().split(".")
+  if (parts.length > 3) {
+    throw new Error(`Invalid table name: ${table}. Use DATABASE.SCHEMA.TABLE.`)
+  }
+  const validated = parts.map((part) => ident(part, "table"))
+  return `DESCRIBE TABLE ${validated.join(".")}`
+}
+
+// Reject anything that isn't a bare identifier so a name can't carry extra SQL
+// into a SHOW/DESCRIBE statement.
+function ident(value: string, label: string): string {
+  const trimmed = value.trim()
+  if (!/^[A-Za-z0-9_$]+$/.test(trimmed)) {
+    throw new Error(`Invalid ${label} name: ${value}`)
+  }
+  return trimmed
+}
+
+function stripTrailingSemicolon(sql: string): string {
+  const trimmed = sql.trim()
+  return trimmed.endsWith(";") ? trimmed.slice(0, -1).trim() : trimmed
+}

--- a/examples/workers/tools/snowflake-query/test.ts
+++ b/examples/workers/tools/snowflake-query/test.ts
@@ -1,0 +1,123 @@
+// Tests for the read-only SQL guard and SHOW/DESCRIBE builders in src/sql.ts.
+// These are the security-relevant bits and need no Snowflake connection.
+// Run: npm test  (or: npx tsx test.ts)
+import {
+  assertSelectOnly,
+  buildBoundedQuery,
+  buildDescribeTable,
+  buildShowTables,
+} from "./src/sql.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+function accepts(sql: string): boolean {
+  try {
+    assertSelectOnly(sql)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function rejects(build: () => unknown): boolean {
+  try {
+    build()
+    return false
+  } catch {
+    return true
+  }
+}
+
+console.log("assertSelectOnly accepts read-only selects:")
+ok("plain select", accepts("SELECT 1"))
+ok(
+  "select from table",
+  accepts("SELECT id, name FROM orders WHERE status = 'open'")
+)
+ok("with/cte", accepts("WITH t AS (SELECT 1 AS x) SELECT * FROM t"))
+ok(
+  "semicolon inside string literal",
+  accepts("SELECT col FROM t WHERE v = 'a;b'")
+)
+ok("trailing semicolon", accepts("SELECT 1;"))
+ok("lowercase keyword", accepts("select current_date()"))
+ok("trailing line comment", accepts("SELECT id FROM t -- get all\n"))
+
+console.log("assertSelectOnly rejects everything else:")
+ok("delete", !accepts("DELETE FROM t"))
+ok("update", !accepts("UPDATE t SET x = 1"))
+ok("insert", !accepts("INSERT INTO t VALUES (1)"))
+ok("drop", !accepts("DROP TABLE t"))
+ok("create", !accepts("CREATE TABLE t (x int)"))
+ok(
+  "merge",
+  !accepts("MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE")
+)
+ok("select ... into (write)", !accepts("SELECT * INTO new_table FROM t"))
+ok("multi-statement", !accepts("SELECT 1; SELECT 2"))
+ok("select then delete", !accepts("SELECT 1; DELETE FROM t"))
+ok("show (use listTables instead)", !accepts("SHOW TABLES"))
+ok("describe (use describeTable instead)", !accepts("DESCRIBE TABLE t"))
+ok("empty", !accepts(""))
+ok("garbage", !accepts("not sql at all"))
+
+console.log("buildBoundedQuery:")
+ok(
+  "wraps and fetches one extra row",
+  buildBoundedQuery("SELECT 1", 10) ===
+    "SELECT * FROM (\nSELECT 1\n) AS query_result LIMIT 11"
+)
+ok(
+  "strips a trailing semicolon",
+  buildBoundedQuery("SELECT 1;", 5) ===
+    "SELECT * FROM (\nSELECT 1\n) AS query_result LIMIT 6"
+)
+ok(
+  "trailing line comment can't swallow the LIMIT",
+  buildBoundedQuery("SELECT id FROM t -- c", 10) ===
+    "SELECT * FROM (\nSELECT id FROM t -- c\n) AS query_result LIMIT 11"
+)
+
+console.log("buildShowTables / buildDescribeTable:")
+ok("bare", buildShowTables({}) === "SHOW TABLES")
+ok(
+  "db + schema",
+  buildShowTables({ database: "MY_DB", schema: "PUBLIC" }) ===
+    "SHOW TABLES IN SCHEMA MY_DB.PUBLIC"
+)
+ok(
+  "like before in (snowflake grammar)",
+  buildShowTables({ database: "MY_DB", like: "%ORDER%" }) ===
+    "SHOW TABLES LIKE '%ORDER%' IN DATABASE MY_DB"
+)
+ok(
+  "like escapes single quotes",
+  buildShowTables({ like: "O'B%" }) === "SHOW TABLES LIKE 'O''B%'"
+)
+ok(
+  "rejects identifier injection",
+  rejects(() => buildShowTables({ database: "x; DROP TABLE y" }))
+)
+ok(
+  "describe fully qualified",
+  buildDescribeTable("MY_DB.PUBLIC.ORDERS") ===
+    "DESCRIBE TABLE MY_DB.PUBLIC.ORDERS"
+)
+ok(
+  "describe rejects injection",
+  rejects(() => buildDescribeTable("t; DROP TABLE x"))
+)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/tools/snowflake-query/tsconfig.json
+++ b/examples/workers/tools/snowflake-query/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds `examples/workers/tools/snowflake-query/` — a Notion worker that lets a custom agent query a Snowflake warehouse read-only. Three tools an agent can chain (find a table → check its columns → query it):

- `listTables` — `SHOW TABLES` (optional database/schema/`LIKE`)
- `describeTable` — `DESCRIBE TABLE`
- `query` — a single read-only `SELECT` / `WITH ... SELECT`

Key-pair (JWT) auth, `node-sql-parser` SELECT-only validation, bounded results + statement timeout. The README walks a customer through a dedicated read-only role + key-pair setup, deploy, secrets, and connecting to a custom agent.

## Verification

- `npm run check` (typecheck), prettier, and markdownlint all clean
- 30/30 credential-free SQL-guard logic tests (accepts SELECT/CTE; rejects DELETE/UPDATE/INSERT/DROP/CREATE/MERGE/multi-statement/SHOW/DESCRIBE/empty/garbage; identifier-injection blocked)
- End-to-end against a live read-only Snowflake connection via `ntn workers exec --local`: `query` (`CURRENT_DATE`), `listTables` (170 tables), `describeTable` (61 columns); a `DELETE` is rejected before reaching Snowflake
- Deployed to the dev workspace; tools register as `listTables` / `describeTable` / `query`

No secrets committed — `.env`, `workers.json`, and key files are gitignored; only `.env.example` (placeholders) ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
