### PR TITLE
feat(workers): add cloudwatch-logs tool example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -16,5 +16,6 @@ The [tools](tools/) directory includes agent tool examples that extend Notion ag
 
 - **[airflow](tools/airflow/)**: Query Airflow DAGs, runs, tasks, and logs from a Notion agent
 - **[chart-generator](tools/chart-generator/)**: Render a Vega-Lite chart to an image and embed it in a Notion page
+- **[cloudwatch-logs](tools/cloudwatch-logs/)**: Query AWS CloudWatch log groups, streams, and events from a Notion agent
 - **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results
 - **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_

--- a/examples/workers/tools/cloudwatch-logs/.env.example
+++ b/examples/workers/tools/cloudwatch-logs/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to `.env` and fill in your values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# The AWS region where your log groups live.
+AWS_REGION=
+
+# AWS credentials come from the standard SDK credential provider chain — the
+# worker code only reads AWS_REGION. In a deployed worker, set credentials
+# with `ntn workers env set`:
+#
+#   AWS_ACCESS_KEY_ID=
+#   AWS_SECRET_ACCESS_KEY=
+#   AWS_SESSION_TOKEN=   # only needed for temporary credentials
+#
+# Locally, you can instead set AWS_PROFILE to use a named profile from
+# ~/.aws/credentials, or rely on an instance/task role if running on EC2/ECS.

--- a/examples/workers/tools/cloudwatch-logs/.gitignore
+++ b/examples/workers/tools/cloudwatch-logs/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/tools/cloudwatch-logs/README.md
+++ b/examples/workers/tools/cloudwatch-logs/README.md
@@ -1,0 +1,137 @@
+# Worker tool: CloudWatch Logs
+
+A Notion worker that lets a custom agent browse and read AWS CloudWatch Logs. It registers three tools:
+
+- `listLogGroups` lists log groups matching a name prefix.
+- `getLogStreams` lists log streams within a group, ordered by most recent activity.
+- `getLogEvents` fetches events from a specific stream with optional time filtering.
+
+Together they let the agent find the right log group, narrow to a stream, and read the events — without anyone digging through the AWS console. Everything runs on Notion Workers, so there is no separate service to host.
+
+## How it works
+
+```
+src/
+  index.ts   Worker definition and the three tools
+  config.ts  CloudWatch client and error helper
+```
+
+The tools chain naturally: `listLogGroups` → `getLogStreams` → `getLogEvents`. All three return paginated, capped results so responses stay readable in the agent conversation.
+
+## Tools
+
+### `listLogGroups`
+
+Lists log groups matching a name prefix. Results are capped at 50; default is 10.
+
+Common prefixes:
+
+- `/aws/lambda/` — Lambda function logs
+- `/aws/kinesis-analytics/` — Kinesis Data Analytics / Flink job logs
+
+### `getLogStreams`
+
+Lists streams in a log group ordered by most recent event. Results are capped at 50; default is 10.
+
+Pass `filterPrefix` to narrow by stream name prefix. For Airflow-style log groups that name streams after their tasks, `dag_id=my_dag_name` scopes results to a specific workflow.
+
+### `getLogEvents`
+
+Fetches events from a single stream in chronological order. Results are capped at 500; default is 100.
+
+Pass `startTime` and/or `endTime` as ISO 8601 strings (e.g. `"2024-06-01T12:00:00Z"`) to filter by time range.
+
+## Setup
+
+### 1. Install the Notion Workers CLI
+
+```zsh
+npm install -g @notionhq/workers-cli
+```
+
+### 2. Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/tools/cloudwatch-logs
+npm install
+```
+
+> **Note:** The AWS SDK has a large dependency tree. Expect `node_modules` to be 50-80 MB after install.
+
+### 3. Connect to your workspace
+
+```zsh
+ntn login
+```
+
+### 4. Deploy
+
+```zsh
+ntn workers deploy --name cloudwatch-logs
+```
+
+### 5. Set environment variables
+
+```zsh
+ntn workers env set AWS_REGION=us-east-1
+ntn workers env set AWS_ACCESS_KEY_ID=your_access_key_id
+ntn workers env set AWS_SECRET_ACCESS_KEY=your_secret_access_key
+# Only needed for temporary credentials (e.g. assumed roles):
+# ntn workers env set AWS_SESSION_TOKEN=your_session_token
+```
+
+### 6. Connect to an agent
+
+Once deployed, add the worker to a custom agent under **Tools and access > Add connection**. The agent can then call `listLogGroups`, `getLogStreams`, and `getLogEvents`.
+
+A prompt like:
+
+> What errors appeared in the my-function Lambda logs in the last hour?
+
+will have the agent list groups, find the right stream, and fetch the events.
+
+## AWS credentials and IAM permissions
+
+The worker uses the standard AWS SDK credential provider chain. Set credentials via environment variables (above) or, if running on EC2/ECS, rely on the instance or task role — the worker only reads `AWS_REGION` plus the standard `AWS_*` credential variables.
+
+The IAM principal needs these permissions on the relevant log groups:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "logs:DescribeLogGroups",
+    "logs:DescribeLogStreams",
+    "logs:GetLogEvents"
+  ],
+  "Resource": "*"
+}
+```
+
+Scope `Resource` to specific log group ARNs in production to follow least-privilege.
+
+> **Note on error messages:** tool errors are returned to the agent verbatim to help it self-correct. An AWS authorization failure can include the caller's account id and IAM principal ARN (e.g. `User: arn:aws:iam::123456789012:user/foo is not authorized...`). That's your own identity surfaced to your own agent, but if you expose this worker more broadly, sanitize errors before returning them.
+
+## Local testing
+
+Copy `.env.example` to `.env`, fill in `AWS_REGION` and your AWS credentials, then run a tool without deploying:
+
+```zsh
+ntn workers exec listLogGroups --local -d '{"prefix": "/aws/lambda/", "limit": 5}'
+ntn workers exec getLogStreams --local -d '{"logGroupName": "/aws/lambda/my-function", "limit": 5}'
+ntn workers exec getLogEvents --local -d '{"logGroupName": "/aws/lambda/my-function", "logStreamName": "2024/06/01/[$LATEST]abc123", "limit": 10}'
+```
+
+Run the offline unit tests (no AWS needed):
+
+```zsh
+npm test
+```
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [AWS CloudWatch Logs API reference](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/)
+- [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/)
+- [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/tools/cloudwatch-logs/package.json
+++ b/examples/workers/tools/cloudwatch-logs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cloudwatch-logs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.700.0"
+  }
+}

--- a/examples/workers/tools/cloudwatch-logs/src/config.ts
+++ b/examples/workers/tools/cloudwatch-logs/src/config.ts
@@ -1,0 +1,5 @@
+import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs"
+
+export const REGION = process.env.AWS_REGION ?? "us-east-1"
+
+export const logsClient = new CloudWatchLogsClient({ region: REGION })

--- a/examples/workers/tools/cloudwatch-logs/src/index.ts
+++ b/examples/workers/tools/cloudwatch-logs/src/index.ts
@@ -1,0 +1,259 @@
+import { Worker } from "@notionhq/workers"
+import { j } from "@notionhq/workers/schema-builder"
+import {
+  DescribeLogGroupsCommand,
+  DescribeLogStreamsCommand,
+  GetLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs"
+import { logsClient } from "./config.js"
+
+const worker = new Worker()
+export default worker
+
+// Three tools an agent can chain to answer questions about CloudWatch logs:
+// find a log group, list its streams, then fetch events from a stream.
+
+// ─── listLogGroups ────────────────────────────────────────────────────────────
+
+worker.tool("listLogGroups", {
+  title: "List CloudWatch Log Groups",
+  description:
+    "Lists CloudWatch log groups matching a name prefix. Use this to discover available log groups before fetching streams. " +
+    'For example, Lambda function logs are under "/aws/lambda/", and Kinesis Data Analytics logs are under "/aws/kinesis-analytics/".',
+  schema: j.object({
+    prefix: j
+      .string()
+      .describe(
+        'Log group name prefix to filter by, e.g. "/aws/lambda/" or "/aws/kinesis-analytics/".'
+      ),
+    limit: j
+      .number()
+      .nullable()
+      .describe("Max number of log groups to return (default: 10, max: 50)."),
+  }),
+  execute: async ({ prefix, limit }) =>
+    safely(async () => {
+      const maxResults = clampLimit(limit, 10, 50)
+      const groups: {
+        logGroupName: string
+        retentionDays: number | null
+        storedBytes: number | null
+      }[] = []
+      let nextToken: string | undefined
+
+      do {
+        const response = await logsClient.send(
+          new DescribeLogGroupsCommand({
+            logGroupNamePrefix: prefix,
+            limit: maxResults - groups.length,
+            nextToken,
+          })
+        )
+        for (const g of response.logGroups ?? []) {
+          if (g.logGroupName) {
+            groups.push({
+              logGroupName: g.logGroupName,
+              retentionDays: g.retentionInDays ?? null,
+              storedBytes: g.storedBytes ?? null,
+            })
+          }
+        }
+        nextToken = groups.length < maxResults ? response.nextToken : undefined
+      } while (nextToken)
+
+      return { prefix, total: groups.length, logGroups: groups }
+    }),
+})
+
+// ─── getLogStreams ────────────────────────────────────────────────────────────
+
+worker.tool("getLogStreams", {
+  title: "Get CloudWatch Log Streams",
+  description:
+    "Lists log streams in a CloudWatch log group, ordered by most recent event. " +
+    "Use listLogGroups first to find the exact log group name. " +
+    'Optionally narrow results with filterPrefix (e.g. "dag_id=my_dag_name" for Airflow, or a task/container name for other services).',
+  schema: j.object({
+    logGroupName: j
+      .string()
+      .describe(
+        'Full log group name, e.g. "/aws/lambda/my-function" or "/aws/kinesis-analytics/my-flink-app-prod".'
+      ),
+    filterPrefix: j
+      .string()
+      .nullable()
+      .describe(
+        'Filter streams by name prefix, e.g. "dag_id=my_dag_name" to scope to a specific workflow.'
+      ),
+    limit: j
+      .number()
+      .nullable()
+      .describe("Max number of streams to return (default: 10, max: 50)."),
+  }),
+  execute: async ({ logGroupName, filterPrefix, limit }) =>
+    safely(async () => {
+      const maxResults = clampLimit(limit, 10, 50)
+      const streams: {
+        logStreamName: string
+        lastEventTime: string | null
+        firstEventTime: string | null
+      }[] = []
+      let nextToken: string | undefined
+
+      do {
+        const response = await logsClient.send(
+          new DescribeLogStreamsCommand({
+            logGroupName,
+            logStreamNamePrefix: filterPrefix ?? undefined,
+            // Can't combine orderBy LastEventTime with a name prefix filter.
+            orderBy: filterPrefix ? "LogStreamName" : "LastEventTime",
+            descending: true,
+            limit: Math.min(maxResults - streams.length, 50),
+            nextToken,
+          })
+        )
+        for (const s of response.logStreams ?? []) {
+          if (s.logStreamName) {
+            streams.push({
+              logStreamName: s.logStreamName,
+              lastEventTime: s.lastEventTimestamp
+                ? new Date(s.lastEventTimestamp).toISOString()
+                : null,
+              firstEventTime: s.firstEventTimestamp
+                ? new Date(s.firstEventTimestamp).toISOString()
+                : null,
+            })
+          }
+        }
+        nextToken = streams.length < maxResults ? response.nextToken : undefined
+      } while (nextToken)
+
+      return {
+        logGroupName,
+        filterPrefix: filterPrefix ?? null,
+        total: streams.length,
+        logStreams: streams,
+      }
+    }),
+})
+
+// ─── getLogEvents ─────────────────────────────────────────────────────────────
+
+worker.tool("getLogEvents", {
+  title: "Get CloudWatch Log Events",
+  description:
+    "Fetches log events from a specific CloudWatch log stream. " +
+    "Use getLogStreams first to find the logStreamName. " +
+    'Optionally filter by time range using ISO 8601 timestamps (e.g. "2024-06-01T12:00:00Z"). ' +
+    "Returns events in chronological order.",
+  schema: j.object({
+    logGroupName: j
+      .string()
+      .describe(
+        'Full log group name, e.g. "/aws/lambda/my-function". Use listLogGroups to discover available groups.'
+      ),
+    logStreamName: j
+      .string()
+      .describe("Log stream name. Use getLogStreams to find this."),
+    startTime: j
+      .string()
+      .nullable()
+      .describe(
+        'ISO 8601 start time (e.g. "2024-06-01T12:00:00Z"). Omit to start from the beginning of the stream.'
+      ),
+    endTime: j
+      .string()
+      .nullable()
+      .describe(
+        'ISO 8601 end time (e.g. "2024-06-01T13:00:00Z"). Omit to read until the end of the stream.'
+      ),
+    limit: j
+      .number()
+      .nullable()
+      .describe("Max number of log events to return (default: 100, max: 500)."),
+  }),
+  execute: async ({ logGroupName, logStreamName, startTime, endTime, limit }) =>
+    safely(async () => {
+      const maxEvents = clampLimit(limit, 100, 500)
+      const startMs = toEpochMs(startTime, "startTime")
+      const endMs = toEpochMs(endTime, "endTime")
+      const events: { timestamp: string; message: string }[] = []
+      let nextForwardToken: string | undefined
+
+      do {
+        const response = await logsClient.send(
+          new GetLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            startTime: startMs,
+            endTime: endMs,
+            limit: Math.min(maxEvents - events.length, 500),
+            startFromHead: true,
+            nextToken: nextForwardToken,
+          })
+        )
+
+        for (const e of response.events ?? []) {
+          if (e.message) {
+            events.push({
+              timestamp: e.timestamp ? new Date(e.timestamp).toISOString() : "",
+              message: e.message.trimEnd(),
+            })
+          }
+        }
+
+        // GetLogEvents returns the same token when there are no more events.
+        const newToken = response.nextForwardToken
+        nextForwardToken =
+          events.length < maxEvents && newToken !== nextForwardToken
+            ? newToken
+            : undefined
+      } while (nextForwardToken)
+
+      return {
+        logGroupName,
+        logStreamName,
+        startTime: startTime ?? null,
+        endTime: endTime ?? null,
+        total: events.length,
+        events,
+      }
+    }),
+})
+
+// Hand the agent a readable error instead of throwing, so it can correct itself.
+async function safely<T>(fn: () => Promise<T>): Promise<T | { error: string }> {
+  try {
+    return await fn()
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+// Clamp a nullable user-supplied limit to [1, max]; fall back to defaultVal.
+export function clampLimit(
+  value: number | null,
+  defaultVal: number,
+  max: number
+): number {
+  if (value == null) return defaultVal
+  const n = Math.floor(value)
+  if (!Number.isFinite(n) || n <= 0) return defaultVal
+  return Math.min(n, max)
+}
+
+// Convert an optional ISO 8601 string to epoch ms, rejecting invalid input with
+// a clear message instead of passing NaN to AWS (which returns an opaque error).
+export function toEpochMs(
+  value: string | null,
+  label: string
+): number | undefined {
+  if (!value) return undefined
+  const ms = new Date(value).getTime()
+  if (Number.isNaN(ms)) {
+    throw new Error(
+      `${label} must be an ISO 8601 timestamp (e.g. "2024-06-01T12:00:00Z").`
+    )
+  }
+  return ms
+}

--- a/examples/workers/tools/cloudwatch-logs/test.ts
+++ b/examples/workers/tools/cloudwatch-logs/test.ts
@@ -1,0 +1,31 @@
+// Tests for the pure helpers in src/index.ts.
+// These run offline — no AWS connection needed.
+// Run: npm test  (or: npx tsx test.ts)
+import { clampLimit } from "./src/index.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+console.log("clampLimit:")
+ok("null → default", clampLimit(null, 10, 50) === 10)
+ok("above max → max", clampLimit(100, 10, 50) === 50)
+ok("zero → default", clampLimit(0, 10, 50) === 10)
+ok("negative → default", clampLimit(-5, 10, 50) === 10)
+ok("valid within range", clampLimit(25, 10, 50) === 25)
+ok("exactly max", clampLimit(50, 10, 50) === 50)
+ok("fractional → floored", clampLimit(7.9, 10, 50) === 7)
+ok("default for events (100)", clampLimit(null, 100, 500) === 100)
+ok("above events max → 500", clampLimit(999, 100, 500) === 500)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/tools/cloudwatch-logs/tsconfig.json
+++ b/examples/workers/tools/cloudwatch-logs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds `examples/workers/tools/cloudwatch-logs/` — a Notion worker exposing 3 read-only tools over AWS CloudWatch Logs: `listLogGroups`, `getLogStreams`, `getLogEvents` (with pagination and result caps).

Authentication uses the standard AWS SDK credential provider chain; the worker code only reads `AWS_REGION`. Required IAM permissions are documented in the README (`logs:DescribeLogGroups`, `logs:DescribeLogStreams`, `logs:GetLogEvents`). The internal service-alias map was dropped — every tool takes an explicit `logGroupName`, and all example strings are generic.

## Verification

- `npm run check`, `npm run build`, `npm test`, `prettier --check`, `markdownlint` — all clean
- Deploy-smoke: deployed to the dev workspace; all 3 tools discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
