### PR TITLE
feat(workers): add postgres-query tool example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -16,6 +16,7 @@ The [tools](tools/) directory includes agent tool examples that extend Notion ag
 - **[airflow](tools/airflow/)**: Query Airflow DAGs, runs, tasks, and logs from a Notion agent
 - **[chart-generator](tools/chart-generator/)**: Render a Vega-Lite chart to an image and embed it in a Notion page
 - **[cloudwatch-logs](tools/cloudwatch-logs/)**: Query AWS CloudWatch log groups, streams, and events from a Notion agent
+- **[postgres-query](tools/postgres-query/)**: Query a PostgreSQL database from a Notion agent and return results
 - **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results
 - **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_
 

--- a/examples/workers/tools/postgres-query/.env.example
+++ b/examples/workers/tools/postgres-query/.env.example
@@ -1,0 +1,22 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Connection — use either DATABASE_URL or the discrete PG* vars, not both.
+#
+# Option A: full connection string
+# DATABASE_URL=postgres://user:pass@host:5432/dbname
+#
+# Option B: discrete vars (pg reads these automatically if DATABASE_URL is not set)
+# PGHOST=
+# PGPORT=5432
+# PGDATABASE=
+# PGUSER=
+# PGPASSWORD=
+# PGSSLMODE=require
+
+# Optional
+# Default row cap for the `query` tool (capped at 1000).
+# POSTGRES_MAX_ROWS=100
+# Statement timeout in seconds (capped at 300).
+# POSTGRES_QUERY_TIMEOUT_SECONDS=60

--- a/examples/workers/tools/postgres-query/.gitignore
+++ b/examples/workers/tools/postgres-query/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/tools/postgres-query/README.md
+++ b/examples/workers/tools/postgres-query/README.md
@@ -1,0 +1,165 @@
+# Worker tool: Postgres query
+
+A Notion worker that lets a custom agent query your Postgres database and get
+the rows back in the conversation. It registers three tools:
+
+- `listTables` queries `information_schema.tables`, optionally scoped to a
+  schema or filtered with an ILIKE pattern.
+- `describeTable` queries `information_schema.columns` and returns a table's
+  columns, types, and nullability.
+- `query` runs a single read-only `SELECT` (or `WITH ... SELECT`) and returns
+  the rows.
+
+Together they let the agent find a table, check its columns, and query it
+without anyone writing SQL by hand. Everything runs on Notion Workers against
+your database, so there's no separate service to host.
+
+## Project structure
+
+```text
+src/
+  index.ts     Worker definition and the three tools
+  sql.ts       Read-only SQL validation and the information_schema builders
+  postgres.ts  Connection, query execution, and result normalization
+```
+
+## How it works
+
+`listTables` and `describeTable` use parameterized `information_schema` queries,
+so table and schema names are always passed as bind values rather than
+interpolated into SQL. `query` parses the SQL with `node-sql-parser` (Postgres
+dialect) and only allows a single `SELECT` or `WITH ... SELECT`. Every `query`
+call also runs inside a `BEGIN` / `SET TRANSACTION READ ONLY` / `ROLLBACK`
+block as a second layer of defense.
+
+> **Note:** The real security boundary is a read-only Postgres role. The
+> parse check and read-only transaction are convenience layers, not guarantees.
+> Create a dedicated user with only `GRANT SELECT` and `GRANT USAGE` on the
+> schemas the agent should see (see "Set up Postgres" below).
+>
+> **Note on error messages:** database and parser errors are returned to the
+> agent verbatim to help it self-correct, which can disclose schema, column, or
+> value details into the agent transcript. That's an intentional tradeoff for an
+> example bounded by the read-only role; sanitize errors in stricter environments.
+
+Results are capped at `POSTGRES_MAX_ROWS` (default 100, hard cap 1000) and run
+under a `statement_timeout`, so the worker is meant for answering questions
+inline, not bulk export.
+
+## Set up Postgres
+
+Create a dedicated read-only user scoped to just the data the agent should see.
+Run this in `psql` or your preferred client, replacing `mydb` and schema names
+as needed:
+
+```sql
+CREATE ROLE notion_agent_readonly;
+
+-- Grant connection and schema usage
+GRANT CONNECT ON DATABASE mydb TO notion_agent_readonly;
+GRANT USAGE ON SCHEMA public TO notion_agent_readonly;
+
+-- Grant SELECT on existing and future tables
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO notion_agent_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO notion_agent_readonly;
+
+-- Create the service user
+CREATE USER notion_agent_svc WITH PASSWORD 'changeme';
+GRANT notion_agent_readonly TO notion_agent_svc;
+```
+
+That role, not the SQL check in the code, is what actually keeps the agent from
+writing.
+
+## Setup
+
+### 1. Install the Notion Workers CLI
+
+```zsh
+npm install -g @notionhq/workers-cli
+```
+
+### 2. Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/tools/postgres-query
+npm install
+```
+
+### 3. Connect to your workspace
+
+```zsh
+ntn login
+```
+
+### 4. Deploy
+
+```zsh
+ntn workers deploy --name postgres-query
+```
+
+### 5. Set the connection secrets
+
+These are worker secrets and never live in the repo (`.env` and `workers.json`
+are gitignored). Use either `DATABASE_URL` or the discrete `PG*` vars:
+
+```zsh
+# Option A: full connection string
+ntn workers env set DATABASE_URL=postgres://notion_agent_svc:changeme@host:5432/mydb
+
+# Option B: discrete vars
+ntn workers env set PGHOST=host
+ntn workers env set PGPORT=5432
+ntn workers env set PGDATABASE=mydb
+ntn workers env set PGUSER=notion_agent_svc
+ntn workers env set PGPASSWORD=changeme
+ntn workers env set PGSSLMODE=require
+```
+
+Optional tuning:
+
+```zsh
+# Default row cap for the query tool (default 100, capped at 1000)
+ntn workers env set POSTGRES_MAX_ROWS=100
+# Statement timeout in seconds (default 60, capped at 300)
+ntn workers env set POSTGRES_QUERY_TIMEOUT_SECONDS=60
+```
+
+## Connect it to an agent
+
+Once deployed, add the worker to a custom agent under
+**Tools and access > Add connection**. The agent can then call `listTables`,
+`describeTable`, and `query`.
+
+A prompt like:
+
+> What were total orders by month this year? Find the right table first.
+
+usually has the agent list tables, describe the likely one, then run a query
+and summarize what comes back.
+
+## Local testing
+
+Copy `.env.example` to `.env`, fill in your values, and run a tool without
+deploying:
+
+```zsh
+ntn workers exec listTables --local -d '{}'
+ntn workers exec describeTable --local -d '{"table": "orders"}'
+ntn workers exec query --local \
+  -d '{"sql": "SELECT current_date AS ds", "maxRows": 10}'
+```
+
+Run the offline test suite (no database required):
+
+```zsh
+npm test
+```
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [Postgres role system](https://www.postgresql.org/docs/current/user-manag.html)
+- [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/tools/postgres-query/package.json
+++ b/examples/workers/tools/postgres-query/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "postgres-query",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@types/pg": "^8.11.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0",
+    "node-sql-parser": "^5.4.0",
+    "pg": "^8.13.0"
+  }
+}

--- a/examples/workers/tools/postgres-query/src/index.ts
+++ b/examples/workers/tools/postgres-query/src/index.ts
@@ -1,0 +1,75 @@
+import { Worker } from "@notionhq/workers"
+import { j } from "@notionhq/workers/schema-builder"
+
+import { runCommand, runQuery } from "./postgres.js"
+import { assertSelectOnly, buildDescribeTable, buildListTables } from "./sql.js"
+
+const worker = new Worker()
+export default worker
+
+// Three tools an agent can chain to answer questions about a database:
+// find a table, check its columns, then query it.
+
+worker.tool("listTables", {
+  title: "List Tables",
+  description:
+    "List tables in the Postgres database. Optionally scope to a schema, or filter names with an ILIKE pattern (e.g. '%orders%'). Use this to discover what data is available before querying.",
+  schema: j.object({
+    schema: j
+      .string()
+      .nullable()
+      .describe("Schema to list from. Defaults to 'public'."),
+    like: j
+      .string()
+      .nullable()
+      .describe(
+        "Case-insensitive ILIKE pattern to filter table names, e.g. '%order%'."
+      ),
+  }),
+  execute: async ({ schema, like }) =>
+    safely(() => runCommand(buildListTables({ schema, like }))),
+})
+
+worker.tool("describeTable", {
+  title: "Describe Table",
+  description:
+    "Describe a table's columns (name, type, nullability) so you know its shape before querying. Pass the table name, optionally with a schema (default public).",
+  schema: j.object({
+    table: j.string().describe("Table name to describe."),
+    schema: j
+      .string()
+      .nullable()
+      .describe("Schema the table lives in. Defaults to 'public'."),
+  }),
+  execute: async ({ table, schema }) =>
+    safely(() => runCommand(buildDescribeTable({ table, schema }))),
+})
+
+worker.tool("query", {
+  title: "Query Postgres",
+  description:
+    "Run a read-only SQL SELECT against Postgres and return the rows. Only a single SELECT (or WITH ... SELECT) is allowed; writes and other statements are rejected. Results are capped at maxRows.",
+  schema: j.object({
+    sql: j
+      .string()
+      .describe("A single read-only SELECT or WITH ... SELECT statement."),
+    maxRows: j
+      .number()
+      .nullable()
+      .describe("Maximum rows to return. Defaults to 100; capped at 1000."),
+  }),
+  execute: async ({ sql, maxRows }) =>
+    safely(() => {
+      assertSelectOnly(sql)
+      return runQuery(sql, maxRows)
+    }),
+})
+
+// Hand the agent a readable error instead of throwing, so it can correct itself.
+async function safely<T>(fn: () => Promise<T>): Promise<T | { error: string }> {
+  try {
+    return await fn()
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/examples/workers/tools/postgres-query/src/postgres.ts
+++ b/examples/workers/tools/postgres-query/src/postgres.ts
@@ -1,0 +1,174 @@
+import pg from "pg"
+
+import { buildBoundedQuery } from "./sql.js"
+
+const HARD_MAX_ROWS = 1000
+const DEFAULT_MAX_ROWS = Math.min(
+  readPositiveInt("POSTGRES_MAX_ROWS", 100),
+  HARD_MAX_ROWS
+)
+const TIMEOUT_SECONDS = Math.min(
+  readPositiveInt("POSTGRES_QUERY_TIMEOUT_SECONDS", 60),
+  300
+)
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type ColumnInfo = {
+  name: string
+  type: string | null
+  nullable: boolean | null
+}
+
+export type QueryResult = {
+  rows: Record<string, JsonValue>[]
+  columns: ColumnInfo[]
+  rowCount: number
+  truncated: boolean
+}
+
+export async function runQuery(
+  sql: string,
+  requestedMaxRows: number | null
+): Promise<QueryResult> {
+  const maxRows = clamp(requestedMaxRows, DEFAULT_MAX_ROWS, HARD_MAX_ROWS)
+  // The wrapper fetches one extra row so we can report truncation.
+  const result = await executeSelect(buildBoundedQuery(sql, maxRows))
+  return capRows(result, maxRows)
+}
+
+// information_schema queries can't be wrapped in a subquery the same way,
+// so run them directly and cap the rows in memory.
+export async function runCommand(query: {
+  text: string
+  values: unknown[]
+}): Promise<QueryResult> {
+  const result = await executeCommand(query)
+  return capRows(result, HARD_MAX_ROWS)
+}
+
+function capRows(result: QueryResult, maxRows: number): QueryResult {
+  const truncated = result.rows.length > maxRows
+  const rows = truncated ? result.rows.slice(0, maxRows) : result.rows
+  return { ...result, rows, rowCount: rows.length, truncated }
+}
+
+// Run a SELECT inside a read-only transaction for defense in depth.
+// assertSelectOnly already validated the SQL; this is an extra layer.
+async function executeSelect(sql: string): Promise<QueryResult> {
+  const client = createClient()
+  await client.connect()
+  try {
+    await client.query("BEGIN")
+    await client.query("SET TRANSACTION READ ONLY")
+    if (TIMEOUT_SECONDS > 0) {
+      await client.query(
+        `SET LOCAL statement_timeout = ${TIMEOUT_SECONDS * 1000}`
+      )
+    }
+    const result = await client.query(sql)
+    // We only read, so rollback is the clean path (avoids any savepoint overhead).
+    await client.query("ROLLBACK")
+    return toQueryResult(result)
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw err
+  } finally {
+    await client.end().catch(() => {})
+  }
+}
+
+// Run a parameterized information_schema query (no transaction needed — read-only by construction).
+async function executeCommand(query: {
+  text: string
+  values: unknown[]
+}): Promise<QueryResult> {
+  const client = createClient()
+  await client.connect()
+  try {
+    const result = await client.query(query)
+    return toQueryResult(result)
+  } finally {
+    await client.end().catch(() => {})
+  }
+}
+
+function toQueryResult(result: pg.QueryResult): QueryResult {
+  // pg exposes field names but not type names or nullability at query time;
+  // use describeTable for full column introspection.
+  const columns: ColumnInfo[] = result.fields.map((field) => ({
+    name: field.name,
+    type: null,
+    nullable: null,
+  }))
+
+  return {
+    rows: (result.rows as Record<string, unknown>[]).map(normalizeRow),
+    columns,
+    rowCount: result.rows.length,
+    truncated: false,
+  }
+}
+
+function createClient(): pg.Client {
+  const url = process.env.DATABASE_URL
+  const host = process.env.PGHOST
+  const database = process.env.PGDATABASE
+  const user = process.env.PGUSER
+
+  if (!url && !(host && database && user)) {
+    throw new Error(
+      "Missing Postgres configuration. Set DATABASE_URL, or set PGHOST, PGDATABASE, and PGUSER."
+    )
+  }
+
+  // If DATABASE_URL is set, pass it directly; otherwise pg reads PG* vars automatically.
+  return url ? new pg.Client({ connectionString: url }) : new pg.Client()
+}
+
+function normalizeRow(row: Record<string, unknown>): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, normalizeValue(value)])
+  )
+}
+
+function normalizeValue(value: unknown): JsonValue {
+  if (value == null) return null
+  if (typeof value === "string") return value
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : String(value)
+  if (typeof value === "boolean") return value
+  if (typeof value === "bigint") return value.toString()
+  if (value instanceof Date) return value.toISOString()
+  if (Buffer.isBuffer(value)) return value.toString("base64")
+  if (Array.isArray(value)) return value.map(normalizeValue)
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        normalizeValue(nested),
+      ])
+    )
+  }
+  return String(value)
+}
+
+function clamp(value: number | null, fallback: number, max: number): number {
+  if (value == null) return fallback
+  const n = Math.floor(value)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  return Math.min(n, max)
+}
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/examples/workers/tools/postgres-query/src/sql.ts
+++ b/examples/workers/tools/postgres-query/src/sql.ts
@@ -1,0 +1,96 @@
+import { Parser } from "node-sql-parser"
+
+const parser = new Parser()
+
+// We parse the statement instead of pattern-matching on keywords so comments
+// and string literals can't smuggle in a write. This is a convenience check,
+// not the security boundary — that's the read-only Postgres role (see README).
+export function assertSelectOnly(sql: string): void {
+  if (!sql.trim()) {
+    throw new Error("sql must be a non-empty string.")
+  }
+
+  let statements
+  try {
+    statements = parser.astify(sql, { database: "Postgresql" })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Could not parse SQL as a read-only SELECT query: ${detail}`
+    )
+  }
+
+  const list = Array.isArray(statements) ? statements : [statements]
+  if (list.length !== 1) {
+    throw new Error("Only one SQL statement is allowed.")
+  }
+  // WITH ... SELECT parses as a select node with a .with clause.
+  const statement = list[0]
+  if (statement?.type !== "select") {
+    throw new Error("Only read-only SELECT queries are allowed.")
+  }
+  // `SELECT ... INTO <target>` parses as a select but writes; reject it.
+  // A normal select has `into: { position: null }`; an INTO clause sets `expr`.
+  const into = (statement as { into?: { expr?: unknown } }).into
+  if (into?.expr != null) {
+    throw new Error("Only read-only SELECT queries are allowed.")
+  }
+}
+
+// Cap the result set and grab one extra row to detect truncation. The inner
+// query sits on its own line so a trailing line comment (-- ...) can't swallow
+// the closing paren and LIMIT.
+export function buildBoundedQuery(sql: string, maxRows: number): string {
+  const inner = stripTrailingSemicolon(sql)
+  return `SELECT * FROM (\n${inner}\n) AS query_result LIMIT ${maxRows + 1}`
+}
+
+// Returns a parameterized query for listing tables from information_schema.
+// Using $1/$2 placeholders means no quoting or injection is possible.
+export function buildListTables(input: {
+  schema?: string | null
+  like?: string | null
+}): { text: string; values: unknown[] } {
+  const schema = input.schema ?? "public"
+
+  if (input.like) {
+    return {
+      text:
+        "SELECT table_schema, table_name, table_type" +
+        " FROM information_schema.tables" +
+        " WHERE table_schema = $1 AND table_name ILIKE $2" +
+        " ORDER BY table_name",
+      values: [schema, input.like],
+    }
+  }
+
+  return {
+    text:
+      "SELECT table_schema, table_name, table_type" +
+      " FROM information_schema.tables" +
+      " WHERE table_schema = $1" +
+      " ORDER BY table_name",
+    values: [schema],
+  }
+}
+
+// Returns a parameterized query for describing a table's columns.
+export function buildDescribeTable(input: {
+  table: string
+  schema?: string | null
+}): { text: string; values: unknown[] } {
+  const schema = input.schema ?? "public"
+  return {
+    text:
+      "SELECT column_name, data_type, is_nullable" +
+      " FROM information_schema.columns" +
+      " WHERE table_schema = $1 AND table_name = $2" +
+      " ORDER BY ordinal_position",
+    values: [schema, input.table],
+  }
+}
+
+function stripTrailingSemicolon(sql: string): string {
+  const trimmed = sql.trim()
+  return trimmed.endsWith(";") ? trimmed.slice(0, -1).trim() : trimmed
+}

--- a/examples/workers/tools/postgres-query/test.ts
+++ b/examples/workers/tools/postgres-query/test.ts
@@ -1,0 +1,126 @@
+// Tests for the read-only SQL guard and information_schema builders in src/sql.ts.
+// These are the security-relevant bits and need no Postgres connection.
+// Run: npm test  (or: npx tsx test.ts)
+import {
+  assertSelectOnly,
+  buildBoundedQuery,
+  buildDescribeTable,
+  buildListTables,
+} from "./src/sql.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+function accepts(sql: string): boolean {
+  try {
+    assertSelectOnly(sql)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function rejects(build: () => unknown): boolean {
+  try {
+    build()
+    return false
+  } catch {
+    return true
+  }
+}
+
+console.log("assertSelectOnly accepts read-only selects:")
+ok("plain select", accepts("SELECT 1"))
+ok(
+  "select from table",
+  accepts("SELECT id, name FROM orders WHERE status = 'open'")
+)
+ok("with/cte", accepts("WITH t AS (SELECT 1 AS x) SELECT * FROM t"))
+ok(
+  "semicolon inside string literal",
+  accepts("SELECT col FROM t WHERE v = 'a;b'")
+)
+ok("trailing semicolon", accepts("SELECT 1;"))
+ok("lowercase keyword", accepts("select current_date"))
+ok("trailing line comment", accepts("SELECT id FROM t -- get all\n"))
+
+console.log("assertSelectOnly rejects everything else:")
+ok("delete", !accepts("DELETE FROM t"))
+ok("update", !accepts("UPDATE t SET x = 1"))
+ok("insert", !accepts("INSERT INTO t VALUES (1)"))
+ok("drop", !accepts("DROP TABLE t"))
+ok("create", !accepts("CREATE TABLE t (x int)"))
+ok("select ... into (write)", !accepts("SELECT * INTO new_table FROM t"))
+ok("multi-statement", !accepts("SELECT 1; SELECT 2"))
+ok("select then delete", !accepts("SELECT 1; DELETE FROM t"))
+ok("empty", !accepts(""))
+ok("garbage", !accepts("not sql at all"))
+
+console.log("buildBoundedQuery:")
+ok(
+  "wraps and fetches one extra row",
+  buildBoundedQuery("SELECT 1", 10) ===
+    "SELECT * FROM (\nSELECT 1\n) AS query_result LIMIT 11"
+)
+ok(
+  "strips a trailing semicolon",
+  buildBoundedQuery("SELECT 1;", 5) ===
+    "SELECT * FROM (\nSELECT 1\n) AS query_result LIMIT 6"
+)
+ok(
+  "trailing line comment can't swallow the LIMIT",
+  buildBoundedQuery("SELECT id FROM t -- c", 10) ===
+    "SELECT * FROM (\nSELECT id FROM t -- c\n) AS query_result LIMIT 11"
+)
+
+console.log("buildListTables:")
+ok(
+  "defaults to public schema",
+  buildListTables({}).text.includes("WHERE table_schema = $1") &&
+    buildListTables({}).values[0] === "public"
+)
+ok(
+  "custom schema",
+  buildListTables({ schema: "myschema" }).values[0] === "myschema"
+)
+ok(
+  "like adds ILIKE clause with two values",
+  buildListTables({ like: "%order%" }).text.includes("ILIKE $2") &&
+    buildListTables({ like: "%order%" }).values.length === 2 &&
+    buildListTables({ like: "%order%" }).values[1] === "%order%"
+)
+ok(
+  "no like gives one value",
+  buildListTables({ schema: "public" }).values.length === 1
+)
+
+console.log("buildDescribeTable:")
+ok(
+  "defaults to public schema",
+  buildDescribeTable({ table: "orders" }).values[0] === "public" &&
+    buildDescribeTable({ table: "orders" }).values[1] === "orders"
+)
+ok(
+  "custom schema",
+  buildDescribeTable({ table: "orders", schema: "myschema" }).values[0] ===
+    "myschema"
+)
+ok(
+  "query text uses $1 and $2",
+  buildDescribeTable({ table: "orders" }).text.includes(
+    "WHERE table_schema = $1 AND table_name = $2"
+  )
+)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/tools/postgres-query/tsconfig.json
+++ b/examples/workers/tools/postgres-query/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds `examples/workers/tools/postgres-query/` — a PostgreSQL port of the `snowflake-query` example. Three tools an agent chains: `listTables`, `describeTable`, `query`.

- SELECT-only guard via `node-sql-parser` (Postgres dialect) — single statement, rejects writes and `SELECT ... INTO`
- Table/column introspection via parameterized `information_schema` queries (injection-proof)
- Every query runs inside a `READ ONLY` transaction with a statement timeout (defense in depth)
- Connects via `DATABASE_URL` or standard `PG*` vars

The README states the real security boundary is a read-only Postgres role (`GRANT SELECT`); the parse + read-only transaction are convenience layers.

## Verification

- `npm run check`, `npm run build`, `npm test` (27 offline SQL-guard/builder tests), `prettier --check`, `markdownlint` — all clean
- Deploy-smoke: deployed to the dev workspace; all 3 tools discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
