### PR TITLE
feat(workers): add sqlite demo tool example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -20,6 +20,7 @@ The [tools](tools/) directory includes agent tool examples that extend Notion ag
 - **[postgres-query](tools/postgres-query/)**: Query a PostgreSQL database from a Notion agent and return results
 - **[snowflake-query](tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results
 - **[spotify-control](tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_
+- **[sqlite-demo](tools/sqlite-demo/)**: Query a self-contained in-memory SQLite database seeded with sample data — no setup required
 
 ## Webhooks
 

--- a/examples/workers/tools/sqlite-demo/.gitignore
+++ b/examples/workers/tools/sqlite-demo/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/tools/sqlite-demo/README.md
+++ b/examples/workers/tools/sqlite-demo/README.md
@@ -1,0 +1,141 @@
+# Worker tool: SQLite demo
+
+A self-contained Notion worker that lets a custom agent query an in-memory
+SQLite database seeded with sample sales data. No external database, no
+credentials, no environment variables — deploy it and start querying
+immediately.
+
+The database resets each time the worker process starts. It is designed for
+demos, onboarding, and learning the worker tool pattern, not for persisting
+real data.
+
+## Seeded schema
+
+Four tables are created and populated on startup:
+
+```text
+customers   (id, name, email, country, signup_date)          8 rows
+products    (id, name, category, price)                       6 rows
+orders      (id, customer_id, order_date, status, total)     15 rows
+order_items (id, order_id, product_id, quantity, unit_price) 28 rows
+```
+
+Products span three categories (Subscription, Services, Add-on). Orders
+have statuses `completed`, `refunded`, and `pending`.
+
+## Tools
+
+The worker registers three tools:
+
+- `listTables` — lists the four tables in the demo database.
+- `describeTable` — returns column names and types for a given table via
+  `PRAGMA table_info`.
+- `query` — runs a single read-only `SELECT` (or `WITH ... SELECT`) and
+  returns the rows, capped at `maxRows` (default 100, max 1000).
+
+Example questions an agent can answer out of the box:
+
+- Who are the top customers by total spend?
+- What is revenue by product category?
+- How many orders are in each status?
+- Which products appear most often in completed orders?
+
+## How it works
+
+The SQLite database is opened with Node's built-in `node:sqlite` module
+(`DatabaseSync` from `node:sqlite`, available flag-free in Node 22+). No
+third-party database driver is needed.
+
+`query` parses the SQL with `node-sql-parser` (SQLite dialect) and only
+allows a single `SELECT` or `WITH ... SELECT`. Writes are rejected before
+execution, not just by database-level permissions.
+
+`describeTable` uses `PRAGMA table_info(<table>)`, which cannot be
+parameterized. The table name is validated against a strict identifier regex
+(`/^[A-Za-z0-9_$]+$/`) before interpolation.
+
+## Project structure
+
+```text
+src/
+  index.ts   Worker definition and the three tools
+  sql.ts     Read-only SQL guard, buildBoundedQuery, catalog helpers
+  sqlite.ts  Database singleton, query execution, result normalization
+  seed.ts    Schema DDL and deterministic INSERT statements
+test.ts      Offline end-to-end tests (no network or credentials required)
+```
+
+## Setup
+
+### 1. Install the Notion Workers CLI
+
+```zsh
+npm install -g @notionhq/workers-cli
+```
+
+### 2. Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/tools/sqlite-demo
+npm install
+```
+
+### 3. Connect to your workspace
+
+```zsh
+ntn login
+```
+
+### 4. Deploy
+
+```zsh
+ntn workers deploy --name sqlite-demo
+```
+
+No environment variables are needed. The worker is ready as soon as it deploys.
+
+## Connect it to an agent
+
+Once deployed, add the worker to a custom agent under
+**Tools and access > Add connection**. The agent can then call `listTables`,
+`describeTable`, and `query`.
+
+A prompt like:
+
+> Who are the top three customers by total spend? Use the demo database.
+
+usually has the agent list tables, describe `orders` and `customers`, join
+them, and summarize the result.
+
+## Local testing
+
+Run the offline test suite (no network or credentials required):
+
+```zsh
+npm test
+```
+
+Run a tool locally without deploying:
+
+```zsh
+ntn workers exec listTables --local -d '{}'
+ntn workers exec describeTable --local -d '{"table": "orders"}'
+ntn workers exec query --local \
+  -d '{"sql": "SELECT name, country FROM customers ORDER BY name", "maxRows": 10}'
+```
+
+## Notes
+
+- Data is ephemeral. The in-memory database resets when the worker process
+  restarts. It is not intended for production use.
+- This worker uses Node's built-in `node:sqlite` module (Node 22+), which
+  requires no additional npm dependencies beyond `node-sql-parser`.
+- For a worker that connects to a real external database, see
+  `../postgres-query` or `../snowflake-query`.
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [node:sqlite documentation](https://nodejs.org/api/sqlite.html)
+- [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/tools/sqlite-demo/package.json
+++ b/examples/workers/tools/sqlite-demo/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sqlite-demo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0",
+    "node-sql-parser": "^5.4.0"
+  }
+}

--- a/examples/workers/tools/sqlite-demo/src/index.ts
+++ b/examples/workers/tools/sqlite-demo/src/index.ts
@@ -1,0 +1,61 @@
+import { Worker } from "@notionhq/workers"
+import { j } from "@notionhq/workers/schema-builder"
+
+import { runCommand, runQuery } from "./sqlite.js"
+import { assertSelectOnly, buildDescribeTable, buildListTables } from "./sql.js"
+
+const worker = new Worker()
+export default worker
+
+// Three tools an agent can chain to explore and query the demo database:
+// discover tables, inspect columns, then run a SELECT.
+
+worker.tool("listTables", {
+  title: "List Tables",
+  description:
+    "List the tables available in the demo SQLite database. This database is seeded with sample sales data: customers, products, orders, and order_items. Use this first to discover what data is available.",
+  schema: j.object({}),
+  execute: async () => safely(() => runCommand(buildListTables())),
+})
+
+worker.tool("describeTable", {
+  title: "Describe Table",
+  description:
+    "Describe a table's columns (name, type, constraints) so you know its shape before querying. Pass the table name exactly as returned by listTables.",
+  schema: j.object({
+    table: j
+      .string()
+      .describe("Table name to describe, e.g. 'orders' or 'customers'."),
+  }),
+  execute: async ({ table }) =>
+    safely(() => runCommand(buildDescribeTable(table))),
+})
+
+worker.tool("query", {
+  title: "Query Demo Database (SQLite)",
+  description:
+    "Run a read-only SQL SELECT against the in-memory SQLite demo database and return the rows. Only a single SELECT (or WITH ... SELECT) is allowed; writes are rejected. Results are capped at maxRows (default 100, max 1000).\n\nExample questions you can answer:\n- 'Who are the top customers by total spend?'\n- 'What is revenue by product category?'\n- 'How many orders are in each status?'\n- 'Which products appear most often in completed orders?'",
+  schema: j.object({
+    sql: j
+      .string()
+      .describe("A single read-only SELECT or WITH ... SELECT statement."),
+    maxRows: j
+      .number()
+      .nullable()
+      .describe("Maximum rows to return. Defaults to 100; capped at 1000."),
+  }),
+  execute: async ({ sql, maxRows }) =>
+    safely(() => {
+      assertSelectOnly(sql)
+      return runQuery(sql, maxRows)
+    }),
+})
+
+// Hand the agent a readable error instead of throwing, so it can correct itself.
+async function safely<T>(fn: () => Promise<T>): Promise<T | { error: string }> {
+  try {
+    return await fn()
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/examples/workers/tools/sqlite-demo/src/seed.ts
+++ b/examples/workers/tools/sqlite-demo/src/seed.ts
@@ -1,0 +1,138 @@
+// Schema and deterministic sample data for the in-memory demo database.
+// Every INSERT uses literal values so the data is reproducible across runs.
+//
+// Order totals equal sum(quantity * unit_price) across their order_items rows.
+
+export const SCHEMA_SQL = `
+CREATE TABLE customers (
+  id          INTEGER PRIMARY KEY,
+  name        TEXT    NOT NULL,
+  email       TEXT    NOT NULL,
+  country     TEXT    NOT NULL,
+  signup_date TEXT    NOT NULL
+);
+
+CREATE TABLE products (
+  id       INTEGER PRIMARY KEY,
+  name     TEXT    NOT NULL,
+  category TEXT    NOT NULL,
+  price    REAL    NOT NULL
+);
+
+CREATE TABLE orders (
+  id          INTEGER PRIMARY KEY,
+  customer_id INTEGER NOT NULL REFERENCES customers(id),
+  order_date  TEXT    NOT NULL,
+  status      TEXT    NOT NULL,
+  total       REAL    NOT NULL
+);
+
+CREATE TABLE order_items (
+  id         INTEGER PRIMARY KEY,
+  order_id   INTEGER NOT NULL REFERENCES orders(id),
+  product_id INTEGER NOT NULL REFERENCES products(id),
+  quantity   INTEGER NOT NULL,
+  unit_price REAL    NOT NULL
+);
+`
+
+// Row counts: customers=8, products=6, orders=15, order_items=28
+//
+// Per-order totals (verified: sum qty*unit_price equals orders.total):
+//  1   149 = Pro(1x149)
+//  2   448 = Pro(1x149) + Onboarding(1x299)
+//  3    49 = Starter(1x49)
+//  4   877 = Enterprise(1x499) + Export(1x79) + Onboarding(1x299)
+//  5   299 = Onboarding(1x299)
+//  6   228 = Pro(1x149) + Export(1x79)
+//  7   499 = Enterprise(1x499)
+//  8   149 = Pro(1x149)  [refunded]
+//  9   997 = Enterprise(1x499) + Onboarding(1x299) + Support(1x199)
+// 10   149 = Pro(1x149)
+// 11  1076 = Enterprise(1x499) + Support(1x199) + Export(1x79) + Onboarding(1x299)
+// 12   199 = Support(1x199)  [pending]
+// 13  1155 = Enterprise(1x499) + Onboarding(1x299) + Support(1x199) + Export(2x79)
+// 14   456 = Pro(2x149) + Export(2x79)
+// 15    79 = Export(1x79)  [pending]
+
+export const SEED_SQL = `
+INSERT INTO customers VALUES
+  (1, 'Acme Corp',        'acme@example.com',     'US', '2023-01-15'),
+  (2, 'Bright Ideas Ltd', 'hello@brightideas.co', 'GB', '2023-02-20'),
+  (3, 'Cedar Solutions',  'info@cedarsol.com',    'CA', '2023-03-05'),
+  (4, 'Delta Dynamics',   'sales@deltadyn.io',    'DE', '2023-04-12'),
+  (5, 'Echo Ventures',    'contact@echovntr.com', 'AU', '2023-05-18'),
+  (6, 'Foxtrot Systems',  'ops@foxtrotsys.com',   'US', '2023-06-22'),
+  (7, 'Gamma Analytics',  'data@gammalytics.net', 'FR', '2023-07-30'),
+  (8, 'Harbor Networks',  'team@harbornet.dev',   'SG', '2023-08-09');
+
+INSERT INTO products VALUES
+  (1, 'Starter Plan',       'Subscription',  49.00),
+  (2, 'Pro Plan',           'Subscription', 149.00),
+  (3, 'Enterprise Plan',    'Subscription', 499.00),
+  (4, 'Onboarding Pack',    'Services',     299.00),
+  (5, 'Data Export Add-on', 'Add-on',        79.00),
+  (6, 'Priority Support',   'Add-on',       199.00);
+
+INSERT INTO orders VALUES
+  (1,  1, '2024-01-10', 'completed',  149.00),
+  (2,  2, '2024-01-14', 'completed',  448.00),
+  (3,  3, '2024-01-22', 'completed',   49.00),
+  (4,  1, '2024-02-05', 'completed',  877.00),
+  (5,  4, '2024-02-11', 'completed',  299.00),
+  (6,  5, '2024-02-18', 'completed',  228.00),
+  (7,  6, '2024-03-02', 'completed',  499.00),
+  (8,  2, '2024-03-15', 'refunded',   149.00),
+  (9,  7, '2024-03-20', 'completed',  997.00),
+  (10, 3, '2024-04-01', 'completed',  149.00),
+  (11, 8, '2024-04-08', 'completed', 1076.00),
+  (12, 1, '2024-04-22', 'pending',    199.00),
+  (13, 4, '2024-05-03', 'completed', 1155.00),
+  (14, 5, '2024-05-17', 'completed',  456.00),
+  (15, 6, '2024-06-01', 'pending',     79.00);
+
+INSERT INTO order_items VALUES
+  -- order 1: Pro x1 = 149
+  (1,  1,  2, 1, 149.00),
+  -- order 2: Pro x1 + Onboarding x1 = 448
+  (2,  2,  2, 1, 149.00),
+  (3,  2,  4, 1, 299.00),
+  -- order 3: Starter x1 = 49
+  (4,  3,  1, 1,  49.00),
+  -- order 4: Enterprise x1 + Export x1 + Onboarding x1 = 877
+  (5,  4,  3, 1, 499.00),
+  (6,  4,  5, 1,  79.00),
+  (7,  4,  4, 1, 299.00),
+  -- order 5: Onboarding x1 = 299
+  (8,  5,  4, 1, 299.00),
+  -- order 6: Pro x1 + Export x1 = 228
+  (9,  6,  2, 1, 149.00),
+  (10, 6,  5, 1,  79.00),
+  -- order 7: Enterprise x1 = 499
+  (11, 7,  3, 1, 499.00),
+  -- order 8: Pro x1 = 149
+  (12, 8,  2, 1, 149.00),
+  -- order 9: Enterprise x1 + Onboarding x1 + Support x1 = 997
+  (13, 9,  3, 1, 499.00),
+  (14, 9,  4, 1, 299.00),
+  (15, 9,  6, 1, 199.00),
+  -- order 10: Pro x1 = 149
+  (16, 10, 2, 1, 149.00),
+  -- order 11: Enterprise x1 + Support x1 + Export x1 + Onboarding x1 = 1076
+  (17, 11, 3, 1, 499.00),
+  (18, 11, 6, 1, 199.00),
+  (19, 11, 5, 1,  79.00),
+  (20, 11, 4, 1, 299.00),
+  -- order 12: Support x1 = 199
+  (21, 12, 6, 1, 199.00),
+  -- order 13: Enterprise x1 + Onboarding x1 + Support x1 + Export x2 = 1155
+  (22, 13, 3, 1, 499.00),
+  (23, 13, 4, 1, 299.00),
+  (24, 13, 6, 1, 199.00),
+  (25, 13, 5, 2,  79.00),
+  -- order 14: Pro x2 + Export x2 = 456
+  (26, 14, 2, 2, 149.00),
+  (27, 14, 5, 2,  79.00),
+  -- order 15: Export x1 = 79
+  (28, 15, 5, 1,  79.00);
+`

--- a/examples/workers/tools/sqlite-demo/src/sql.ts
+++ b/examples/workers/tools/sqlite-demo/src/sql.ts
@@ -1,0 +1,71 @@
+import { Parser } from "node-sql-parser"
+
+const parser = new Parser()
+
+// We parse the statement instead of pattern-matching on keywords so comments
+// and string literals can't smuggle in a write. The demo has no external
+// security boundary, so this is the only write guard — keep it strict.
+export function assertSelectOnly(sql: string): void {
+  if (!sql.trim()) {
+    throw new Error("sql must be a non-empty string.")
+  }
+
+  let statements
+  try {
+    statements = parser.astify(sql, { database: "Sqlite" })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Could not parse SQL as a read-only SELECT query: ${detail}`
+    )
+  }
+
+  const list = Array.isArray(statements) ? statements : [statements]
+  if (list.length !== 1) {
+    throw new Error("Only one SQL statement is allowed.")
+  }
+  // WITH ... SELECT parses as a select node with a .with clause.
+  const statement = list[0]
+  if (statement?.type !== "select") {
+    throw new Error("Only read-only SELECT queries are allowed.")
+  }
+  // `SELECT ... INTO <target>` parses as a select but writes; reject it.
+  // A normal select has `into: { position: null }`; an INTO clause sets `expr`.
+  const into = (statement as { into?: { expr?: unknown } }).into
+  if (into?.expr != null) {
+    throw new Error("Only read-only SELECT queries are allowed.")
+  }
+}
+
+// Cap the result set and grab one extra row to detect truncation. The inner
+// query sits on its own line so a trailing line comment (-- ...) can't swallow
+// the closing paren and LIMIT.
+export function buildBoundedQuery(sql: string, maxRows: number): string {
+  const inner = stripTrailingSemicolon(sql)
+  return `SELECT * FROM (\n${inner}\n) AS query_result LIMIT ${maxRows + 1}`
+}
+
+// List all user-created tables in the database.
+export function buildListTables(): string {
+  return (
+    "SELECT name FROM sqlite_master" +
+    " WHERE type = 'table' AND name NOT LIKE 'sqlite_%'" +
+    " ORDER BY name"
+  )
+}
+
+// Return column metadata for a table via PRAGMA table_info.
+// PRAGMA statements cannot be parameterized, so we validate the identifier
+// with a strict regex before interpolating it (mirrors snowflake-query's ident()).
+export function buildDescribeTable(table: string): string {
+  const trimmed = table.trim()
+  if (!/^[A-Za-z0-9_$]+$/.test(trimmed)) {
+    throw new Error(`Invalid table name: ${table}`)
+  }
+  return `PRAGMA table_info(${trimmed})`
+}
+
+function stripTrailingSemicolon(sql: string): string {
+  const trimmed = sql.trim()
+  return trimmed.endsWith(";") ? trimmed.slice(0, -1).trim() : trimmed
+}

--- a/examples/workers/tools/sqlite-demo/src/sqlite.ts
+++ b/examples/workers/tools/sqlite-demo/src/sqlite.ts
@@ -1,0 +1,129 @@
+import { DatabaseSync } from "node:sqlite"
+
+import { buildBoundedQuery } from "./sql.js"
+import { SCHEMA_SQL, SEED_SQL } from "./seed.js"
+
+const HARD_MAX_ROWS = 1000
+const DEFAULT_MAX_ROWS = 100
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type ColumnInfo = {
+  name: string
+  type: string | null
+  nullable: boolean | null
+}
+
+export type QueryResult = {
+  rows: Record<string, JsonValue>[]
+  columns: ColumnInfo[]
+  rowCount: number
+  truncated: boolean
+}
+
+// Module-level singleton: the DB is opened and seeded once per process,
+// then reused for every tool call.
+let _db: DatabaseSync | null = null
+
+function getDb(): DatabaseSync {
+  if (_db === null) {
+    const db = new DatabaseSync(":memory:")
+    db.exec(SCHEMA_SQL)
+    db.exec(SEED_SQL)
+    _db = db
+  }
+  return _db
+}
+
+export async function runQuery(
+  sql: string,
+  requestedMaxRows: number | null
+): Promise<QueryResult> {
+  const maxRows = clamp(requestedMaxRows, DEFAULT_MAX_ROWS, HARD_MAX_ROWS)
+  // Fetch one extra row so we can report whether the result was truncated.
+  const bounded = buildBoundedQuery(sql, maxRows)
+  const db = getDb()
+  const rows = db.prepare(bounded).all() as Record<string, unknown>[]
+  return capRows(toQueryResult(rows), maxRows)
+}
+
+// Run a catalog or PRAGMA query (list tables, describe table) and cap in memory.
+export async function runCommand(sql: string): Promise<QueryResult> {
+  const db = getDb()
+  const rows = db.prepare(sql).all() as Record<string, unknown>[]
+  return capRows(toQueryResult(rows), HARD_MAX_ROWS)
+}
+
+function capRows(result: QueryResult, maxRows: number): QueryResult {
+  const truncated = result.rows.length > maxRows
+  const rows = truncated ? result.rows.slice(0, maxRows) : result.rows
+  return { ...result, rows, rowCount: rows.length, truncated }
+}
+
+function toQueryResult(rows: Record<string, unknown>[]): QueryResult {
+  // Derive column names from the first row's keys (SQLite doesn't expose
+  // field metadata separately from the result set).
+  const columns: ColumnInfo[] =
+    rows.length > 0
+      ? Object.keys(rows[0]).map((name) => ({
+          name,
+          type: null,
+          nullable: null,
+        }))
+      : []
+
+  return {
+    rows: rows.map(normalizeRow),
+    columns,
+    rowCount: rows.length,
+    truncated: false,
+  }
+}
+
+function normalizeRow(row: Record<string, unknown>): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, normalizeValue(value)])
+  )
+}
+
+function normalizeValue(value: unknown): JsonValue {
+  if (value == null) return null
+  if (typeof value === "string") return value
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : String(value)
+  if (typeof value === "boolean") return value
+  // SQLite returns bigint for INTEGER columns when the value exceeds
+  // Number.MAX_SAFE_INTEGER; keep precision by stringifying when needed.
+  if (typeof value === "bigint") {
+    return value >= BigInt(Number.MIN_SAFE_INTEGER) &&
+      value <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(value)
+      : value.toString()
+  }
+  // SQLite BLOBs come back as Buffer (Node.js Buffer or Uint8Array).
+  if (Buffer.isBuffer(value)) return value.toString("base64")
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("base64")
+  if (Array.isArray(value)) return value.map(normalizeValue)
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        normalizeValue(nested),
+      ])
+    )
+  }
+  return String(value)
+}
+
+function clamp(value: number | null, fallback: number, max: number): number {
+  if (value == null) return fallback
+  const n = Math.floor(value)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  return Math.min(n, max)
+}

--- a/examples/workers/tools/sqlite-demo/test.ts
+++ b/examples/workers/tools/sqlite-demo/test.ts
@@ -1,0 +1,256 @@
+// End-to-end tests for the SQLite demo worker.
+// All tests run fully offline against the in-memory seeded database.
+// Run: npm test  (or: npx tsx test.ts)
+import {
+  assertSelectOnly,
+  buildBoundedQuery,
+  buildDescribeTable,
+  buildListTables,
+} from "./src/sql.js"
+import { runCommand, runQuery } from "./src/sqlite.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+function accepts(sql: string): boolean {
+  try {
+    assertSelectOnly(sql)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// assertSelectOnly guard
+// ---------------------------------------------------------------------------
+
+console.log("assertSelectOnly accepts read-only selects:")
+ok("plain select", accepts("SELECT 1"))
+ok(
+  "select from table",
+  accepts("SELECT id, name FROM orders WHERE status = 'open'")
+)
+ok("with/cte", accepts("WITH t AS (SELECT 1 AS x) SELECT * FROM t"))
+ok(
+  "semicolon inside string literal",
+  accepts("SELECT col FROM t WHERE v = 'a;b'")
+)
+ok("trailing semicolon", accepts("SELECT 1;"))
+ok("lowercase keyword", accepts("select 42"))
+ok("trailing line comment", accepts("SELECT id FROM t -- get all\n"))
+
+console.log("assertSelectOnly rejects writes and invalid input:")
+ok("delete", !accepts("DELETE FROM customers"))
+ok("update", !accepts("UPDATE customers SET name = 'x'"))
+ok(
+  "insert",
+  !accepts("INSERT INTO customers VALUES (1,'x','x','US','2024-01-01')")
+)
+ok("drop", !accepts("DROP TABLE customers"))
+ok("create", !accepts("CREATE TABLE t (x int)"))
+ok(
+  "select ... into (write)",
+  !accepts("SELECT * INTO new_table FROM customers")
+)
+ok("multi-statement", !accepts("SELECT 1; SELECT 2"))
+ok("empty", !accepts(""))
+ok("garbage", !accepts("not sql at all"))
+
+// ---------------------------------------------------------------------------
+// buildBoundedQuery
+// ---------------------------------------------------------------------------
+
+console.log("buildBoundedQuery:")
+ok(
+  "wraps and fetches one extra row",
+  buildBoundedQuery("SELECT 1", 10) ===
+    "SELECT * FROM (\nSELECT 1\n) AS query_result LIMIT 11"
+)
+ok(
+  "strips a trailing semicolon",
+  buildBoundedQuery("SELECT 1;", 5) ===
+    "SELECT * FROM (\nSELECT 1\n) AS query_result LIMIT 6"
+)
+ok(
+  "trailing line comment can't swallow the LIMIT",
+  buildBoundedQuery("SELECT id FROM t -- c", 10) ===
+    "SELECT * FROM (\nSELECT id FROM t -- c\n) AS query_result LIMIT 11"
+)
+
+// ---------------------------------------------------------------------------
+// buildListTables / buildDescribeTable
+// ---------------------------------------------------------------------------
+
+console.log("buildListTables:")
+ok(
+  "returns catalog query for sqlite_master",
+  buildListTables().includes("sqlite_master")
+)
+ok("excludes sqlite_ internal tables", buildListTables().includes("sqlite_%"))
+
+console.log("buildDescribeTable:")
+ok(
+  "valid name passes",
+  (() => {
+    try {
+      buildDescribeTable("orders")
+      return true
+    } catch {
+      return false
+    }
+  })()
+)
+ok(
+  "result contains PRAGMA table_info",
+  buildDescribeTable("orders").startsWith("PRAGMA table_info(orders)")
+)
+ok(
+  "rejects name with spaces",
+  (() => {
+    try {
+      buildDescribeTable("my table")
+      return false
+    } catch {
+      return true
+    }
+  })()
+)
+ok(
+  "rejects name with semicolon",
+  (() => {
+    try {
+      buildDescribeTable("t; DROP TABLE customers")
+      return false
+    } catch {
+      return true
+    }
+  })()
+)
+
+// ---------------------------------------------------------------------------
+// Seeded database — real queries against in-memory data
+// ---------------------------------------------------------------------------
+
+async function runDbTests() {
+  console.log("seeded database — listTables:")
+  const tablesResult = await runCommand(buildListTables())
+  const tableNames = tablesResult.rows.map((r) => r["name"] as string).sort()
+  ok("returns exactly 4 tables", tableNames.length === 4)
+  ok(
+    "tables are customers, order_items, orders, products",
+    JSON.stringify(tableNames) ===
+      JSON.stringify(["customers", "order_items", "orders", "products"])
+  )
+
+  console.log("seeded database — describeTable:")
+  const descResult = await runCommand(buildDescribeTable("customers"))
+  const colNames = descResult.rows.map((r) => r["name"] as string)
+  ok("customers has 5 columns", descResult.rows.length === 5)
+  ok("first column is id", colNames[0] === "id")
+  ok(
+    "includes name, email, country, signup_date",
+    ["name", "email", "country", "signup_date"].every((c) =>
+      colNames.includes(c)
+    )
+  )
+
+  console.log("seeded database — COUNT(*) queries:")
+  const custCount = await runQuery("SELECT COUNT(*) AS n FROM customers", null)
+  ok(
+    "customers has 8 rows",
+    custCount.rows.length === 1 && custCount.rows[0]["n"] === 8
+  )
+  const prodCount = await runQuery("SELECT COUNT(*) AS n FROM products", null)
+  ok(
+    "products has 6 rows",
+    prodCount.rows.length === 1 && prodCount.rows[0]["n"] === 6
+  )
+  const orderCount = await runQuery("SELECT COUNT(*) AS n FROM orders", null)
+  ok(
+    "orders has 15 rows",
+    orderCount.rows.length === 1 && orderCount.rows[0]["n"] === 15
+  )
+  const itemCount = await runQuery(
+    "SELECT COUNT(*) AS n FROM order_items",
+    null
+  )
+  ok(
+    "order_items has 28 rows",
+    itemCount.rows.length === 1 && itemCount.rows[0]["n"] === 28
+  )
+
+  console.log("seeded database — top customer by spend:")
+  const topCustomer = await runQuery(
+    `WITH spend AS (
+       SELECT customer_id, SUM(total) AS total_spend
+       FROM orders
+       WHERE status = 'completed'
+       GROUP BY customer_id
+     )
+     SELECT c.name, s.total_spend
+     FROM spend s
+     JOIN customers c ON c.id = s.customer_id
+     ORDER BY s.total_spend DESC
+     LIMIT 1`,
+    null
+  )
+  ok("returns one row", topCustomer.rows.length === 1)
+  // Delta Dynamics: order 5 (299) + order 13 (1155) = 1454
+  ok(
+    "top customer is Delta Dynamics",
+    topCustomer.rows[0]["name"] === "Delta Dynamics"
+  )
+  ok(
+    "Delta Dynamics total spend is 1454",
+    topCustomer.rows[0]["total_spend"] === 1454
+  )
+
+  console.log("seeded database — revenue by category:")
+  const revByCat = await runQuery(
+    `SELECT p.category, SUM(oi.quantity * oi.unit_price) AS revenue
+     FROM order_items oi
+     JOIN products p ON p.id = oi.product_id
+     GROUP BY p.category
+     ORDER BY revenue DESC`,
+    null
+  )
+  ok("returns 3 categories", revByCat.rows.length === 3)
+  ok(
+    "first category is Subscription",
+    revByCat.rows[0]["category"] === "Subscription"
+  )
+
+  console.log("seeded database — orders by status:")
+  const byStatus = await runQuery(
+    "SELECT status, COUNT(*) AS cnt FROM orders GROUP BY status ORDER BY status",
+    null
+  )
+  const statuses = byStatus.rows.map((r) => r["status"] as string)
+  ok("includes completed status", statuses.includes("completed"))
+  ok("includes pending status", statuses.includes("pending"))
+  ok("includes refunded status", statuses.includes("refunded"))
+
+  console.log("seeded database — row cap and truncation:")
+  const capped = await runQuery("SELECT * FROM order_items", 5)
+  ok("caps to 5 rows", capped.rows.length === 5)
+  ok("reports truncated=true", capped.truncated === true)
+
+  const exact = await runQuery("SELECT * FROM customers", 100)
+  ok("8 customers, no truncation", exact.rows.length === 8 && !exact.truncated)
+}
+
+runDbTests().then(() => {
+  console.log(`\n${passed} passed, ${failed} failed`)
+  if (failed > 0) process.exit(1)
+})

--- a/examples/workers/tools/sqlite-demo/tsconfig.json
+++ b/examples/workers/tools/sqlite-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds `examples/workers/tools/sqlite-demo/` — a **self-contained demo** worker using Node's built-in `node:sqlite` (zero external dependencies). It seeds an in-memory SQLite database with the same sample sales data as the duckdb-demo and exposes `listTables`, `describeTable`, `query`. No external database, no credentials, no env vars — deploy and query immediately.

SELECT-only guard via `node-sql-parser` (SQLite dialect). The README notes the data is ephemeral/in-memory and resets each run.

## Verification

- `npm run check`, `npm run build`, `npm test` (45 offline tests, including real queries against the seeded DB), `prettier --check`, `markdownlint` — all clean
- Deploy-smoke: deployed to the dev workspace; all 3 tools discovered (`node:sqlite` loads flag-free on the runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
