### PR TITLE
feat(workers): add snowflake-sync example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -7,6 +7,7 @@ This directory contains example [Notion workers](https://developers.notion.com/d
 The [syncs](syncs/) directory includes one-way sync examples that bring data from external systems into Notion databases:
 
 - **[duckdb-sync-demo](syncs/duckdb-sync-demo/)**: Sync a self-contained in-memory DuckDB into a managed Notion database — no setup required
+- **[snowflake-sync](syncs/snowflake-sync/)**: Sync rows from a Snowflake query into a managed Notion database
 - **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
 - **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_
 

--- a/examples/workers/syncs/snowflake-sync/.env.example
+++ b/examples/workers/syncs/snowflake-sync/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Required
+SNOWFLAKE_ACCOUNT=
+SNOWFLAKE_USER=
+SNOWFLAKE_WAREHOUSE=
+# Paste the full PEM. Newlines may be written as literal \n — the worker normalizes them.
+SNOWFLAKE_PRIVATE_KEY=
+
+# Optional
+# SNOWFLAKE_PRIVATE_KEY_PASS=
+# SNOWFLAKE_DATABASE=
+# SNOWFLAKE_SCHEMA=
+# SNOWFLAKE_ROLE=
+
+# The SELECT query whose rows will be synced into the managed Notion database.
+# The query must return at least an `id` column (or `ID`) that uniquely identifies each row.
+# Example:
+# SNOWFLAKE_SYNC_QUERY=SELECT id, name, email, status, updated_at FROM my_db.my_schema.my_table
+SNOWFLAKE_SYNC_QUERY=
+
+# Optional: title for the auto-provisioned Notion database (default: "Snowflake Sync")
+# SNOWFLAKE_SYNC_DB_TITLE=Snowflake Sync

--- a/examples/workers/syncs/snowflake-sync/.gitignore
+++ b/examples/workers/syncs/snowflake-sync/.gitignore
@@ -1,0 +1,12 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Private keys — never commit these
+*.p8
+rsa_key*
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/snowflake-sync/README.md
+++ b/examples/workers/syncs/snowflake-sync/README.md
@@ -1,0 +1,149 @@
+# Worker sync: Snowflake
+
+Syncs rows from a Snowflake query into a managed Notion database. The worker
+declares the schema; Notion auto-provisions and owns the database. Each run
+fetches the full result set in 200-row pages and upserts every row by the `ID`
+column. Rows removed from the source query are removed from the Notion database
+on the next full sync (`mode: "replace"`).
+
+## How it works
+
+1. You provide a `SNOWFLAKE_SYNC_QUERY` — any `SELECT` that returns an `id`
+   column (case-insensitive) plus whatever columns you want to show in Notion.
+2. On each sync run the worker pages through the query results (200 rows at a
+   time, using `LIMIT`/`OFFSET`) and emits an `upsert` change for every row.
+3. The platform applies those changes to the managed database and loops until
+   `hasMore` is false.
+
+The example schema maps `id, name, email, status, updated_at`. See
+[Adapting to your query](#adapting-to-your-query) to change it.
+
+## Prerequisites
+
+- Node >= 22, npm >= 10.9.2
+- A Snowflake account with a read-only service role and an RSA key pair for
+  JWT authentication. See the
+  [snowflake-query README](../../tools/snowflake-query/README.md) for key-pair
+  setup instructions.
+- The `ntn` CLI installed and authenticated (`ntn auth login`).
+
+## Environment variables
+
+### Required
+
+| Variable                | Description                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `SNOWFLAKE_ACCOUNT`     | Account identifier (e.g. `xy12345.us-east-1`)                                 |
+| `SNOWFLAKE_USER`        | Snowflake username                                                            |
+| `SNOWFLAKE_WAREHOUSE`   | Warehouse to use for queries                                                  |
+| `SNOWFLAKE_PRIVATE_KEY` | Full PEM private key. Literal `\n` sequences are normalized automatically.    |
+| `SNOWFLAKE_SYNC_QUERY`  | The `SELECT` statement to sync (trailing semicolon is stripped automatically) |
+
+### Optional
+
+| Variable                     | Default            | Description                                   |
+| ---------------------------- | ------------------ | --------------------------------------------- |
+| `SNOWFLAKE_PRIVATE_KEY_PASS` | —                  | Passphrase for an encrypted private key       |
+| `SNOWFLAKE_DATABASE`         | —                  | Default database for the session              |
+| `SNOWFLAKE_SCHEMA`           | —                  | Default schema for the session                |
+| `SNOWFLAKE_ROLE`             | —                  | Role to assume for the query                  |
+| `SNOWFLAKE_SYNC_DB_TITLE`    | `"Snowflake Sync"` | Title of the auto-provisioned Notion database |
+
+No `NOTION_API_TOKEN` is needed. The platform manages the database and handles
+the Notion credentials automatically.
+
+## Setup and deploy
+
+```sh
+# Install dependencies
+cd examples/workers/syncs/snowflake-sync
+npm install
+
+# Typecheck
+npm run check
+
+# Build
+npm run build
+
+# Run offline tests
+npm test
+```
+
+Deploy the worker:
+
+```sh
+ntn workers deploy
+```
+
+Set environment variables on the deployed worker:
+
+```sh
+ntn workers env set SNOWFLAKE_ACCOUNT=xy12345.us-east-1
+ntn workers env set SNOWFLAKE_USER=svc_notion_sync
+ntn workers env set SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+ntn workers env set SNOWFLAKE_PRIVATE_KEY="$(cat rsa_key.p8)"
+ntn workers env set SNOWFLAKE_SYNC_QUERY="SELECT id, name, email, status, updated_at FROM my_db.my_schema.my_table"
+```
+
+Preview a sync without writing to Notion:
+
+```sh
+ntn workers sync trigger snowflakeSync --preview
+```
+
+Run a real sync:
+
+```sh
+ntn workers sync trigger snowflakeSync
+```
+
+## Adapting to your query
+
+The example targets five columns. To match your own query, edit two files:
+
+**`src/schema.ts`** — declares the Notion database properties. Each key is a
+property name; the value is a Schema factory call. Supported types include
+`Schema.title()`, `Schema.richText()`, `Schema.email()`, `Schema.date()`,
+`Schema.select([...])`, `Schema.number()`, `Schema.url()`, and
+`Schema.checkbox()`. Keep `PRIMARY_KEY` pointing at the property that holds
+the unique row identifier.
+
+**`src/transform.ts`** — maps a raw Snowflake row to a sync change. Column
+lookups use `row["COLUMN"] ?? row["column"]` to handle Snowflake's UPPERCASE
+default and explicit lowercase aliases. Add or remove `Builder.*` calls to
+match your schema.
+
+## Pagination
+
+The worker uses `LIMIT 200 OFFSET N` to page through results. The platform
+loops execute() calls until `hasMore` is false. For queries returning millions
+of rows this is reliable but sequential. An `ORDER BY` clause in
+`SNOWFLAKE_SYNC_QUERY` is recommended to make pages deterministic.
+
+## Incremental syncs for large or frequently-changing tables
+
+`mode: "replace"` re-syncs the entire result set on every run. For large tables
+or tables that change often, switch to `mode: "incremental"` and carry a cursor
+in `nextState`:
+
+```ts
+// In execute():
+const since = state?.updatedSince ?? "1970-01-01"
+const query = `${baseQuery} WHERE updated_at > '${since}' ORDER BY updated_at`
+// ...
+return {
+  changes,
+  hasMore: false,
+  nextState: { updatedSince: latestUpdatedAt },
+}
+```
+
+Incremental mode also supports `type: "delete"` changes for rows removed from
+the source.
+
+## Access control
+
+The worker connects using the Snowflake role configured via `SNOWFLAKE_ROLE` (or
+the user's default role). Use a read-only role that has `SELECT` privileges only
+on the tables your query references. The role's grants are the effective read
+boundary — the worker cannot access tables the role cannot see.

--- a/examples/workers/syncs/snowflake-sync/package.json
+++ b/examples/workers/syncs/snowflake-sync/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "snowflake-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0",
+    "snowflake-sdk": "^2.4.3"
+  }
+}

--- a/examples/workers/syncs/snowflake-sync/src/index.ts
+++ b/examples/workers/syncs/snowflake-sync/src/index.ts
@@ -1,0 +1,58 @@
+import { Worker } from "@notionhq/workers"
+
+import { fetchPage } from "./snowflake.js"
+import { INITIAL_TITLE, PRIMARY_KEY, rowSchema } from "./schema.js"
+import { rowToChange } from "./transform.js"
+
+// How many rows to fetch per page. 200 is a safe balance between round-trips
+// and memory pressure. Increase for very wide tables or decrease for very
+// narrow ones.
+const PAGE_SIZE = 200
+
+// State carried between execute() calls while hasMore is true.
+type SyncState = {
+  offset: number
+}
+
+const worker = new Worker()
+
+const database = worker.database("rows", {
+  type: "managed",
+  initialTitle: INITIAL_TITLE,
+  primaryKeyProperty: PRIMARY_KEY,
+  schema: rowSchema,
+})
+
+worker.sync("snowflakeSync", {
+  database,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state: SyncState | undefined, _context) => {
+    const query = process.env.SNOWFLAKE_SYNC_QUERY
+    if (!query || !query.trim()) {
+      throw new Error(
+        "SNOWFLAKE_SYNC_QUERY is not set. " +
+          "Set it to a SELECT statement whose rows should be synced into Notion."
+      )
+    }
+
+    const offset = state?.offset ?? 0
+    const rows = await fetchPage(query, PAGE_SIZE, offset)
+
+    // A full page means there may be more rows; a partial page means we're done.
+    const hasMore = rows.length === PAGE_SIZE
+
+    const changes = rows.flatMap((row) => {
+      const change = rowToChange(row)
+      return change !== null ? [change] : []
+    })
+
+    return {
+      changes,
+      hasMore,
+      nextState: hasMore ? { offset: offset + rows.length } : undefined,
+    }
+  },
+})
+
+export default worker

--- a/examples/workers/syncs/snowflake-sync/src/schema.ts
+++ b/examples/workers/syncs/snowflake-sync/src/schema.ts
@@ -1,0 +1,48 @@
+// =============================================================================
+// EDIT THIS to match the columns your SNOWFLAKE_SYNC_QUERY returns.
+//
+// Each key in `properties` becomes a property in the managed Notion database.
+// The platform auto-provisions and owns the database — you do not create it
+// manually.
+//
+// Schema reference:
+//   Schema.title()         — the page title property (required: exactly one)
+//   Schema.richText()      — free-form text
+//   Schema.email()         — email address (rendered as a mailto link)
+//   Schema.date()          — date or datetime
+//   Schema.select([...])   — single-select with known option names
+//   Schema.number()        — numeric value
+//   Schema.url()           — URL link
+//   Schema.checkbox()      — boolean checkbox
+// =============================================================================
+
+import * as Schema from "@notionhq/workers/schema"
+
+export const INITIAL_TITLE =
+  process.env.SNOWFLAKE_SYNC_DB_TITLE ?? "Snowflake Sync"
+
+// The property name used as the unique key for upserts. Must exist in the
+// properties map below and be passed as `primaryKeyProperty` on the database
+// handle.
+export const PRIMARY_KEY = "ID"
+
+export const rowSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    // The page title — required by Notion; mapped from the `name` column.
+    Name: Schema.title(),
+
+    // Unique identifier for each row. Used as the upsert key.
+    ID: Schema.richText(),
+
+    // Email address column.
+    Email: Schema.email(),
+
+    // Status is mapped to richText because the option values aren't known
+    // up front. Switch to Schema.select(["Active", "Inactive", ...]) if you
+    // know the full set of values.
+    Status: Schema.richText(),
+
+    // Date column. Expects a YYYY-MM-DD string (or ISO timestamp — see transform.ts).
+    "Updated At": Schema.date(),
+  },
+}

--- a/examples/workers/syncs/snowflake-sync/src/snowflake.ts
+++ b/examples/workers/syncs/snowflake-sync/src/snowflake.ts
@@ -1,0 +1,153 @@
+import snowflake from "snowflake-sdk"
+
+snowflake.configure({ logLevel: "ERROR" })
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export function createConnection(): snowflake.Connection {
+  const account = process.env.SNOWFLAKE_ACCOUNT ?? ""
+  const username = process.env.SNOWFLAKE_USER ?? ""
+  const warehouse = process.env.SNOWFLAKE_WAREHOUSE ?? ""
+  const privateKey = process.env.SNOWFLAKE_PRIVATE_KEY ?? ""
+  const privateKeyPass = process.env.SNOWFLAKE_PRIVATE_KEY_PASS
+  const database = process.env.SNOWFLAKE_DATABASE
+  const schema = process.env.SNOWFLAKE_SCHEMA
+  const role = process.env.SNOWFLAKE_ROLE
+
+  if (!account || !username || !warehouse || !privateKey) {
+    throw new Error(
+      "Missing Snowflake configuration. Set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_WAREHOUSE, and SNOWFLAKE_PRIVATE_KEY."
+    )
+  }
+
+  return snowflake.createConnection({
+    account,
+    username,
+    warehouse,
+    authenticator: "SNOWFLAKE_JWT",
+    // A key stored as a one-line secret often has its newlines escaped.
+    privateKey: privateKey.replace(/\\n/g, "\n"),
+    ...(privateKeyPass ? { privateKeyPass } : {}),
+    ...(database ? { database } : {}),
+    ...(schema ? { schema } : {}),
+    ...(role ? { role } : {}),
+  })
+}
+
+function connect(conn: snowflake.Connection): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn.connect((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+function destroy(conn: snowflake.Connection): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn.destroy((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+export function executeSql(
+  conn: snowflake.Connection,
+  sqlText: string
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText,
+      complete: (err, _stmt, rows) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve((rows ?? []) as Record<string, unknown>[])
+      },
+    })
+  })
+}
+
+export function normalizeValue(value: unknown): JsonValue {
+  if (value == null) return null
+  if (typeof value === "string") return value
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : String(value)
+  if (typeof value === "boolean") return value
+  if (typeof value === "bigint") return value.toString()
+  if (value instanceof Date) return value.toISOString()
+  if (Buffer.isBuffer(value)) return value.toString("base64")
+  if (Array.isArray(value)) return value.map(normalizeValue)
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        normalizeValue(nested),
+      ])
+    )
+  }
+  return String(value)
+}
+
+export function clamp(
+  value: number | null,
+  fallback: number,
+  max: number
+): number {
+  if (value == null) return fallback
+  const n = Math.floor(value)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  return Math.min(n, max)
+}
+
+export function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+/**
+ * Build the paginated subquery string without executing it.
+ * Exported so it can be tested without a Snowflake connection.
+ */
+export function buildPageSql(
+  query: string,
+  limit: number,
+  offset: number
+): string {
+  // Strip trailing whitespace and a trailing semicolon so it doesn't break
+  // the subquery wrapper. Trim again after removing the semicolon to handle
+  // patterns like "SELECT 1 ;  ".
+  const trimmed = query.trimEnd().replace(/;$/, "").trimEnd()
+  return `SELECT * FROM (\n${trimmed}\n) AS src LIMIT ${limit} OFFSET ${offset}`
+}
+
+/**
+ * Fetch one page of rows from a query using LIMIT/OFFSET pagination.
+ *
+ * @param query  A SELECT statement (trailing semicolon is stripped automatically).
+ * @param limit  Maximum rows to return for this page.
+ * @param offset Row offset to start from.
+ */
+export async function fetchPage(
+  query: string,
+  limit: number,
+  offset: number
+): Promise<Record<string, unknown>[]> {
+  const sql = buildPageSql(query, limit, offset)
+  const conn = createConnection()
+  await connect(conn)
+  try {
+    const rows = await executeSql(conn, sql)
+    return rows.map((row) =>
+      Object.fromEntries(
+        Object.entries(row).map(([key, value]) => [key, normalizeValue(value)])
+      )
+    )
+  } finally {
+    await destroy(conn).catch(() => {})
+  }
+}

--- a/examples/workers/syncs/snowflake-sync/src/transform.ts
+++ b/examples/workers/syncs/snowflake-sync/src/transform.ts
@@ -1,0 +1,70 @@
+// =============================================================================
+// EDIT THIS to match the columns your SNOWFLAKE_SYNC_QUERY returns.
+//
+// Snowflake returns column names in UPPERCASE by default, so lookups use
+// `row["COLUMN"] ?? row["column"]` to handle both casing conventions.
+// =============================================================================
+
+import * as Builder from "@notionhq/workers/builder"
+
+/**
+ * Convert a raw Snowflake row into a sync upsert change.
+ *
+ * Returns null for rows with an empty key — they cannot be upserted
+ * deterministically and will be skipped. Filter the result array with
+ * `.flatMap(row => { const c = rowToChange(row); return c ? [c] : [] })`.
+ */
+export function rowToChange(row: Record<string, unknown>) {
+  const rawKey = row["ID"] ?? row["id"]
+  if (rawKey == null || rawKey === "") {
+    // Skip rows with no ID — upserts require a stable key.
+    return null
+  }
+
+  const updatedAt = dateOnly(row["UPDATED_AT"] ?? row["updated_at"])
+
+  return {
+    type: "upsert" as const,
+    key: str(rawKey),
+    properties: {
+      Name: Builder.title(str(row["NAME"] ?? row["name"])),
+      ID: Builder.richText(str(row["ID"] ?? row["id"])),
+      Email: Builder.email(str(row["EMAIL"] ?? row["email"])),
+      Status: Builder.richText(str(row["STATUS"] ?? row["status"])),
+      // Builder.date requires a non-empty YYYY-MM-DD string. When the source
+      // column is null, spread nothing so the property is omitted from the
+      // change rather than passed as an empty or invalid value.
+      ...(updatedAt ? { "Updated At": Builder.date(updatedAt) } : {}),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Coerce any value to a non-null string. */
+function str(value: unknown): string {
+  if (value == null) return ""
+  return String(value)
+}
+
+/**
+ * Extract a YYYY-MM-DD date string from a value that may be:
+ *   - already a YYYY-MM-DD string
+ *   - an ISO 8601 timestamp ("2024-03-15T12:00:00Z")
+ *   - a Date object
+ *   - null / undefined (returns "" — caller treats "" as "omit")
+ */
+function dateOnly(value: unknown): string {
+  if (value == null) return ""
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10)
+  }
+  const s = String(value).trim()
+  if (!s) return ""
+  // ISO timestamp — take the date part before the T.
+  if (s.includes("T")) return s.slice(0, 10)
+  // Already YYYY-MM-DD (or close enough).
+  return s.slice(0, 10)
+}

--- a/examples/workers/syncs/snowflake-sync/test.ts
+++ b/examples/workers/syncs/snowflake-sync/test.ts
@@ -1,0 +1,130 @@
+// Offline tests for the snowflake-sync worker.
+// No Snowflake connection is made — all assertions run against pure functions.
+// Run: npm test  (or: npx tsx test.ts)
+
+import { buildPageSql } from "./src/snowflake.js"
+import { rowToChange } from "./src/transform.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buildPageSql — wraps query in a subquery with LIMIT/OFFSET
+// ---------------------------------------------------------------------------
+
+console.log("buildPageSql:")
+
+ok(
+  "wraps query with LIMIT and OFFSET",
+  buildPageSql("SELECT id FROM t", 200, 0) ===
+    "SELECT * FROM (\nSELECT id FROM t\n) AS src LIMIT 200 OFFSET 0"
+)
+
+ok(
+  "strips a trailing semicolon",
+  buildPageSql("SELECT id FROM t;", 200, 0) ===
+    "SELECT * FROM (\nSELECT id FROM t\n) AS src LIMIT 200 OFFSET 0"
+)
+
+ok(
+  "strips semicolon with trailing whitespace",
+  buildPageSql("SELECT id FROM t ;  ", 200, 0) ===
+    "SELECT * FROM (\nSELECT id FROM t\n) AS src LIMIT 200 OFFSET 0"
+)
+
+ok(
+  "applies non-zero offset",
+  buildPageSql("SELECT id FROM t", 200, 400) ===
+    "SELECT * FROM (\nSELECT id FROM t\n) AS src LIMIT 200 OFFSET 400"
+)
+
+ok(
+  "preserves a trailing line comment (comment cannot swallow LIMIT)",
+  buildPageSql("SELECT id FROM t -- filter", 50, 0) ===
+    "SELECT * FROM (\nSELECT id FROM t -- filter\n) AS src LIMIT 50 OFFSET 0"
+)
+
+// ---------------------------------------------------------------------------
+// rowToChange — maps Snowflake row to a sync upsert change
+// ---------------------------------------------------------------------------
+
+console.log("rowToChange — UPPERCASE keys (Snowflake default):")
+
+const uppercaseRow = {
+  ID: "user-1",
+  NAME: "Alice",
+  EMAIL: "alice@example.com",
+  STATUS: "Active",
+  UPDATED_AT: "2024-03-15",
+}
+
+const upperChange = rowToChange(uppercaseRow)
+
+ok("returns non-null", upperChange !== null)
+ok("type is upsert", upperChange?.type === "upsert")
+ok("key equals ID", upperChange?.key === "user-1")
+ok(
+  "Name property set",
+  (upperChange?.properties.Name as { content?: string } | undefined)
+    ?.content === "Alice" ||
+    JSON.stringify(upperChange?.properties.Name).includes("Alice")
+)
+ok(
+  "Email property set",
+  JSON.stringify(upperChange?.properties.Email).includes("alice@example.com")
+)
+ok(
+  "Status property set",
+  JSON.stringify(upperChange?.properties.Status).includes("Active")
+)
+ok(
+  "Updated At property set",
+  JSON.stringify(upperChange?.properties["Updated At"]).includes("2024-03-15")
+)
+
+console.log("rowToChange — lowercase keys:")
+
+const lowercaseRow = {
+  id: "user-2",
+  name: "Bob",
+  email: "bob@example.com",
+  status: "Inactive",
+  updated_at: "2024-06-01T08:00:00Z",
+}
+
+const lowerChange = rowToChange(lowercaseRow)
+
+ok("returns non-null", lowerChange !== null)
+ok("key equals id", lowerChange?.key === "user-2")
+ok(
+  "Updated At truncates ISO timestamp to date",
+  JSON.stringify(lowerChange?.properties["Updated At"]).includes("2024-06-01")
+)
+
+console.log("rowToChange — edge cases:")
+
+ok("null ID returns null", rowToChange({ ID: null, NAME: "Ghost" }) === null)
+ok(
+  "missing ID returns null",
+  rowToChange({ NAME: "No ID Row" } as Record<string, unknown>) === null
+)
+ok("empty string ID returns null", rowToChange({ ID: "" }) === null)
+
+ok(
+  "null UPDATED_AT omits the Updated At property",
+  rowToChange({ ID: "x", UPDATED_AT: null })?.properties["Updated At"] ===
+    undefined
+)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/syncs/snowflake-sync/tsconfig.json
+++ b/examples/workers/syncs/snowflake-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds `examples/workers/syncs/snowflake-sync/` — a complete, runnable warehouse→Notion sync. It reads a configurable Snowflake query (`SNOWFLAKE_SYNC_QUERY`) using the same key-pair auth as the `snowflake-query` tool, and syncs the rows into a **managed** Notion database via `worker.database` + `worker.sync`. Paginated with `LIMIT`/`OFFSET` (200/page), `mode: "replace"`.

`schema.ts` and `transform.ts` are a worked example (columns `id, name, email, status, updated_at`) with prominent "edit to match your query's columns" guidance. Runnable once `SNOWFLAKE_*` env is set; the README notes the real read boundary is the Snowflake role's grants (use a read-only role) and points at incremental-mode + cursor as a follow-up for large/changing tables.

## Verification

- `npm run check`, `npm run build`, `npm test` (19 offline tests: the `LIMIT`/`OFFSET` page-SQL builder + row→property mapping, incl. Snowflake UPPERCASE keys and null-date handling), `prettier --check`, `markdownlint` — all clean
- Deploy-smoke: deployed to dev; `sync snowflakeSync` discovered (`snowflake-sdk` bundles fine; env is validated lazily so discovery works without creds). A full run requires `SNOWFLAKE_*` credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
