### PR TITLE
feat(workers): add duckdb-sync-demo example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -6,6 +6,7 @@ This directory contains example [Notion workers](https://developers.notion.com/d
 
 The [syncs](syncs/) directory includes one-way sync examples that bring data from external systems into Notion databases:
 
+- **[duckdb-sync-demo](syncs/duckdb-sync-demo/)**: Sync a self-contained in-memory DuckDB into a managed Notion database — no setup required
 - **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
 - **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_
 

--- a/examples/workers/syncs/duckdb-sync-demo/.gitignore
+++ b/examples/workers/syncs/duckdb-sync-demo/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/duckdb-sync-demo/README.md
+++ b/examples/workers/syncs/duckdb-sync-demo/README.md
@@ -1,0 +1,92 @@
+# Worker sync: DuckDB demo
+
+A self-contained sync worker that seeds an in-memory DuckDB database with
+sample sales data and syncs the `customers` table into a managed Notion
+database. No external database, no credentials, no environment variables
+required.
+
+## How it works
+
+### Managed databases
+
+This worker declares a managed database. The Notion platform auto-provisions
+the database on first deploy and migrates its schema on subsequent deploys.
+Users can rename, move, and share the database freely — the worker owns the
+schema and data, not the page title or location.
+
+### Sync mode
+
+The worker uses `mode: "replace"` with `schedule: "manual"`. On each run the
+worker returns the complete set of customer rows. After `hasMore: false`, the
+platform performs mark-and-sweep: any page whose `Customer ID` was not seen in
+this run is archived. This keeps the Notion database in sync with the source
+without explicit delete markers.
+
+### Primary key
+
+Each change carries a `key` matching the `Customer ID` property value. The
+platform uses this key to match incoming upserts against existing pages.
+
+### In-memory data
+
+DuckDB is initialised with `:memory:` and seeded on startup. Data is ephemeral
+— each worker process seeds fresh. For a real sync worker you would query an
+external database instead.
+
+## Seeded schema
+
+| Table       | Rows | Notes                                 |
+| ----------- | ---- | ------------------------------------- |
+| customers   | 8    | Synced to Notion                      |
+| products    | 6    | Subscriptions, services, add-ons      |
+| orders      | 15   | completed / refunded / pending        |
+| order_items | 30   | Line items linking orders to products |
+
+Customer countries in the dataset: AU, CA, DE, FR, GB, SG, US.
+
+## Setup
+
+Install the Notion workers CLI:
+
+```
+npm install -g @notionhq/workers-cli
+```
+
+Clone the repo and install dependencies:
+
+```
+cd examples/workers/syncs/duckdb-sync-demo
+npm install
+```
+
+Authenticate:
+
+```
+ntn login
+```
+
+Deploy the worker:
+
+```
+ntn workers deploy
+```
+
+Trigger a dry run to preview changes without writing to Notion:
+
+```
+ntn workers sync trigger customersSync --preview
+```
+
+Trigger a real sync to write rows into the managed Notion database:
+
+```
+ntn workers sync trigger customersSync
+```
+
+## Local checks
+
+```
+npm run check   # TypeScript type-check (no output = clean)
+npm run build   # Compile to dist/
+npm test        # Run offline assertions against the seeded DB
+```

--- a/examples/workers/syncs/duckdb-sync-demo/package.json
+++ b/examples/workers/syncs/duckdb-sync-demo/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "duckdb-sync-demo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@duckdb/node-api": "^1.5.4-r.1",
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/duckdb-sync-demo/src/duckdb.ts
+++ b/examples/workers/syncs/duckdb-sync-demo/src/duckdb.ts
@@ -1,0 +1,128 @@
+import {
+  DuckDBBlobValue,
+  DuckDBConnection,
+  DuckDBDateValue,
+  DuckDBDecimalValue,
+  DuckDBInstance,
+  DuckDBTimestampMicrosecondsValue,
+  DuckDBTimestampMillisecondsValue,
+  DuckDBTimestampNanosecondsValue,
+  DuckDBTimestampSecondsValue,
+  DuckDBTimestampTZValue,
+  DuckDBTimestampValue,
+  dateFromDateValue,
+  dateFromTimestampMillisecondsValue,
+  dateFromTimestampNanosecondsValue,
+  dateFromTimestampSecondsValue,
+  dateFromTimestampTZValue,
+  dateFromTimestampValue,
+  doubleFromDecimalValue,
+} from "@duckdb/node-api"
+
+import { seedDatabase } from "./seed.js"
+
+// Module-level singleton — the in-memory database is created once per process
+// and reused across all sync executions. Seeding is instant.
+let connectionPromise: Promise<DuckDBConnection> | null = null
+
+function getConnection(): Promise<DuckDBConnection> {
+  if (!connectionPromise) {
+    connectionPromise = (async () => {
+      // Disable DuckDB's external file/network access as a hardening default.
+      // This worker only runs fixed internal SELECTs, but keeping external
+      // access off matches the duckdb-demo tool and is the safe default for any
+      // engine you might later point at agent-supplied SQL.
+      const instance = await DuckDBInstance.create(":memory:", {
+        enable_external_access: "false",
+      })
+      const conn = await instance.connect()
+      await seedDatabase(conn)
+      return conn
+    })()
+  }
+  return connectionPromise
+}
+
+// Run a fixed internal SELECT and return plain JS objects with JSON-safe values.
+export async function fetchRows(
+  sql: string
+): Promise<Record<string, unknown>[]> {
+  const conn = await getConnection()
+  const reader = await conn.runAndReadAll(sql)
+  const rawRows = reader.getRowObjects() as Record<string, unknown>[]
+  return rawRows.map(normalizeRow)
+}
+
+function normalizeRow(row: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, normalizeValue(value)])
+  )
+}
+
+// DuckDB returns native JS types for most columns, but DATE, TIMESTAMP, and
+// DECIMAL come back as special value objects. BigInt appears for BIGINT columns.
+// We convert everything to a JSON-safe primitive.
+export function normalizeValue(value: unknown): unknown {
+  if (value == null) return null
+  if (typeof value === "boolean") return value
+  if (typeof value === "string") return value
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : String(value)
+
+  // BIGINT — safe as a JS number if it fits, otherwise a string
+  if (typeof value === "bigint") {
+    const n = Number(value)
+    return Number.isSafeInteger(n) ? n : value.toString()
+  }
+
+  // DECIMAL(p, s) — convert to a JS double via the official helper
+  if (value instanceof DuckDBDecimalValue) {
+    return doubleFromDecimalValue(value)
+  }
+
+  // DATE — convert days-since-epoch to an ISO date string
+  if (value instanceof DuckDBDateValue) {
+    return dateFromDateValue(value).toISOString().slice(0, 10)
+  }
+
+  // TIMESTAMP variants — convert micros/millis/nanos/seconds to ISO string
+  if (value instanceof DuckDBTimestampValue) {
+    return dateFromTimestampValue(value).toISOString()
+  }
+  if (value instanceof DuckDBTimestampMicrosecondsValue) {
+    // DuckDBTimestampValue is the microseconds variant; alias for clarity
+    return dateFromTimestampValue(
+      value as unknown as DuckDBTimestampValue
+    ).toISOString()
+  }
+  if (value instanceof DuckDBTimestampMillisecondsValue) {
+    return dateFromTimestampMillisecondsValue(value).toISOString()
+  }
+  if (value instanceof DuckDBTimestampNanosecondsValue) {
+    return dateFromTimestampNanosecondsValue(value).toISOString()
+  }
+  if (value instanceof DuckDBTimestampSecondsValue) {
+    return dateFromTimestampSecondsValue(value).toISOString()
+  }
+  if (value instanceof DuckDBTimestampTZValue) {
+    return dateFromTimestampTZValue(value).toISOString()
+  }
+
+  // BLOB — encode as base64
+  if (value instanceof DuckDBBlobValue) {
+    return Buffer.from(value.bytes).toString("base64")
+  }
+
+  // Arrays and nested objects (LIST, STRUCT, MAP)
+  if (Array.isArray(value)) return value.map(normalizeValue)
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k,
+        normalizeValue(v),
+      ])
+    )
+  }
+
+  return String(value)
+}

--- a/examples/workers/syncs/duckdb-sync-demo/src/index.ts
+++ b/examples/workers/syncs/duckdb-sync-demo/src/index.ts
@@ -1,0 +1,31 @@
+import { Worker } from "@notionhq/workers"
+
+import { fetchRows } from "./duckdb.js"
+import { INITIAL_TITLE, PRIMARY_KEY, customerSchema } from "./schema.js"
+import { customerToChange, type CustomerRow } from "./transform.js"
+
+const worker = new Worker()
+
+const database = worker.database("customers", {
+  type: "managed",
+  initialTitle: INITIAL_TITLE,
+  primaryKeyProperty: PRIMARY_KEY,
+  schema: customerSchema,
+})
+
+worker.sync("customersSync", {
+  database,
+  mode: "replace",
+  schedule: "manual",
+  execute: async () => {
+    const rows = await fetchRows(
+      "SELECT id, name, email, country, signup_date FROM customers ORDER BY id"
+    )
+    return {
+      changes: rows.map((row) => customerToChange(row as CustomerRow)),
+      hasMore: false,
+    }
+  },
+})
+
+export default worker

--- a/examples/workers/syncs/duckdb-sync-demo/src/schema.ts
+++ b/examples/workers/syncs/duckdb-sync-demo/src/schema.ts
@@ -1,0 +1,24 @@
+import * as Schema from "@notionhq/workers/schema"
+
+// The seed customers table has 8 rows with these distinct country codes:
+// US, GB, CA, DE, AU, FR, SG
+export const INITIAL_TITLE = "Demo Customers"
+export const PRIMARY_KEY = "Customer ID"
+
+export const customerSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    Name: Schema.title(),
+    "Customer ID": Schema.richText(),
+    Email: Schema.email(),
+    Country: Schema.select([
+      { name: "AU" },
+      { name: "CA" },
+      { name: "DE" },
+      { name: "FR" },
+      { name: "GB" },
+      { name: "SG" },
+      { name: "US" },
+    ]),
+    "Signup Date": Schema.date(),
+  },
+}

--- a/examples/workers/syncs/duckdb-sync-demo/src/seed.ts
+++ b/examples/workers/syncs/duckdb-sync-demo/src/seed.ts
@@ -1,0 +1,156 @@
+// Schema and deterministic sample data for the in-memory demo database.
+// Every INSERT uses literal values so the data is reproducible across runs.
+//
+// Order totals equal the sum of (quantity * unit_price) across their items.
+// This module is shared with the sqlite-demo worker so both demos use the
+// same dataset for consistency.
+
+import type { DuckDBConnection } from "@duckdb/node-api"
+
+const SCHEMA_SQL = `
+CREATE TABLE customers (
+  id          INTEGER PRIMARY KEY,
+  name        TEXT    NOT NULL,
+  email       TEXT    NOT NULL,
+  country     TEXT    NOT NULL,
+  signup_date DATE    NOT NULL
+);
+
+CREATE TABLE products (
+  id       INTEGER PRIMARY KEY,
+  name     TEXT            NOT NULL,
+  category TEXT            NOT NULL,
+  price    DECIMAL(10, 2)  NOT NULL
+);
+
+CREATE TABLE orders (
+  id          INTEGER        PRIMARY KEY,
+  customer_id INTEGER        NOT NULL REFERENCES customers(id),
+  order_date  DATE           NOT NULL,
+  status      TEXT           NOT NULL,
+  total       DECIMAL(10, 2) NOT NULL
+);
+
+CREATE TABLE order_items (
+  id         INTEGER        PRIMARY KEY,
+  order_id   INTEGER        NOT NULL REFERENCES orders(id),
+  product_id INTEGER        NOT NULL REFERENCES products(id),
+  quantity   INTEGER        NOT NULL,
+  unit_price DECIMAL(10, 2) NOT NULL
+);
+`
+
+// Customers: 8 rows
+// Products: 6 rows  (3 subscriptions, 1 service, 2 add-ons)
+// Orders: 15 rows
+// Order items: 30 rows
+//
+// Totals per order (sum of qty * unit_price):
+//  1: Pro(149)                               = 149.00
+//  2: Pro(149) + Onboarding(299)             = 448.00
+//  3: Starter(49)                            =  49.00
+//  4: Enterprise(499) + Export(79)           = 578.00
+//  5: Onboarding(299)                        = 299.00
+//  6: Pro(149) + Export(79)                  = 228.00
+//  7: Enterprise(499)                        = 499.00
+//  8: Pro(149)            [refunded]         = 149.00
+//  9: Enterprise(499) + Onboarding(299)      = 798.00
+// 10: Pro(149)                               = 149.00
+// 11: Enterprise(499)+Support(199)+Export(79)= 777.00
+// 12: Support(199)       [pending]           = 199.00
+// 13: Enterprise(499)+Onboarding(299)        = 798.00
+// 14: Enterprise(499)                        = 499.00
+// 15: Export(79)         [pending]           =  79.00
+
+const SEED_SQL = `
+INSERT INTO customers VALUES
+  (1, 'Acme Corp',        'acme@example.com',     'US', '2023-01-15'),
+  (2, 'Bright Ideas Ltd', 'hello@brightideas.co', 'GB', '2023-02-20'),
+  (3, 'Cedar Solutions',  'info@cedarsol.com',    'CA', '2023-03-05'),
+  (4, 'Delta Dynamics',   'sales@deltadyn.io',    'DE', '2023-04-12'),
+  (5, 'Echo Ventures',    'contact@echovntr.com', 'AU', '2023-05-18'),
+  (6, 'Foxtrot Systems',  'ops@foxtrotsys.com',   'US', '2023-06-22'),
+  (7, 'Gamma Analytics',  'data@gammalytics.net', 'FR', '2023-07-30'),
+  (8, 'Harbor Networks',  'team@harbornet.dev',   'SG', '2023-08-09');
+
+INSERT INTO products VALUES
+  (1, 'Starter Plan',       'Subscription',  49.00),
+  (2, 'Pro Plan',           'Subscription', 149.00),
+  (3, 'Enterprise Plan',    'Subscription', 499.00),
+  (4, 'Onboarding Pack',    'Services',     299.00),
+  (5, 'Data Export Add-on', 'Add-on',        79.00),
+  (6, 'Priority Support',   'Add-on',       199.00);
+
+INSERT INTO orders VALUES
+  (1,  1, '2024-01-10', 'completed', 149.00),
+  (2,  2, '2024-01-14', 'completed', 448.00),
+  (3,  3, '2024-01-22', 'completed',  49.00),
+  (4,  1, '2024-02-05', 'completed', 578.00),
+  (5,  4, '2024-02-11', 'completed', 299.00),
+  (6,  5, '2024-02-18', 'completed', 228.00),
+  (7,  6, '2024-03-02', 'completed', 499.00),
+  (8,  2, '2024-03-15', 'refunded',  149.00),
+  (9,  7, '2024-03-20', 'completed', 798.00),
+  (10, 3, '2024-04-01', 'completed', 149.00),
+  (11, 8, '2024-04-08', 'completed', 777.00),
+  (12, 1, '2024-04-22', 'pending',   199.00),
+  (13, 4, '2024-05-03', 'completed', 798.00),
+  (14, 5, '2024-05-17', 'completed', 499.00),
+  (15, 6, '2024-06-01', 'pending',    79.00);
+
+INSERT INTO order_items VALUES
+  -- order 1: Pro x1 = 149
+  (1,  1,  2, 1, 149.00),
+  -- order 2: Pro x1 + Onboarding x1 = 149 + 299 = 448
+  (2,  2,  2, 1, 149.00),
+  (3,  2,  4, 1, 299.00),
+  -- order 3: Starter x1 = 49
+  (4,  3,  1, 1,  49.00),
+  -- order 4: Enterprise x1 + Export x1 = 499 + 79 = 578
+  (5,  4,  3, 1, 499.00),
+  (6,  4,  5, 1,  79.00),
+  -- order 5: Onboarding x1 = 299
+  (7,  5,  4, 1, 299.00),
+  -- order 6: Pro x1 + Export x1 = 149 + 79 = 228
+  (8,  6,  2, 1, 149.00),
+  (9,  6,  5, 1,  79.00),
+  -- order 7: Enterprise x1 = 499
+  (10, 7,  3, 1, 499.00),
+  -- order 8: Pro x1 = 149 (refunded)
+  (11, 8,  2, 1, 149.00),
+  -- order 9: Enterprise x1 + Onboarding x1 = 499 + 299 = 798
+  (12, 9,  3, 1, 499.00),
+  (13, 9,  4, 1, 299.00),
+  -- order 10: Pro x1 = 149
+  (14, 10, 2, 1, 149.00),
+  -- order 11: Enterprise x1 + Support x1 + Export x1 = 499 + 199 + 79 = 777
+  (15, 11, 3, 1, 499.00),
+  (16, 11, 6, 1, 199.00),
+  (17, 11, 5, 1,  79.00),
+  -- order 12: Support x1 = 199 (pending)
+  (18, 12, 6, 1, 199.00),
+  -- order 13: Enterprise x1 + Onboarding x1 = 499 + 299 = 798
+  (19, 13, 3, 1, 499.00),
+  (20, 13, 4, 1, 299.00),
+  -- order 14: Enterprise x1 = 499
+  (21, 14, 3, 1, 499.00),
+  -- order 15: Export x1 = 79 (pending)
+  (22, 15, 5, 1,  79.00),
+  -- extra items to reach 30 rows (Starter add-ons at 0 extra cost bundled in totals)
+  (23, 1,  1, 1,   0.00),
+  (24, 3,  1, 1,   0.00),
+  (25, 5,  1, 1,   0.00),
+  (26, 7,  1, 1,   0.00),
+  (27, 8,  1, 1,   0.00),
+  (28, 10, 1, 1,   0.00),
+  (29, 12, 1, 1,   0.00),
+  (30, 14, 1, 1,   0.00);
+`
+
+// Create the schema and populate with sample data on the given connection.
+// Call once per in-memory database; the data persists for the lifetime of
+// the DuckDB instance.
+export async function seedDatabase(conn: DuckDBConnection): Promise<void> {
+  await conn.run(SCHEMA_SQL)
+  await conn.run(SEED_SQL)
+}

--- a/examples/workers/syncs/duckdb-sync-demo/src/transform.ts
+++ b/examples/workers/syncs/duckdb-sync-demo/src/transform.ts
@@ -1,0 +1,23 @@
+import * as Builder from "@notionhq/workers/builder"
+
+export type CustomerRow = {
+  id: unknown
+  name: unknown
+  email: unknown
+  country: unknown
+  signup_date: unknown
+}
+
+export function customerToChange(row: CustomerRow) {
+  return {
+    type: "upsert" as const,
+    key: String(row.id),
+    properties: {
+      Name: Builder.title(String(row.name)),
+      "Customer ID": Builder.richText(String(row.id)),
+      Email: Builder.email(String(row.email)),
+      Country: Builder.select(String(row.country)),
+      "Signup Date": Builder.date(String(row.signup_date)),
+    },
+  }
+}

--- a/examples/workers/syncs/duckdb-sync-demo/test.ts
+++ b/examples/workers/syncs/duckdb-sync-demo/test.ts
@@ -1,0 +1,113 @@
+// Offline test harness — uses the real in-memory seeded DuckDB.
+// No Notion credentials required.
+// Run: npm test  (or: npx tsx test.ts)
+
+import { fetchRows } from "./src/duckdb.js"
+import { customerToChange } from "./src/transform.js"
+
+let passed = 0
+let failed = 0
+
+function ok(label: string, condition: boolean): void {
+  if (condition) {
+    passed++
+    console.log(`  ok   ${label}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${label}`)
+  }
+}
+
+async function runTests() {
+  // fetchRows returns all 8 seeded customers
+  console.log("fetchRows — customers:")
+  const rows = await fetchRows(
+    "SELECT id, name, email, country, signup_date FROM customers ORDER BY id"
+  )
+
+  ok("returns 8 rows", rows.length === 8)
+
+  // Known seed row: id=1, Acme Corp, acme@example.com, US, 2023-01-15
+  const first = rows[0] as {
+    id: unknown
+    name: unknown
+    email: unknown
+    country: unknown
+    signup_date: unknown
+  }
+
+  ok("first row id is 1", String(first.id) === "1")
+  ok("first row name is Acme Corp", String(first.name) === "Acme Corp")
+  ok(
+    "first row email is acme@example.com",
+    String(first.email) === "acme@example.com"
+  )
+  ok("first row country is US", String(first.country) === "US")
+  ok(
+    "first row signup_date is 2023-01-15",
+    String(first.signup_date) === "2023-01-15"
+  )
+
+  // customerToChange produces the expected shape
+  console.log("customerToChange — known row:")
+  const change = customerToChange(first)
+
+  ok("change type is upsert", change.type === "upsert")
+  ok("change key matches id", change.key === "1")
+
+  // Builder values are objects — verify text content via JSON roundtrip
+  const p = change.properties
+  ok(
+    "Name property contains Acme Corp",
+    JSON.stringify(p["Name"]).includes("Acme Corp")
+  )
+  ok(
+    "Customer ID property contains 1",
+    JSON.stringify(p["Customer ID"]).includes("1")
+  )
+  ok(
+    "Email property contains acme@example.com",
+    JSON.stringify(p["Email"]).includes("acme@example.com")
+  )
+  ok(
+    "Country property contains US",
+    JSON.stringify(p["Country"]).includes("US")
+  )
+  ok(
+    "Signup Date property contains 2023-01-15",
+    JSON.stringify(p["Signup Date"]).includes("2023-01-15")
+  )
+
+  // All 8 changes have type upsert and non-empty key
+  console.log("all changes — type and key:")
+  const allChanges = rows.map((row) =>
+    customerToChange(
+      row as {
+        id: unknown
+        name: unknown
+        email: unknown
+        country: unknown
+        signup_date: unknown
+      }
+    )
+  )
+
+  ok(
+    "all changes have type upsert",
+    allChanges.every((c) => c.type === "upsert")
+  )
+  ok(
+    "all changes have non-empty key",
+    allChanges.every((c) => c.key.length > 0)
+  )
+}
+
+runTests()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`)
+    if (failed > 0) process.exit(1)
+  })
+  .catch((err) => {
+    console.error("Unexpected error:", err)
+    process.exit(1)
+  })

--- a/examples/workers/syncs/duckdb-sync-demo/tsconfig.json
+++ b/examples/workers/syncs/duckdb-sync-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds `examples/workers/syncs/duckdb-sync-demo/` — the cookbook's first implemented **sync** example, and a self-contained one. An in-memory DuckDB seeded with sample sales data is synced into a **managed** Notion database via `worker.database` (managed) + `worker.sync`. No external database, no credentials, no env vars.

Demonstrates the DB→Notion sync pattern: the worker declares the schema, the platform auto-provisions and owns the Notion database, and rows upsert by `Customer ID` (`mode: "replace"`, `schedule: "manual"`). Reuses the seed from the `duckdb-demo` tool example.

## Verification

- `npm run check`, `npm run build`, `npm test` (15 offline tests run against the real in-memory seeded DB), `prettier --check`, `markdownlint` — all clean
- Deploy-smoke: deployed to dev; `sync customersSync` discovered. Triggered end-to-end (`ntn workers sync trigger customersSync`) → the managed "Demo Customers" Notion DB was created and populated with **8 upserts, 0 deletes** (run exit 0). No `NOTION_API_TOKEN` is required — managed-DB sync writes are runtime-authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
