### PR TITLE
Add Snowflake sync worker example

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -6,6 +6,7 @@ This directory contains example [Notion workers](https://developers.notion.com/d
 
 The [syncs](syncs/) directory includes one-way sync examples that bring data from external systems into Notion databases:
 
+- **[snowflake](syncs/snowflake/)**: One-way sync that runs a `SELECT` against a Snowflake warehouse and writes the rows into a Notion database (defaults to syncing your table catalog)
 - **[zendesk](syncs/zendesk/)**: One-way sync from Zendesk tickets into a Notion database _(coming soon)_
 - **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
 - **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_

--- a/examples/workers/syncs/snowflake/.env.example
+++ b/examples/workers/syncs/snowflake/.env.example
@@ -1,0 +1,26 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Required
+SNOWFLAKE_ACCOUNT=
+SNOWFLAKE_USER=
+SNOWFLAKE_WAREHOUSE=
+# Paste the full PEM. Newlines may be written as literal \n — the worker normalizes them.
+SNOWFLAKE_PRIVATE_KEY=
+
+# The default query lists tables in your current schema, so set these two so
+# CURRENT_SCHEMA() resolves. (They're also the default context for any query.)
+SNOWFLAKE_DATABASE=
+SNOWFLAKE_SCHEMA=
+
+# Optional
+# SNOWFLAKE_PRIVATE_KEY_PASS=
+# SNOWFLAKE_ROLE=
+# Statement timeout in seconds (capped at 300).
+# SNOWFLAKE_QUERY_TIMEOUT_SECONDS=60
+
+# Override the SELECT the sync runs. Omit it to use the built-in table-catalog
+# query. Do NOT include LIMIT/OFFSET — the sync paginates for you. If you change
+# the columns here, update the schema and mapping in src/index.ts too.
+# SNOWFLAKE_SYNC_QUERY=SELECT ID, NAME, AMOUNT FROM MY_DB.PUBLIC.ORDERS ORDER BY ID

--- a/examples/workers/syncs/snowflake/.gitignore
+++ b/examples/workers/syncs/snowflake/.gitignore
@@ -1,0 +1,11 @@
+# Secrets — never commit these
+.env
+workers.json
+
+# Private keys — never commit these
+*.p8
+rsa_key*
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/snowflake/README.md
+++ b/examples/workers/syncs/snowflake/README.md
@@ -1,0 +1,162 @@
+# Worker Sync: Snowflake
+
+A Notion worker sync that runs a single `SELECT` against your Snowflake warehouse and writes each row into a Notion database, keeping it up to date on a schedule.
+
+Out of the box it syncs your **table catalog** — the tables and views in your configured database/schema, from `INFORMATION_SCHEMA.TABLES`. That query needs no special grants (any role can read the `INFORMATION_SCHEMA` of a database it can use), so it works on any account without setup beyond credentials. Point it at your own query when you're ready.
+
+## How it works
+
+- `worker.database(...)` declares the Notion database (its title, primary key, and property schema). Notion creates and migrates this database for you on deploy.
+- `worker.sync(...)` runs on a schedule, calls `runQuery` for a page of rows, and returns them as `upsert` changes keyed by the primary key.
+- The sync uses **`mode: "replace"`** because a plain `SELECT` has no change feed: each cycle re-pulls the full result set, and rows that no longer appear are deleted.
+- Pagination is done with `LIMIT ... OFFSET`. Each `execute` returns one page plus a `nextState` offset; the runtime calls `execute` again until a page comes back short.
+
+```
+src/
+  index.ts       Worker: the database schema, the sync, and the row → property mapping
+  snowflake.ts   Connection, query execution, and result normalization
+```
+
+The default query lists tables in the connection's current schema, so it relies on `SNOWFLAKE_DATABASE` and `SNOWFLAKE_SCHEMA` being set (so `CURRENT_SCHEMA()` resolves). It maps each row to: `Name` (table name), `Full Name` (the fully-qualified name, used as the primary key), `Schema`, `Type` (`BASE TABLE` / `VIEW`), and `Rows` (row count).
+
+## Set up Snowflake
+
+The worker connects as a Snowflake user, so give it a dedicated read-only one scoped to just the data the sync should see.
+
+Run this in a worksheet, replacing `MY_DB` with the database you want to sync:
+
+```sql
+USE ROLE SECURITYADMIN;
+CREATE ROLE IF NOT EXISTS NOTION_SYNC_READONLY;
+
+CREATE WAREHOUSE IF NOT EXISTS NOTION_SYNC_WH
+  WITH WAREHOUSE_SIZE = 'XSMALL'
+  AUTO_SUSPEND = 60
+  AUTO_RESUME = TRUE
+  INITIALLY_SUSPENDED = TRUE;
+GRANT USAGE ON WAREHOUSE NOTION_SYNC_WH TO ROLE NOTION_SYNC_READONLY;
+
+-- USAGE lets the role see the catalog; SELECT is needed once you query real tables.
+GRANT USAGE ON DATABASE MY_DB TO ROLE NOTION_SYNC_READONLY;
+GRANT USAGE ON ALL SCHEMAS IN DATABASE MY_DB TO ROLE NOTION_SYNC_READONLY;
+GRANT SELECT ON ALL TABLES IN DATABASE MY_DB TO ROLE NOTION_SYNC_READONLY;
+GRANT SELECT ON ALL VIEWS IN DATABASE MY_DB TO ROLE NOTION_SYNC_READONLY;
+
+USE ROLE USERADMIN;
+CREATE USER IF NOT EXISTS NOTION_SYNC_SVC
+  DEFAULT_ROLE = NOTION_SYNC_READONLY
+  DEFAULT_WAREHOUSE = NOTION_SYNC_WH;
+GRANT ROLE NOTION_SYNC_READONLY TO USER NOTION_SYNC_SVC;
+```
+
+### Key-pair authentication
+
+The worker authenticates with an RSA key pair rather than a password. Generate one:
+
+```zsh
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Attach the public key to the service user. Paste the body of `rsa_key.pub` without the `BEGIN`/`END` lines:
+
+```sql
+ALTER USER NOTION_SYNC_SVC SET RSA_PUBLIC_KEY='MIIBIjANBgkqh...';
+```
+
+`rsa_key.p8` stays on your machine and is only ever passed to the worker as a secret. The `.gitignore` here ignores `*.p8` and `rsa_key*` so it won't get committed by accident.
+
+## Setup
+
+### 1. Install the Notion Workers CLI
+
+```zsh
+npm install -g @notionhq/workers-cli
+```
+
+### 2. Clone and install
+
+```zsh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/workers/syncs/snowflake
+npm install
+```
+
+### 3. Connect to your workspace
+
+```zsh
+ntn login
+```
+
+### 4. Deploy
+
+```zsh
+ntn workers deploy --name snowflake-sync
+```
+
+On first deploy, Notion creates the **Snowflake Tables** database for you.
+
+### 5. Set the connection secrets
+
+These are worker secrets and never live in the repo (`.env` and `workers.json` are gitignored):
+
+```zsh
+ntn workers env set SNOWFLAKE_ACCOUNT=your_org-your_account
+ntn workers env set SNOWFLAKE_USER=NOTION_SYNC_SVC
+ntn workers env set SNOWFLAKE_WAREHOUSE=NOTION_SYNC_WH
+ntn workers env set SNOWFLAKE_PRIVATE_KEY="$(cat rsa_key.p8)"
+
+# The default query lists tables in this schema, so set both:
+ntn workers env set SNOWFLAKE_DATABASE=MY_DB
+ntn workers env set SNOWFLAKE_SCHEMA=PUBLIC
+
+# Optional:
+ntn workers env set SNOWFLAKE_ROLE=NOTION_SYNC_READONLY
+```
+
+`SNOWFLAKE_ACCOUNT` is the `orgname-account_name` identifier ([docs](https://docs.snowflake.com/en/user-guide/admin-account-identifier)). Other optional secrets: `SNOWFLAKE_PRIVATE_KEY_PASS` if the key is encrypted, and `SNOWFLAKE_QUERY_TIMEOUT_SECONDS` (default 60, capped at 300).
+
+### 6. Trigger the first run
+
+The sync runs hourly by default. To pull immediately:
+
+```zsh
+ntn workers sync trigger snowflakeSync
+ntn workers sync status snowflakeSync
+```
+
+## Sync your own data
+
+The default query and the database schema are wired together in `src/index.ts`. To sync a different table:
+
+1. Set `SNOWFLAKE_SYNC_QUERY` to your `SELECT`. Leave off `LIMIT`/`OFFSET` (the sync adds them to paginate) and include an `ORDER BY` so paging is stable.
+
+   ```zsh
+   ntn workers env set SNOWFLAKE_SYNC_QUERY="SELECT ID, NAME, AMOUNT FROM MY_DB.PUBLIC.ORDERS ORDER BY ID"
+   ```
+
+2. Update the `worker.database(...)` schema, its `primaryKeyProperty`, and the `rowToEntry` mapping in `src/index.ts` so the property names and types match your columns.
+3. Redeploy. Schema changes migrate the database; `ntn workers deploy` does **not** reset sync state, so use `ntn workers sync state reset snowflakeSync` if you want a clean re-pull.
+
+## Test locally
+
+Copy `.env.example` to `.env`, fill in your values, and preview the sync without writing to Notion:
+
+```zsh
+ntn workers sync trigger snowflakeSync --preview
+```
+
+Preview calls `execute` and prints the rows it would produce. Run a real cycle (writes to the database) with `ntn workers sync trigger snowflakeSync`.
+
+## Notes
+
+- **`replace` vs `incremental`:** this example uses `replace` because a generic `SELECT` can't tell you what changed. If your source tracks changes (an `UPDATED_AT` column, a stream, a CDC table), switch to `mode: "incremental"`, filter by a cursor stored in `nextState`, and emit `{ type: "delete", key }` markers for removed rows. See the [Workers sync docs](https://developers.notion.com/docs/workers).
+- **Batch size:** rows are paged at 100 per `execute`. Returning too many changes in one call can fail, so keep batches around this size.
+- **Read-only by design:** the sync only ever reads. A read-only Snowflake role like the one above is what enforces that at the warehouse — not the worker code.
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [Snowflake key-pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth)
+- [Snowflake INFORMATION_SCHEMA](https://docs.snowflake.com/en/sql-reference/info-schema)
+- [Contribute to this cookbook](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/snowflake/package.json
+++ b/examples/workers/syncs/snowflake/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "snowflake-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0",
+    "snowflake-sdk": "^2.4.3"
+  }
+}

--- a/examples/workers/syncs/snowflake/src/index.ts
+++ b/examples/workers/syncs/snowflake/src/index.ts
@@ -1,0 +1,99 @@
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import { runQuery, type JsonValue } from "./snowflake.js"
+
+const worker = new Worker()
+export default worker
+
+// A generic Snowflake → Notion sync. It runs a single SELECT and writes each
+// row to a Notion database. By default it syncs the table catalog of your
+// configured database/schema (INFORMATION_SCHEMA.TABLES) — a query every role
+// can run, so it works out of the box on any account without special grants.
+//
+// To sync your own data instead, set SNOWFLAKE_SYNC_QUERY to your SELECT (no
+// LIMIT / OFFSET — the sync paginates for you) and update the schema and
+// `rowToEntry` mapping below so the columns line up.
+
+// Lists the tables and views in the connection's current schema. Requires
+// SNOWFLAKE_DATABASE and SNOWFLAKE_SCHEMA to be set so CURRENT_SCHEMA() resolves.
+const DEFAULT_QUERY = `SELECT
+		TABLE_CATALOG || '.' || TABLE_SCHEMA || '.' || TABLE_NAME AS FULL_NAME,
+		TABLE_NAME,
+		TABLE_SCHEMA,
+		TABLE_TYPE,
+		COALESCE(ROW_COUNT, 0) AS ROW_COUNT
+	FROM INFORMATION_SCHEMA.TABLES
+	WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+	ORDER BY TABLE_NAME`
+
+const BASE_QUERY = process.env.SNOWFLAKE_SYNC_QUERY?.trim() || DEFAULT_QUERY
+
+// Rows per execute call. The runtime calls execute again with the next offset
+// until a page comes back short, so the whole result set syncs across the cycle.
+const BATCH_SIZE = 100
+
+type SyncState = { offset: number }
+
+const tables = worker.database("snowflakeTables", {
+  type: "managed",
+  initialTitle: "Snowflake Tables",
+  primaryKeyProperty: "Full Name",
+  schema: {
+    properties: {
+      Name: Schema.title(),
+      "Full Name": Schema.richText(),
+      Schema: Schema.richText(),
+      Type: Schema.richText(),
+      Rows: Schema.number(),
+    },
+  },
+})
+
+worker.sync("snowflakeSync", {
+  database: tables,
+  // A plain SELECT has no change feed, so re-pull the full result set each cycle.
+  // After the final page, rows that disappeared from the query are deleted.
+  mode: "replace",
+  // Runs on a schedule; tune to taste ("15m", "1h", "1d", "continuous", ...).
+  schedule: "1h",
+  execute: async (state: SyncState | undefined) => {
+    const offset = state?.offset ?? 0
+    const { rows } = await runQuery(
+      `${BASE_QUERY}\nLIMIT ${BATCH_SIZE} OFFSET ${offset}`
+    )
+
+    const changes = rows.map((row) => ({
+      type: "upsert" as const,
+      key: String(row.FULL_NAME),
+      properties: rowToEntry(row),
+    }))
+
+    const hasMore = rows.length === BATCH_SIZE
+    return {
+      changes,
+      hasMore,
+      nextState: hasMore ? { offset: offset + BATCH_SIZE } : undefined,
+    }
+  },
+})
+
+function rowToEntry(row: Record<string, JsonValue>) {
+  return {
+    Name: Builder.title(str(row.TABLE_NAME)),
+    "Full Name": Builder.richText(str(row.FULL_NAME)),
+    Schema: Builder.richText(str(row.TABLE_SCHEMA)),
+    Type: Builder.richText(str(row.TABLE_TYPE)),
+    Rows: Builder.number(num(row.ROW_COUNT)),
+  }
+}
+
+function str(value: JsonValue): string {
+  return value == null ? "" : String(value)
+}
+
+function num(value: JsonValue): number {
+  const n = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(n) ? n : 0
+}

--- a/examples/workers/syncs/snowflake/src/snowflake.ts
+++ b/examples/workers/syncs/snowflake/src/snowflake.ts
@@ -1,0 +1,135 @@
+import snowflake from "snowflake-sdk"
+
+snowflake.configure({ logLevel: "ERROR" })
+
+const TIMEOUT_SECONDS = Math.min(
+  readPositiveInt("SNOWFLAKE_QUERY_TIMEOUT_SECONDS", 60),
+  300
+)
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type QueryResult = {
+  rows: Record<string, JsonValue>[]
+  rowCount: number
+}
+
+export async function runQuery(sql: string): Promise<QueryResult> {
+  const conn = createConnection()
+  await connect(conn)
+  try {
+    await executeSql(
+      conn,
+      `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${TIMEOUT_SECONDS}`
+    )
+    return await executeSql(conn, sql)
+  } finally {
+    // Don't let a teardown error mask the real query error.
+    await destroy(conn).catch(() => {})
+  }
+}
+
+function createConnection(): snowflake.Connection {
+  const account = process.env.SNOWFLAKE_ACCOUNT ?? ""
+  const username = process.env.SNOWFLAKE_USER ?? ""
+  const warehouse = process.env.SNOWFLAKE_WAREHOUSE ?? ""
+  const privateKey = process.env.SNOWFLAKE_PRIVATE_KEY ?? ""
+  const privateKeyPass = process.env.SNOWFLAKE_PRIVATE_KEY_PASS
+  const database = process.env.SNOWFLAKE_DATABASE
+  const schema = process.env.SNOWFLAKE_SCHEMA
+  const role = process.env.SNOWFLAKE_ROLE
+
+  if (!account || !username || !warehouse || !privateKey) {
+    throw new Error(
+      "Missing Snowflake configuration. Set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_WAREHOUSE, and SNOWFLAKE_PRIVATE_KEY."
+    )
+  }
+
+  return snowflake.createConnection({
+    account,
+    username,
+    warehouse,
+    authenticator: "SNOWFLAKE_JWT",
+    // A key stored as a one-line secret often has its newlines escaped.
+    privateKey: privateKey.replace(/\\n/g, "\n"),
+    ...(privateKeyPass ? { privateKeyPass } : {}),
+    ...(database ? { database } : {}),
+    ...(schema ? { schema } : {}),
+    ...(role ? { role } : {}),
+  })
+}
+
+function connect(conn: snowflake.Connection): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn.connect((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+function destroy(conn: snowflake.Connection): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn.destroy((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+function executeSql(
+  conn: snowflake.Connection,
+  sqlText: string
+): Promise<QueryResult> {
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText,
+      rowMode: "object_with_renamed_duplicated_columns",
+      complete: (err, _stmt, rows) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        const rawRows = (rows ?? []) as Record<string, unknown>[]
+        resolve({
+          rows: rawRows.map(normalizeRow),
+          rowCount: rawRows.length,
+        })
+      },
+    })
+  })
+}
+
+function normalizeRow(row: Record<string, unknown>): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, normalizeValue(value)])
+  )
+}
+
+function normalizeValue(value: unknown): JsonValue {
+  if (value == null) return null
+  if (typeof value === "string") return value
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : String(value)
+  if (typeof value === "boolean") return value
+  if (typeof value === "bigint") return value.toString()
+  if (value instanceof Date) return value.toISOString()
+  if (Buffer.isBuffer(value)) return value.toString("base64")
+  if (Array.isArray(value)) return value.map(normalizeValue)
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        normalizeValue(nested),
+      ])
+    )
+  }
+  return String(value)
+}
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/examples/workers/syncs/snowflake/tsconfig.json
+++ b/examples/workers/syncs/snowflake/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds a new worker **sync** example at `examples/workers/syncs/snowflake/` — a one-way Snowflake → Notion sync that runs a single `SELECT` and writes each row into a managed Notion database. Complements the existing `tools/snowflake-query` example (which reuses the same key-pair `snowflake-sdk` connection approach).

## What it does
- **Default query** syncs your **table catalog** (`INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA()`). Chosen because any role can read `INFORMATION_SCHEMA` of a database it can use — so it runs on any account with no special grants or sample-data share.
- Uses the `worker.database(...)` + `worker.sync(...)` API, `mode: "replace"`, and `LIMIT/OFFSET` pagination.
- `SNOWFLAKE_SYNC_QUERY` env var lets users point it at their own query; README documents updating the schema + `rowToEntry` mapping to match.

## Files
- `src/index.ts` — database schema, sync, and row → property mapping
- `src/snowflake.ts` — key-pair JWT connection, query execution, result normalization
- `README.md`, `.env.example`, `.gitignore`, `package.json`, `tsconfig.json`
- Updates `examples/workers/README.md` to list the new sync

## Testing
- `npm run check` passes (type-check clean).
- Deployed to a scratch worker and ran a real sync cycle: the **unmodified default query** synced 20 real tables into Notion with correct properties (Name, Full Name, Schema, Type, Rows). `snowflake-sdk` confirmed working in the deployed Worker runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)