### PR TITLE
feat(workers): add zendesk sync example

### DIFF
--- a/examples/workers/syncs/zendesk/.env.example
+++ b/examples/workers/syncs/zendesk/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Required
+ZENDESK_SUBDOMAIN=
+ZENDESK_API_TOKEN=
+ZENDESK_API_USER_EMAIL=
+
+# Optional: title for the auto-provisioned Notion database (default: "Support Tickets")
+# ZENDESK_SYNC_DB_TITLE=Support Tickets

--- a/examples/workers/syncs/zendesk/.gitignore
+++ b/examples/workers/syncs/zendesk/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/zendesk/README.md
+++ b/examples/workers/syncs/zendesk/README.md
@@ -1,0 +1,181 @@
+# Worker sync: Zendesk
+
+Syncs Zendesk support tickets into a managed Notion database. The worker
+declares the schema; Notion auto-provisions and owns the database. Every 5
+minutes the worker pages through all tickets using Zendesk's cursor-based
+pagination and upserts each one by ticket ID. Tickets removed from Zendesk are
+removed from the Notion database on the next full sync (`mode: "replace"`).
+
+## Project structure
+
+```text
+src/
+├── index.ts       — worker entry point; registers the database and sync
+├── schema.ts      — Notion database schema (property names and types)
+├── transform.ts   — maps a Zendesk ticket to a sync upsert change
+└── zendesk.ts     — Zendesk API client (auth, pagination, types)
+```
+
+## How it works
+
+1. On each sync run the worker calls the Zendesk List Tickets API
+   (`/api/v2/tickets.json`) with cursor-based pagination (100 tickets per page).
+2. Each ticket is mapped to an `upsert` change keyed by ticket ID.
+3. The platform applies those changes to the managed database and loops until
+   `hasMore` is false.
+
+## Prerequisites
+
+- Node >= 22, npm >= 10.9.2
+- A Zendesk account with API access enabled.
+- The `ntn` CLI installed and authenticated (`ntn auth login`).
+
+## Environment variables
+
+### Required
+
+| Variable                 | Description                                                |
+| ------------------------ | ---------------------------------------------------------- |
+| `ZENDESK_SUBDOMAIN`      | Your Zendesk subdomain (e.g. `acme` for acme.zendesk.com) |
+| `ZENDESK_API_TOKEN`      | Zendesk API token                                          |
+| `ZENDESK_API_USER_EMAIL` | Email of the Zendesk user associated with the API token    |
+
+### Optional
+
+| Variable                 | Default              | Description                                   |
+| ------------------------ | -------------------- | --------------------------------------------- |
+| `ZENDESK_SYNC_DB_TITLE`  | `"Support Tickets"`  | Title of the auto-provisioned Notion database |
+
+Alternatively, you can set `ZENDESK_BASIC_AUTH_TOKEN` (a base64-encoded
+`email:password` string) instead of `ZENDESK_API_TOKEN` + `ZENDESK_API_USER_EMAIL`.
+
+No `NOTION_API_TOKEN` is needed. The platform manages the database and handles
+the Notion credentials automatically.
+
+## Setup and deploy
+
+1. Install the Notion Workers CLI:
+
+   ```sh
+   npm install -g @notionhq/ntn
+   ```
+
+2. Clone and install:
+
+   ```sh
+   cd examples/workers/syncs/zendesk
+   npm install
+   ```
+
+3. Typecheck and test:
+
+   ```sh
+   npm run check
+   npm test
+   ```
+
+4. Log in to Notion:
+
+   ```sh
+   ntn auth login
+   ```
+
+5. Deploy the worker:
+
+   ```sh
+   ntn workers deploy
+   ```
+
+6. Set environment variables on the deployed worker:
+
+   ```sh
+   ntn workers env set ZENDESK_SUBDOMAIN=acme
+   ntn workers env set ZENDESK_API_TOKEN=your-api-token
+   ntn workers env set ZENDESK_API_USER_EMAIL=agent@example.com
+   ```
+
+7. Preview a sync without writing to Notion:
+
+   ```sh
+   ntn workers sync trigger ticketsSync --preview
+   ```
+
+8. Run a real sync:
+
+   ```sh
+   ntn workers sync trigger ticketsSync
+   ```
+
+Once deployed, tickets sync automatically every 5 minutes.
+
+## Adapting the schema
+
+The example syncs these properties:
+
+| Notion property | Zendesk field              | Type        |
+| --------------- | -------------------------- | ----------- |
+| Tickets         | `subject`                  | title       |
+| Ticket ID       | `id`                       | richText    |
+| Ticket link     | `id` (derived URL)         | url         |
+| Status          | `status`                   | select      |
+| Priority        | `priority`                 | select      |
+| CSAT score      | `satisfaction_rating.score` | select      |
+| Feature tags    | `tags`                     | multiSelect |
+| Created at      | `created_at`               | date        |
+
+Each Notion page body is populated with the ticket `description` via
+`pageContentMarkdown`, and `upstreamUpdatedAt` is set from `updated_at` for
+conflict resolution.
+
+To change the schema, edit two files:
+
+**`src/schema.ts`** — declares the Notion database properties. Each key is a
+property name; the value is a Schema factory call. Supported types include
+`Schema.title()`, `Schema.richText()`, `Schema.email()`, `Schema.date()`,
+`Schema.select([...])`, `Schema.multiSelect([...])`, `Schema.number()`,
+`Schema.url()`, and `Schema.checkbox()`.
+
+**`src/transform.ts`** — maps a Zendesk ticket to a sync change. Add or remove
+`Builder.*` calls to match your schema. Optional properties should be spread
+conditionally so they are omitted (not set to empty) when the source field is
+absent.
+
+## Incremental syncs
+
+`mode: "replace"` re-syncs all tickets on every run. For large Zendesk
+instances, switch to `mode: "incremental"` and filter by `updated_at`:
+
+```ts
+// In execute():
+const since = state?.updatedSince ?? "1970-01-01"
+const url = `...&sort_by=updated_at&sort_order=asc&start_time=${since}`
+// ...
+return {
+  changes,
+  hasMore: false,
+  nextState: { updatedSince: latestUpdatedAt },
+}
+```
+
+Incremental mode also supports `type: "delete"` changes for tickets that have
+been permanently deleted from Zendesk.
+
+## Local testing
+
+Run offline tests (no Zendesk connection needed):
+
+```sh
+npm test
+```
+
+Test the worker locally against a real Zendesk instance:
+
+```sh
+ntn workers exec ticketsSync --local
+```
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [Zendesk API — List Tickets](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#list-tickets)
+- [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/zendesk/README.md
+++ b/examples/workers/syncs/zendesk/README.md
@@ -12,11 +12,11 @@ schemas and Notion creates and manages each database for you (these are called
 
 | Database | Zendesk resource | Schedule | Plan |
 | --- | --- | --- | --- |
-| **Support Tickets** | Tickets | Every 5 min | All |
-| **Zendesk Organizations** | Organizations | Every 1 hr | All |
-| **Zendesk Users** | Users (agents + end-users) | Every 1 hr | All |
-| **Zendesk CSAT Ratings** | Satisfaction Ratings | Every 30 min | Professional+ |
-| **Zendesk Ticket Metrics** | Ticket Metrics | Every 30 min | All |
+| **Support Tickets** | Tickets | Every 2 min | All |
+| **Zendesk Organizations** | Organizations | Every 5 min | All |
+| **Zendesk Users** | Users (agents + end-users) | Every 5 min | All |
+| **Zendesk CSAT Ratings** | Satisfaction Ratings | Every 5 min | Professional+ |
+| **Zendesk Ticket Metrics** | Ticket Metrics | Every 5 min | All |
 | **Zendesk SLA Policies** | SLA Policies | Manual trigger | Professional+ |
 
 ### Support Tickets
@@ -24,21 +24,23 @@ schemas and Notion creates and manages each database for you (these are called
 | Notion property | Zendesk field               | Type        |
 | --------------- | --------------------------- | ----------- |
 | Subject         | `subject`                   | title       |
-| Ticket ID       | `id`                        | richText    |
-| Ticket link     | clickable link to ticket    | url         |
-| Type            | `type`                      | select      |
 | Status          | `status`                    | select      |
 | Priority        | `priority`                  | select      |
-| CSAT score      | `satisfaction_rating.score` | select      |
-| Tags            | `tags`                      | multiSelect |
-| Channel         | `via.channel`               | select      |
 | Assignee        | agent name (resolved)       | richText    |
-| Requester       | requester name (resolved)   | richText    |
-| Created at      | `created_at`                | date        |
+| Group           | group name (resolved)       | richText    |
+| Ticket link     | clickable link to ticket    | url         |
 | Updated at      | `updated_at`                | date        |
+| Requester       | requester name (resolved)   | richText    |
+| Organization    | org name (resolved)         | richText    |
+| Type            | `type`                      | select      |
+| Channel         | `via.channel`               | select      |
+| Tags            | `tags`                      | multiSelect |
+| CSAT score      | `satisfaction_rating.score` | select      |
+| Created at      | `created_at`                | date        |
+| Ticket ID       | `id`                        | richText    |
 
-Each page body contains the ticket description. Assignee and requester show
-real names (resolved via Zendesk's
+Each page body contains the ticket description. Assignee, requester, group,
+and organization show real names (resolved via Zendesk's
 [sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/),
 with no extra API calls).
 
@@ -47,76 +49,85 @@ with no extra API calls).
 | Notion property | Zendesk field   | Type        |
 | --------------- | --------------- | ----------- |
 | Name            | `name`          | title       |
-| Org ID          | `id`            | richText    |
 | Domains         | `domain_names`  | richText    |
 | Tags            | `tags`          | multiSelect |
 | Details         | `details`       | richText    |
-| Created at      | `created_at`    | date        |
 | Updated at      | `updated_at`    | date        |
+| Org ID          | `id`            | richText    |
+| Created at      | `created_at`    | date        |
 
 Page body contains the organization's `notes` field.
 
 ### Zendesk Users
 
-| Notion property | Zendesk field   | Type       |
-| --------------- | --------------- | ---------- |
-| Name            | `name`          | title      |
-| User ID         | `id`            | richText   |
-| Email           | `email`         | email      |
-| Role            | `role`          | select     |
-| Phone           | `phone`         | richText   |
-| Tags            | `tags`          | multiSelect |
-| Suspended       | `suspended`     | checkbox   |
-| Last login      | `last_login_at` | date       |
-| Created at      | `created_at`    | date       |
-| Updated at      | `updated_at`    | date       |
+| Notion property  | Zendesk field      | Type        |
+| ---------------- | ------------------ | ----------- |
+| Name             | `name`             | title       |
+| Role             | `role`             | select      |
+| Email            | `email`            | email       |
+| Last login       | `last_login_at`    | date        |
+| Tags             | `tags`             | multiSelect |
+| Updated at       | `updated_at`       | date        |
+| Organization ID  | `organization_id`  | richText    |
+| Phone            | `phone`            | richText    |
+| Suspended        | `suspended`        | checkbox    |
+| User ID          | `id`               | richText    |
+| Created at       | `created_at`       | date        |
 
 ### Zendesk CSAT Ratings
 
 | Notion property | Zendesk field   | Type     |
 | --------------- | --------------- | -------- |
 | Comment         | `comment`       | title    |
-| Rating ID       | `id`            | richText |
-| Ticket ID       | `ticket_id`     | richText |
 | Score           | `score`         | select   |
+| Ticket ID       | `ticket_id`     | richText |
 | Reason          | `reason`        | richText |
-| Requester ID    | `requester_id`  | richText |
-| Assignee ID     | `assignee_id`   | richText |
 | Created at      | `created_at`    | date     |
-
-Requester and assignee are numeric IDs — cross-reference with the Users
-database for names.
+| Rating ID       | `id`            | richText |
 
 ### Zendesk Ticket Metrics
 
-| Notion property        | Zendesk field                          | Type   |
-| ---------------------- | -------------------------------------- | ------ |
-| Ticket ID              | `ticket_id`                            | title  |
-| First Reply (min)      | `reply_time_in_minutes.calendar`       | number |
-| First Resolution (min) | `first_resolution_time_in_minutes`     | number |
-| Full Resolution (min)  | `full_resolution_time_in_minutes`      | number |
-| Agent Wait (min)       | `agent_wait_time_in_minutes.calendar`  | number |
-| Requester Wait (min)   | `requester_wait_time_in_minutes`       | number |
-| Reopens                | `reopens`                              | number |
-| Replies                | `replies`                              | number |
-| Created at             | `created_at`                           | date   |
-| Updated at             | `updated_at`                           | date   |
+| Notion property        | Zendesk field                            | Type   |
+| ---------------------- | ---------------------------------------- | ------ |
+| Ticket ID              | `ticket_id`                              | title  |
+| First Reply (min)      | `reply_time_in_minutes.calendar`         | number |
+| Full Resolution (min)  | `full_resolution_time_in_minutes`        | number |
+| Reopens                | `reopens`                                | number |
+| Agents Touched         | `assignee_stations`                      | number |
+| Groups Touched         | `group_stations`                         | number |
+| Solved at              | `solved_at`                              | date   |
+| First Resolution (min) | `first_resolution_time_in_minutes`       | number |
+| Replies                | `replies`                                | number |
+| On Hold (min)          | `on_hold_time_in_minutes.calendar`       | number |
+| Agent Wait (min)       | `agent_wait_time_in_minutes.calendar`    | number |
+| Requester Wait (min)   | `requester_wait_time_in_minutes`         | number |
+| Updated at             | `updated_at`                             | date   |
+| Created at             | `created_at`                             | date   |
 
 Times use calendar minutes by default. To switch to business hours, change
 `.calendar` to `.business` in `src/ticket-metrics.ts`.
 
 ### Zendesk SLA Policies
 
-| Notion property | Zendesk field | Type     |
-| --------------- | ------------- | -------- |
-| Title           | `title`       | title    |
-| Policy ID       | `id`          | richText |
-| Position        | `position`    | number   |
-| Created at      | `created_at`  | date     |
-| Updated at      | `updated_at`  | date     |
+| Notion property              | Zendesk field                  | Type     |
+| ---------------------------- | ------------------------------ | -------- |
+| Title                        | `title`                        | title    |
+| Urgent First Reply (min)     | `policy_metrics` (flattened)   | number   |
+| High First Reply (min)       | `policy_metrics` (flattened)   | number   |
+| Normal First Reply (min)     | `policy_metrics` (flattened)   | number   |
+| Low First Reply (min)        | `policy_metrics` (flattened)   | number   |
+| Position                     | `position`                     | number   |
+| Urgent Resolution (min)      | `policy_metrics` (flattened)   | number   |
+| High Resolution (min)        | `policy_metrics` (flattened)   | number   |
+| Normal Resolution (min)      | `policy_metrics` (flattened)   | number   |
+| Low Resolution (min)         | `policy_metrics` (flattened)   | number   |
+| Policy ID                    | `id`                           | richText |
+| Updated at                   | `updated_at`                   | date     |
+| Created at                   | `created_at`                   | date     |
 
-Page body contains the policy description and a table of SLA targets per
-priority and metric.
+SLA targets are flattened from the `policy_metrics` array into individual
+columns by priority level, so managers can compare targets at a glance.
+Page body contains the policy description.
 
 ## Project structure
 

--- a/examples/workers/syncs/zendesk/README.md
+++ b/examples/workers/syncs/zendesk/README.md
@@ -1,17 +1,25 @@
 # Worker sync: Zendesk
 
-Syncs your Zendesk support tickets into a Notion database that stays
-up to date automatically. Once deployed, the worker checks Zendesk every 5
-minutes and creates or updates a Notion page for each ticket — with the
-subject, status, priority, assignee, tags, CSAT score, and more.
+Syncs your Zendesk data into Notion databases that stay up to date
+automatically. One deploy gives you six synced databases covering tickets,
+organizations, users, CSAT ratings, ticket metrics, and SLA policies.
 
-You don't need to create the Notion database yourself. The worker declares the
-schema and Notion creates and manages the database for you (this is called a
-"managed database").
+You don't need to create the Notion databases yourself. The worker declares the
+schemas and Notion creates and manages each database for you (these are called
+"managed databases").
 
 ## What you get
 
-A Notion database with one page per Zendesk ticket, including:
+| Database | Zendesk resource | Schedule | Plan |
+| --- | --- | --- | --- |
+| **Support Tickets** | Tickets | Every 5 min | All |
+| **Zendesk Organizations** | Organizations | Every 1 hr | All |
+| **Zendesk Users** | Users (agents + end-users) | Every 1 hr | All |
+| **Zendesk CSAT Ratings** | Satisfaction Ratings | Every 30 min | Professional+ |
+| **Zendesk Ticket Metrics** | Ticket Metrics | Every 30 min | All |
+| **Zendesk SLA Policies** | SLA Policies | Manual trigger | Professional+ |
+
+### Support Tickets
 
 | Notion property | Zendesk field               | Type        |
 | --------------- | --------------------------- | ----------- |
@@ -32,35 +40,122 @@ A Notion database with one page per Zendesk ticket, including:
 Each page body contains the ticket description. Assignee and requester show
 real names (resolved via Zendesk's
 [sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/),
-with no extra API calls). Tags are synced as-is from Zendesk — the multiSelect
-options are created automatically as new tags appear.
+with no extra API calls).
+
+### Zendesk Organizations
+
+| Notion property | Zendesk field   | Type        |
+| --------------- | --------------- | ----------- |
+| Name            | `name`          | title       |
+| Org ID          | `id`            | richText    |
+| Domains         | `domain_names`  | richText    |
+| Tags            | `tags`          | multiSelect |
+| Details         | `details`       | richText    |
+| Created at      | `created_at`    | date        |
+| Updated at      | `updated_at`    | date        |
+
+Page body contains the organization's `notes` field.
+
+### Zendesk Users
+
+| Notion property | Zendesk field   | Type       |
+| --------------- | --------------- | ---------- |
+| Name            | `name`          | title      |
+| User ID         | `id`            | richText   |
+| Email           | `email`         | email      |
+| Role            | `role`          | select     |
+| Phone           | `phone`         | richText   |
+| Tags            | `tags`          | multiSelect |
+| Suspended       | `suspended`     | checkbox   |
+| Last login      | `last_login_at` | date       |
+| Created at      | `created_at`    | date       |
+| Updated at      | `updated_at`    | date       |
+
+### Zendesk CSAT Ratings
+
+| Notion property | Zendesk field   | Type     |
+| --------------- | --------------- | -------- |
+| Comment         | `comment`       | title    |
+| Rating ID       | `id`            | richText |
+| Ticket ID       | `ticket_id`     | richText |
+| Score           | `score`         | select   |
+| Reason          | `reason`        | richText |
+| Requester ID    | `requester_id`  | richText |
+| Assignee ID     | `assignee_id`   | richText |
+| Created at      | `created_at`    | date     |
+
+Requester and assignee are numeric IDs — cross-reference with the Users
+database for names.
+
+### Zendesk Ticket Metrics
+
+| Notion property        | Zendesk field                          | Type   |
+| ---------------------- | -------------------------------------- | ------ |
+| Ticket ID              | `ticket_id`                            | title  |
+| First Reply (min)      | `reply_time_in_minutes.calendar`       | number |
+| First Resolution (min) | `first_resolution_time_in_minutes`     | number |
+| Full Resolution (min)  | `full_resolution_time_in_minutes`      | number |
+| Agent Wait (min)       | `agent_wait_time_in_minutes.calendar`  | number |
+| Requester Wait (min)   | `requester_wait_time_in_minutes`       | number |
+| Reopens                | `reopens`                              | number |
+| Replies                | `replies`                              | number |
+| Created at             | `created_at`                           | date   |
+| Updated at             | `updated_at`                           | date   |
+
+Times use calendar minutes by default. To switch to business hours, change
+`.calendar` to `.business` in `src/ticket-metrics.ts`.
+
+### Zendesk SLA Policies
+
+| Notion property | Zendesk field | Type     |
+| --------------- | ------------- | -------- |
+| Title           | `title`       | title    |
+| Policy ID       | `id`          | richText |
+| Position        | `position`    | number   |
+| Created at      | `created_at`  | date     |
+| Updated at      | `updated_at`  | date     |
+
+Page body contains the policy description and a table of SLA targets per
+priority and metric.
 
 ## Project structure
 
 ```text
 src/
-├── index.ts       — worker entry point; registers the database and sync
-├── schema.ts      — Notion database schema (property names and types)
-├── transform.ts   — maps a Zendesk ticket to a sync upsert change
-└── zendesk.ts     — Zendesk API client (auth, pagination, types)
+├── index.ts                 — registers all databases and syncs
+├── zendesk.ts               — API client (auth, pagination, types for all resources)
+├── schema.ts                — ticket schema
+├── transform.ts             — ticket transform + shared helpers (dateOnly, formatLabel)
+├── organizations.ts         — organization schema + transform
+├── users.ts                 — user schema + transform
+├── satisfaction-ratings.ts  — CSAT rating schema + transform
+├── ticket-metrics.ts        — ticket metric schema + transform
+└── sla-policies.ts          — SLA policy schema + transform
 ```
 
 ## How it works
 
-1. Every 5 minutes (or on manual trigger), the worker calls the Zendesk List
-   Tickets API with cursor-based pagination (100 tickets per page).
-2. Each ticket is converted to an `upsert` — a create-or-update operation keyed
-   by ticket ID, so the same ticket is never duplicated.
+1. On each sync run, the worker calls the appropriate Zendesk API endpoint
+   with cursor-based pagination (100 records per page).
+2. Each record is converted to an `upsert` — a create-or-update operation keyed
+   by the resource ID, so the same record is never duplicated.
 3. The platform applies the changes to the managed database and loops until all
    pages have been fetched.
-4. Because the sync uses `mode: "replace"`, tickets deleted from Zendesk are
+4. Because all syncs use `mode: "replace"`, records deleted from Zendesk are
    automatically removed from the Notion database on the next full sync.
+
+All syncs share a single rate limiter (`worker.pacer`) to stay within Zendesk's
+API limits (400 requests per minute on most plans).
 
 ## Prerequisites
 
 - Node >= 22, npm >= 10.9.2
 - A Zendesk account with API access enabled
 - The `ntn` CLI installed and authenticated (`ntn auth login`)
+
+Satisfaction Ratings and SLA Policies require a Zendesk Professional+ plan.
+If your plan doesn't include these features, those syncs will return errors
+from the API — you can remove them from `src/index.ts` if needed.
 
 ### Getting a Zendesk API token
 
@@ -84,7 +179,7 @@ src/
 
 | Variable                 | Default              | Description                                   |
 | ------------------------ | -------------------- | --------------------------------------------- |
-| `ZENDESK_SYNC_DB_TITLE`  | `"Support Tickets"`  | Title of the auto-provisioned Notion database |
+| `ZENDESK_SYNC_DB_TITLE`  | `"Support Tickets"`  | Title of the tickets Notion database          |
 
 Alternatively, you can set `ZENDESK_BASIC_AUTH_TOKEN` (a base64-encoded
 `email:password` string) instead of `ZENDESK_API_TOKEN` + `ZENDESK_API_USER_EMAIL`.
@@ -138,6 +233,8 @@ automatically.
 
    ```sh
    ntn workers sync trigger ticketsSync --preview
+   ntn workers sync trigger organizationsSync --preview
+   ntn workers sync trigger usersSync --preview
    ```
 
 8. Run a real sync:
@@ -146,28 +243,49 @@ automatically.
    ntn workers sync trigger ticketsSync
    ```
 
-Once deployed, tickets sync automatically every 5 minutes. A "Support Tickets"
-database will appear in your Notion workspace after the first sync.
+Once deployed, syncs run automatically on their configured schedules. Six
+databases will appear in your Notion workspace after the first run.
+
+## Triggering syncs manually
+
+```sh
+ntn workers sync trigger ticketsSync
+ntn workers sync trigger organizationsSync
+ntn workers sync trigger usersSync
+ntn workers sync trigger satisfactionRatingsSync
+ntn workers sync trigger ticketMetricsSync
+ntn workers sync trigger slaPoliciesSync
+```
+
+SLA Policies only runs on manual trigger (it's a small, rarely-changing
+dataset).
 
 ## Adapting the schema
 
-To change which fields are synced, edit two files:
+Each resource has its own file with a schema and transform function. To change
+which fields are synced for a resource, edit that resource's file:
 
-**`src/schema.ts`** — declares the Notion database properties. Each key is a
-property name; the value is a Schema factory call (`Schema.title()`,
-`Schema.richText()`, `Schema.select([...])`, `Schema.multiSelect([...])`,
-`Schema.date()`, `Schema.number()`, `Schema.url()`, `Schema.email()`,
-`Schema.checkbox()`). The `PRIMARY_KEY` property is used by the platform to
-match incoming data to existing pages — don't remove it.
+| Resource | File |
+| --- | --- |
+| Tickets | `src/schema.ts` + `src/transform.ts` |
+| Organizations | `src/organizations.ts` |
+| Users | `src/users.ts` |
+| CSAT Ratings | `src/satisfaction-ratings.ts` |
+| Ticket Metrics | `src/ticket-metrics.ts` |
+| SLA Policies | `src/sla-policies.ts` |
 
-**`src/transform.ts`** — maps a Zendesk ticket object to a sync change. Add or
-remove `Builder.*` calls to match your schema. Optional properties should be
-spread conditionally so they are omitted (not set to empty) when the source
-field is absent.
+To add a new Zendesk field to any resource:
+
+1. Add the field to the resource's type in `src/zendesk.ts`
+2. Add a property to the schema with the appropriate `Schema.*` type
+3. Add a `Builder.*` call in the transform function
+
+The `PRIMARY_KEY` property is used by the platform to match incoming data to
+existing pages — don't remove it.
 
 ## Incremental syncs for large instances
 
-`mode: "replace"` re-syncs all tickets on every run. For large Zendesk
+`mode: "replace"` re-syncs all records on every run. For large Zendesk
 instances, switch to `mode: "incremental"` and filter by `updated_at`:
 
 ```ts
@@ -182,8 +300,8 @@ return {
 }
 ```
 
-Incremental mode also supports `type: "delete"` changes for tickets that have
-been permanently deleted from Zendesk.
+Incremental mode also supports `type: "delete"` changes for records removed
+from the source.
 
 ## Local testing
 
@@ -193,14 +311,20 @@ Run offline tests (no Zendesk connection needed):
 npm test
 ```
 
-Test the worker locally against a real Zendesk instance:
+Test a specific sync locally against a real Zendesk instance:
 
 ```sh
 ntn workers exec ticketsSync --local
+ntn workers exec organizationsSync --local
 ```
 
 ## Learn more
 
 - [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Zendesk API — List Tickets](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#list-tickets)
+- [Zendesk API — Tickets](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/)
+- [Zendesk API — Organizations](https://developer.zendesk.com/api-reference/ticketing/organizations/organizations/)
+- [Zendesk API — Users](https://developer.zendesk.com/api-reference/ticketing/users/users/)
+- [Zendesk API — Satisfaction Ratings](https://developer.zendesk.com/api-reference/ticketing/ticket-management/satisfaction_ratings/)
+- [Zendesk API — Ticket Metrics](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metrics/)
+- [Zendesk API — SLA Policies](https://developer.zendesk.com/api-reference/ticketing/business-rules/sla_policies/)
 - [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/zendesk/README.md
+++ b/examples/workers/syncs/zendesk/README.md
@@ -112,20 +112,30 @@ Once deployed, tickets sync automatically every 5 minutes.
 
 The example syncs these properties:
 
-| Notion property | Zendesk field              | Type        |
-| --------------- | -------------------------- | ----------- |
-| Tickets         | `subject`                  | title       |
-| Ticket ID       | `id`                       | richText    |
-| Ticket link     | `id` (derived URL)         | url         |
-| Status          | `status`                   | select      |
-| Priority        | `priority`                 | select      |
+| Notion property | Zendesk field               | Type        |
+| --------------- | --------------------------- | ----------- |
+| Tickets         | `subject`                   | title       |
+| Ticket ID       | `id`                        | richText    |
+| Ticket link     | `id` (derived URL)          | url         |
+| Type            | `type`                      | select      |
+| Status          | `status`                    | select      |
+| Priority        | `priority`                  | select      |
 | CSAT score      | `satisfaction_rating.score` | select      |
-| Feature tags    | `tags`                     | multiSelect |
-| Created at      | `created_at`               | date        |
+| Feature tags    | `tags`                      | multiSelect |
+| Channel         | `via.channel`               | select      |
+| Assignee ID     | `assignee_id`               | richText    |
+| Requester ID    | `requester_id`              | richText    |
+| Created at      | `created_at`                | date        |
 
 Each Notion page body is populated with the ticket `description` via
 `pageContentMarkdown`, and `upstreamUpdatedAt` is set from `updated_at` for
 conflict resolution.
+
+Assignee ID and Requester ID are synced as numeric IDs. To display agent and
+requester names instead, extend `fetchTicketsPage` to use Zendesk's sideloading
+(`?include=users`) and resolve the IDs in `ticketToChange`. See the
+[Zendesk sideloading docs](https://developer.zendesk.com/api-reference/introduction/side-loading/)
+for details.
 
 To change the schema, edit two files:
 

--- a/examples/workers/syncs/zendesk/README.md
+++ b/examples/workers/syncs/zendesk/README.md
@@ -123,19 +123,19 @@ The example syncs these properties:
 | CSAT score      | `satisfaction_rating.score` | select      |
 | Feature tags    | `tags`                      | multiSelect |
 | Channel         | `via.channel`               | select      |
-| Assignee ID     | `assignee_id`               | richText    |
-| Requester ID    | `requester_id`              | richText    |
+| Assignee        | `assignee_id` (resolved)    | richText    |
+| Requester       | `requester_id` (resolved)   | richText    |
 | Created at      | `created_at`                | date        |
 
 Each Notion page body is populated with the ticket `description` via
 `pageContentMarkdown`, and `upstreamUpdatedAt` is set from `updated_at` for
 conflict resolution.
 
-Assignee ID and Requester ID are synced as numeric IDs. To display agent and
-requester names instead, extend `fetchTicketsPage` to use Zendesk's sideloading
-(`?include=users`) and resolve the IDs in `ticketToChange`. See the
-[Zendesk sideloading docs](https://developer.zendesk.com/api-reference/introduction/side-loading/)
-for details.
+Assignee and Requester names are resolved via Zendesk's
+[sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/)
+(`?include=users`), which returns user objects alongside tickets in the same API
+call with no extra requests. If a user ID is missing from the sideloaded data,
+the numeric ID is used as a fallback.
 
 To change the schema, edit two files:
 

--- a/examples/workers/syncs/zendesk/README.md
+++ b/examples/workers/syncs/zendesk/README.md
@@ -1,10 +1,39 @@
 # Worker sync: Zendesk
 
-Syncs Zendesk support tickets into a managed Notion database. The worker
-declares the schema; Notion auto-provisions and owns the database. Every 5
-minutes the worker pages through all tickets using Zendesk's cursor-based
-pagination and upserts each one by ticket ID. Tickets removed from Zendesk are
-removed from the Notion database on the next full sync (`mode: "replace"`).
+Syncs your Zendesk support tickets into a Notion database that stays
+up to date automatically. Once deployed, the worker checks Zendesk every 5
+minutes and creates or updates a Notion page for each ticket — with the
+subject, status, priority, assignee, tags, CSAT score, and more.
+
+You don't need to create the Notion database yourself. The worker declares the
+schema and Notion creates and manages the database for you (this is called a
+"managed database").
+
+## What you get
+
+A Notion database with one page per Zendesk ticket, including:
+
+| Notion property | Zendesk field               | Type        |
+| --------------- | --------------------------- | ----------- |
+| Subject         | `subject`                   | title       |
+| Ticket ID       | `id`                        | richText    |
+| Ticket link     | clickable link to ticket    | url         |
+| Type            | `type`                      | select      |
+| Status          | `status`                    | select      |
+| Priority        | `priority`                  | select      |
+| CSAT score      | `satisfaction_rating.score` | select      |
+| Tags            | `tags`                      | multiSelect |
+| Channel         | `via.channel`               | select      |
+| Assignee        | agent name (resolved)       | richText    |
+| Requester       | requester name (resolved)   | richText    |
+| Created at      | `created_at`                | date        |
+| Updated at      | `updated_at`                | date        |
+
+Each page body contains the ticket description. Assignee and requester show
+real names (resolved via Zendesk's
+[sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/),
+with no extra API calls). Tags are synced as-is from Zendesk — the multiSelect
+options are created automatically as new tags appear.
 
 ## Project structure
 
@@ -18,17 +47,28 @@ src/
 
 ## How it works
 
-1. On each sync run the worker calls the Zendesk List Tickets API
-   (`/api/v2/tickets.json`) with cursor-based pagination (100 tickets per page).
-2. Each ticket is mapped to an `upsert` change keyed by ticket ID.
-3. The platform applies those changes to the managed database and loops until
-   `hasMore` is false.
+1. Every 5 minutes (or on manual trigger), the worker calls the Zendesk List
+   Tickets API with cursor-based pagination (100 tickets per page).
+2. Each ticket is converted to an `upsert` — a create-or-update operation keyed
+   by ticket ID, so the same ticket is never duplicated.
+3. The platform applies the changes to the managed database and loops until all
+   pages have been fetched.
+4. Because the sync uses `mode: "replace"`, tickets deleted from Zendesk are
+   automatically removed from the Notion database on the next full sync.
 
 ## Prerequisites
 
 - Node >= 22, npm >= 10.9.2
-- A Zendesk account with API access enabled.
-- The `ntn` CLI installed and authenticated (`ntn auth login`).
+- A Zendesk account with API access enabled
+- The `ntn` CLI installed and authenticated (`ntn auth login`)
+
+### Getting a Zendesk API token
+
+1. In Zendesk, go to **Admin Center > Apps and integrations > Zendesk API**
+2. Enable **Token Access** if it isn't already
+3. Click **Add API token**, give it a name, and copy the token
+4. Note the email address of the admin account — you'll need it for
+   `ZENDESK_API_USER_EMAIL`
 
 ## Environment variables
 
@@ -37,7 +77,7 @@ src/
 | Variable                 | Description                                                |
 | ------------------------ | ---------------------------------------------------------- |
 | `ZENDESK_SUBDOMAIN`      | Your Zendesk subdomain (e.g. `acme` for acme.zendesk.com) |
-| `ZENDESK_API_TOKEN`      | Zendesk API token                                          |
+| `ZENDESK_API_TOKEN`      | Zendesk API token (from Admin Center)                      |
 | `ZENDESK_API_USER_EMAIL` | Email of the Zendesk user associated with the API token    |
 
 ### Optional
@@ -49,8 +89,8 @@ src/
 Alternatively, you can set `ZENDESK_BASIC_AUTH_TOKEN` (a base64-encoded
 `email:password` string) instead of `ZENDESK_API_TOKEN` + `ZENDESK_API_USER_EMAIL`.
 
-No `NOTION_API_TOKEN` is needed. The platform manages the database and handles
-the Notion credentials automatically.
+No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
+automatically.
 
 ## Setup and deploy
 
@@ -106,51 +146,26 @@ the Notion credentials automatically.
    ntn workers sync trigger ticketsSync
    ```
 
-Once deployed, tickets sync automatically every 5 minutes.
+Once deployed, tickets sync automatically every 5 minutes. A "Support Tickets"
+database will appear in your Notion workspace after the first sync.
 
 ## Adapting the schema
 
-The example syncs these properties:
-
-| Notion property | Zendesk field               | Type        |
-| --------------- | --------------------------- | ----------- |
-| Tickets         | `subject`                   | title       |
-| Ticket ID       | `id`                        | richText    |
-| Ticket link     | `id` (derived URL)          | url         |
-| Type            | `type`                      | select      |
-| Status          | `status`                    | select      |
-| Priority        | `priority`                  | select      |
-| CSAT score      | `satisfaction_rating.score` | select      |
-| Feature tags    | `tags`                      | multiSelect |
-| Channel         | `via.channel`               | select      |
-| Assignee        | `assignee_id` (resolved)    | richText    |
-| Requester       | `requester_id` (resolved)   | richText    |
-| Created at      | `created_at`                | date        |
-
-Each Notion page body is populated with the ticket `description` via
-`pageContentMarkdown`, and `upstreamUpdatedAt` is set from `updated_at` for
-conflict resolution.
-
-Assignee and Requester names are resolved via Zendesk's
-[sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/)
-(`?include=users`), which returns user objects alongside tickets in the same API
-call with no extra requests. If a user ID is missing from the sideloaded data,
-the numeric ID is used as a fallback.
-
-To change the schema, edit two files:
+To change which fields are synced, edit two files:
 
 **`src/schema.ts`** — declares the Notion database properties. Each key is a
-property name; the value is a Schema factory call. Supported types include
-`Schema.title()`, `Schema.richText()`, `Schema.email()`, `Schema.date()`,
-`Schema.select([...])`, `Schema.multiSelect([...])`, `Schema.number()`,
-`Schema.url()`, and `Schema.checkbox()`.
+property name; the value is a Schema factory call (`Schema.title()`,
+`Schema.richText()`, `Schema.select([...])`, `Schema.multiSelect([...])`,
+`Schema.date()`, `Schema.number()`, `Schema.url()`, `Schema.email()`,
+`Schema.checkbox()`). The `PRIMARY_KEY` property is used by the platform to
+match incoming data to existing pages — don't remove it.
 
-**`src/transform.ts`** — maps a Zendesk ticket to a sync change. Add or remove
-`Builder.*` calls to match your schema. Optional properties should be spread
-conditionally so they are omitted (not set to empty) when the source field is
-absent.
+**`src/transform.ts`** — maps a Zendesk ticket object to a sync change. Add or
+remove `Builder.*` calls to match your schema. Optional properties should be
+spread conditionally so they are omitted (not set to empty) when the source
+field is absent.
 
-## Incremental syncs
+## Incremental syncs for large instances
 
 `mode: "replace"` re-syncs all tickets on every run. For large Zendesk
 instances, switch to `mode: "incremental"` and filter by `updated_at`:

--- a/examples/workers/syncs/zendesk/package.json
+++ b/examples/workers/syncs/zendesk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "zendesk",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/zendesk/src/index.ts
+++ b/examples/workers/syncs/zendesk/src/index.ts
@@ -33,7 +33,9 @@ worker.sync("ticketsSync", {
     const subdomain = requireSubdomain()
     const page = await fetchTicketsPage(state?.cursor)
 
-    const changes = page.tickets.map((t) => ticketToChange(t, subdomain))
+    const changes = page.tickets.map((t) =>
+      ticketToChange(t, subdomain, page.users)
+    )
 
     return {
       changes,

--- a/examples/workers/syncs/zendesk/src/index.ts
+++ b/examples/workers/syncs/zendesk/src/index.ts
@@ -1,13 +1,54 @@
-// Entry point — wires together the database schema, Zendesk API client, and
-// sync schedule. Most customization happens in schema.ts and transform.ts;
-// this file rarely needs changes unless you're adjusting the sync mode,
-// schedule, or pagination strategy.
+// Entry point — wires together all synced resources: tickets, organizations,
+// users, satisfaction ratings, ticket metrics, and SLA policies.
+//
+// Each resource has its own schema + transform file. This file registers the
+// managed databases and sync schedules. Most customization happens in those
+// per-resource files; this file rarely needs changes unless you're adjusting
+// sync modes, schedules, or adding a new resource.
 
 import { Worker } from "@notionhq/workers"
 
-import { fetchTicketsPage, requireSubdomain } from "./zendesk.js"
+import {
+  fetchTicketsPage,
+  fetchOrganizationsPage,
+  fetchUsersPage,
+  fetchSatisfactionRatingsPage,
+  fetchTicketMetricsPage,
+  fetchSlaPolicies,
+  requireSubdomain,
+} from "./zendesk.js"
 import { INITIAL_TITLE, PRIMARY_KEY, ticketSchema } from "./schema.js"
 import { ticketToChange } from "./transform.js"
+import {
+  INITIAL_TITLE as ORGS_TITLE,
+  PRIMARY_KEY as ORGS_PK,
+  organizationSchema,
+  organizationToChange,
+} from "./organizations.js"
+import {
+  INITIAL_TITLE as USERS_TITLE,
+  PRIMARY_KEY as USERS_PK,
+  userSchema,
+  userToChange,
+} from "./users.js"
+import {
+  INITIAL_TITLE as CSAT_TITLE,
+  PRIMARY_KEY as CSAT_PK,
+  satisfactionRatingSchema,
+  satisfactionRatingToChange,
+} from "./satisfaction-ratings.js"
+import {
+  INITIAL_TITLE as METRICS_TITLE,
+  PRIMARY_KEY as METRICS_PK,
+  ticketMetricSchema,
+  ticketMetricToChange,
+} from "./ticket-metrics.js"
+import {
+  INITIAL_TITLE as SLA_TITLE,
+  PRIMARY_KEY as SLA_PK,
+  slaPolicySchema,
+  slaPolicyToChange,
+} from "./sla-policies.js"
 
 type SyncState = {
   cursor: string
@@ -16,10 +57,15 @@ type SyncState = {
 const worker = new Worker()
 
 // Zendesk rate-limits API calls to 400 requests per minute on most plans.
+// All syncs share this pacer so they don't exceed the limit collectively.
 const pacer = worker.pacer("zendesk", {
   allowedRequests: 380,
   intervalMs: 60_000,
 })
+
+// ---------------------------------------------------------------------------
+// Tickets — core support ticket data (all plans)
+// ---------------------------------------------------------------------------
 
 const tickets = worker.database("tickets", {
   type: "managed",
@@ -30,28 +76,152 @@ const tickets = worker.database("tickets", {
 
 worker.sync("ticketsSync", {
   database: tickets,
-  // "replace" re-syncs all tickets each run and auto-deletes removed ones.
-  // Switch to "incremental" for large instances — see README.
   mode: "replace",
-  // How often the sync runs. Options: "manual", "5m", "15m", "30m", "1h", "1d".
   schedule: "5m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
-
     const subdomain = requireSubdomain()
     const page = await fetchTicketsPage(state?.cursor)
-
     const changes = page.tickets.map((t) =>
       ticketToChange(t, subdomain, page.users)
     )
-
-    // The platform calls execute() repeatedly while hasMore is true,
-    // passing nextState back as the state parameter on the next call.
     return {
       changes,
       hasMore: page.hasMore,
       nextState: page.nextCursor ? { cursor: page.nextCursor } : undefined,
     }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Organizations — companies / accounts (all plans)
+// ---------------------------------------------------------------------------
+
+const organizations = worker.database("organizations", {
+  type: "managed",
+  initialTitle: ORGS_TITLE,
+  primaryKeyProperty: ORGS_PK,
+  schema: organizationSchema,
+})
+
+worker.sync("organizationsSync", {
+  database: organizations,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const page = await fetchOrganizationsPage(state?.cursor)
+    const changes = page.organizations.map(organizationToChange)
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.nextCursor ? { cursor: page.nextCursor } : undefined,
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Users — agents and end-users (all plans)
+// ---------------------------------------------------------------------------
+
+const users = worker.database("users", {
+  type: "managed",
+  initialTitle: USERS_TITLE,
+  primaryKeyProperty: USERS_PK,
+  schema: userSchema,
+})
+
+worker.sync("usersSync", {
+  database: users,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const page = await fetchUsersPage(state?.cursor)
+    const changes = page.users.map(userToChange)
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.nextCursor ? { cursor: page.nextCursor } : undefined,
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Satisfaction Ratings — CSAT responses with comments (Professional+ plans)
+// ---------------------------------------------------------------------------
+
+const satisfactionRatings = worker.database("satisfactionRatings", {
+  type: "managed",
+  initialTitle: CSAT_TITLE,
+  primaryKeyProperty: CSAT_PK,
+  schema: satisfactionRatingSchema,
+})
+
+worker.sync("satisfactionRatingsSync", {
+  database: satisfactionRatings,
+  mode: "replace",
+  schedule: "30m",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const page = await fetchSatisfactionRatingsPage(state?.cursor)
+    const changes = page.ratings.map(satisfactionRatingToChange)
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.nextCursor ? { cursor: page.nextCursor } : undefined,
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Ticket Metrics — response times, resolution times, reopens (all plans)
+// ---------------------------------------------------------------------------
+
+const ticketMetrics = worker.database("ticketMetrics", {
+  type: "managed",
+  initialTitle: METRICS_TITLE,
+  primaryKeyProperty: METRICS_PK,
+  schema: ticketMetricSchema,
+})
+
+worker.sync("ticketMetricsSync", {
+  database: ticketMetrics,
+  mode: "replace",
+  schedule: "30m",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const page = await fetchTicketMetricsPage(state?.cursor)
+    const changes = page.metrics.map(ticketMetricToChange)
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.nextCursor ? { cursor: page.nextCursor } : undefined,
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// SLA Policies — SLA definitions and targets (Professional+ plans)
+// Small, rarely-changing dataset — manual trigger only.
+// ---------------------------------------------------------------------------
+
+const slaPolicies = worker.database("slaPolicies", {
+  type: "managed",
+  initialTitle: SLA_TITLE,
+  primaryKeyProperty: SLA_PK,
+  schema: slaPolicySchema,
+})
+
+worker.sync("slaPoliciesSync", {
+  database: slaPolicies,
+  mode: "replace",
+  schedule: "manual",
+  execute: async () => {
+    await pacer.wait()
+    const policies = await fetchSlaPolicies()
+    const changes = policies.map(slaPolicyToChange)
+    return { changes, hasMore: false }
   },
 })
 

--- a/examples/workers/syncs/zendesk/src/index.ts
+++ b/examples/workers/syncs/zendesk/src/index.ts
@@ -77,7 +77,7 @@ const tickets = worker.database("tickets", {
 worker.sync("ticketsSync", {
   database: tickets,
   mode: "replace",
-  schedule: "5m",
+  schedule: "2m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const subdomain = requireSubdomain()
@@ -107,7 +107,7 @@ const organizations = worker.database("organizations", {
 worker.sync("organizationsSync", {
   database: organizations,
   mode: "replace",
-  schedule: "1h",
+  schedule: "5m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const page = await fetchOrganizationsPage(state?.cursor)
@@ -134,7 +134,7 @@ const users = worker.database("users", {
 worker.sync("usersSync", {
   database: users,
   mode: "replace",
-  schedule: "1h",
+  schedule: "5m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const page = await fetchUsersPage(state?.cursor)
@@ -161,7 +161,7 @@ const satisfactionRatings = worker.database("satisfactionRatings", {
 worker.sync("satisfactionRatingsSync", {
   database: satisfactionRatings,
   mode: "replace",
-  schedule: "30m",
+  schedule: "5m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const page = await fetchSatisfactionRatingsPage(state?.cursor)
@@ -188,7 +188,7 @@ const ticketMetrics = worker.database("ticketMetrics", {
 worker.sync("ticketMetricsSync", {
   database: ticketMetrics,
   mode: "replace",
-  schedule: "30m",
+  schedule: "5m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const page = await fetchTicketMetricsPage(state?.cursor)
@@ -216,7 +216,7 @@ const slaPolicies = worker.database("slaPolicies", {
 worker.sync("slaPoliciesSync", {
   database: slaPolicies,
   mode: "replace",
-  schedule: "manual",
+  schedule: "1d",
   execute: async () => {
     await pacer.wait()
     const policies = await fetchSlaPolicies()

--- a/examples/workers/syncs/zendesk/src/index.ts
+++ b/examples/workers/syncs/zendesk/src/index.ts
@@ -1,3 +1,8 @@
+// Entry point — wires together the database schema, Zendesk API client, and
+// sync schedule. Most customization happens in schema.ts and transform.ts;
+// this file rarely needs changes unless you're adjusting the sync mode,
+// schedule, or pagination strategy.
+
 import { Worker } from "@notionhq/workers"
 
 import { fetchTicketsPage, requireSubdomain } from "./zendesk.js"
@@ -25,7 +30,10 @@ const tickets = worker.database("tickets", {
 
 worker.sync("ticketsSync", {
   database: tickets,
+  // "replace" re-syncs all tickets each run and auto-deletes removed ones.
+  // Switch to "incremental" for large instances — see README.
   mode: "replace",
+  // How often the sync runs. Options: "manual", "5m", "15m", "30m", "1h", "1d".
   schedule: "5m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
@@ -37,6 +45,8 @@ worker.sync("ticketsSync", {
       ticketToChange(t, subdomain, page.users)
     )
 
+    // The platform calls execute() repeatedly while hasMore is true,
+    // passing nextState back as the state parameter on the next call.
     return {
       changes,
       hasMore: page.hasMore,

--- a/examples/workers/syncs/zendesk/src/index.ts
+++ b/examples/workers/syncs/zendesk/src/index.ts
@@ -1,0 +1,46 @@
+import { Worker } from "@notionhq/workers"
+
+import { fetchTicketsPage, requireSubdomain } from "./zendesk.js"
+import { INITIAL_TITLE, PRIMARY_KEY, ticketSchema } from "./schema.js"
+import { ticketToChange } from "./transform.js"
+
+type SyncState = {
+  cursor: string
+}
+
+const worker = new Worker()
+
+// Zendesk rate-limits API calls to 400 requests per minute on most plans.
+const pacer = worker.pacer("zendesk", {
+  allowedRequests: 380,
+  intervalMs: 60_000,
+})
+
+const tickets = worker.database("tickets", {
+  type: "managed",
+  initialTitle: INITIAL_TITLE,
+  primaryKeyProperty: PRIMARY_KEY,
+  schema: ticketSchema,
+})
+
+worker.sync("ticketsSync", {
+  database: tickets,
+  mode: "replace",
+  schedule: "5m",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+
+    const subdomain = requireSubdomain()
+    const page = await fetchTicketsPage(state?.cursor)
+
+    const changes = page.tickets.map((t) => ticketToChange(t, subdomain))
+
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.nextCursor ? { cursor: page.nextCursor } : undefined,
+    }
+  },
+})
+
+export default worker

--- a/examples/workers/syncs/zendesk/src/index.ts
+++ b/examples/workers/syncs/zendesk/src/index.ts
@@ -83,7 +83,7 @@ worker.sync("ticketsSync", {
     const subdomain = requireSubdomain()
     const page = await fetchTicketsPage(state?.cursor)
     const changes = page.tickets.map((t) =>
-      ticketToChange(t, subdomain, page.users)
+      ticketToChange(t, subdomain, page.users, page.groups, page.orgs)
     )
     return {
       changes,

--- a/examples/workers/syncs/zendesk/src/organizations.ts
+++ b/examples/workers/syncs/zendesk/src/organizations.ts
@@ -6,6 +6,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
 import type { ZendeskOrganization } from "./zendesk.js"
 import { dateOnly } from "./transform.js"
 
@@ -13,10 +14,9 @@ export const INITIAL_TITLE = "Zendesk Organizations"
 export const PRIMARY_KEY = "Org ID"
 
 export const organizationSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("briefcase"),
   properties: {
     Name: Schema.title(),
-
-    "Org ID": Schema.richText(),
 
     Domains: Schema.richText(),
 
@@ -24,9 +24,11 @@ export const organizationSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Details: Schema.richText(),
 
-    "Created at": Schema.date(),
-
     "Updated at": Schema.date(),
+
+    "Org ID": Schema.richText(),
+
+    "Created at": Schema.date(),
   },
 }
 

--- a/examples/workers/syncs/zendesk/src/organizations.ts
+++ b/examples/workers/syncs/zendesk/src/organizations.ts
@@ -1,0 +1,55 @@
+// Organizations sync — tracks the companies in your Zendesk instance.
+// Useful for B2B support teams to see accounts, domains, and tags in Notion.
+//
+// Schema and transform follow the same pattern as tickets — see schema.ts
+// and transform.ts for the conventions.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import type { ZendeskOrganization } from "./zendesk.js"
+import { dateOnly } from "./transform.js"
+
+export const INITIAL_TITLE = "Zendesk Organizations"
+export const PRIMARY_KEY = "Org ID"
+
+export const organizationSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    Name: Schema.title(),
+
+    "Org ID": Schema.richText(),
+
+    Domains: Schema.richText(),
+
+    Tags: Schema.multiSelect([]),
+
+    Details: Schema.richText(),
+
+    "Created at": Schema.date(),
+
+    "Updated at": Schema.date(),
+  },
+}
+
+export function organizationToChange(org: ZendeskOrganization) {
+  return {
+    type: "upsert" as const,
+    key: String(org.id),
+    upstreamUpdatedAt: org.updated_at,
+    pageContentMarkdown: org.notes ?? "",
+    properties: {
+      Name: Builder.title(org.name ?? ""),
+      "Org ID": Builder.richText(String(org.id)),
+      ...(org.domain_names.length > 0
+        ? { Domains: Builder.richText(org.domain_names.join(", ")) }
+        : {}),
+      ...(org.tags.length > 0
+        ? { Tags: Builder.multiSelect(...org.tags) }
+        : {}),
+      ...(org.details
+        ? { Details: Builder.richText(org.details) }
+        : {}),
+      "Created at": Builder.date(dateOnly(org.created_at)),
+      "Updated at": Builder.date(dateOnly(org.updated_at)),
+    },
+  }
+}

--- a/examples/workers/syncs/zendesk/src/satisfaction-ratings.ts
+++ b/examples/workers/syncs/zendesk/src/satisfaction-ratings.ts
@@ -1,9 +1,5 @@
 // Satisfaction Ratings sync — tracks CSAT responses with customer comments.
 // Requires Zendesk Professional+ plan (CSAT is a paid feature).
-//
-// Requester and assignee are stored as numeric IDs. Cross-reference with the
-// Users sync for names, or extend fetchSatisfactionRatingsPage to sideload
-// users if your Zendesk plan supports it.
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
@@ -38,10 +34,6 @@ export const satisfactionRatingSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     "Created at": Schema.date(),
 
     "Rating ID": Schema.richText(),
-
-    "Requester ID": Schema.richText(),
-
-    "Assignee ID": Schema.richText(),
   },
 }
 
@@ -60,8 +52,6 @@ export function satisfactionRatingToChange(rating: ZendeskSatisfactionRating) {
       ...(rating.reason
         ? { Reason: Builder.richText(rating.reason) }
         : {}),
-      "Requester ID": Builder.richText(String(rating.requester_id)),
-      "Assignee ID": Builder.richText(String(rating.assignee_id)),
       "Created at": Builder.date(dateOnly(rating.created_at)),
     },
   }

--- a/examples/workers/syncs/zendesk/src/satisfaction-ratings.ts
+++ b/examples/workers/syncs/zendesk/src/satisfaction-ratings.ts
@@ -1,0 +1,66 @@
+// Satisfaction Ratings sync — tracks CSAT responses with customer comments.
+// Requires Zendesk Professional+ plan (CSAT is a paid feature).
+//
+// Requester and assignee are stored as numeric IDs. Cross-reference with the
+// Users sync for names, or extend fetchSatisfactionRatingsPage to sideload
+// users if your Zendesk plan supports it.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import type { ZendeskSatisfactionRating } from "./zendesk.js"
+import { dateOnly } from "./transform.js"
+
+const SCORE_LABELS: Record<string, string> = {
+  good: "Satisfied",
+  bad: "Not satisfied",
+  offered: "Pending",
+}
+
+export const INITIAL_TITLE = "Zendesk CSAT Ratings"
+export const PRIMARY_KEY = "Rating ID"
+
+export const satisfactionRatingSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    Comment: Schema.title(),
+
+    "Rating ID": Schema.richText(),
+
+    "Ticket ID": Schema.richText(),
+
+    Score: Schema.select([
+      { name: "Satisfied" },
+      { name: "Not satisfied" },
+      { name: "Pending" },
+    ]),
+
+    Reason: Schema.richText(),
+
+    "Requester ID": Schema.richText(),
+
+    "Assignee ID": Schema.richText(),
+
+    "Created at": Schema.date(),
+  },
+}
+
+export function satisfactionRatingToChange(rating: ZendeskSatisfactionRating) {
+  const scoreLabel = SCORE_LABELS[rating.score] ?? rating.score
+
+  return {
+    type: "upsert" as const,
+    key: String(rating.id),
+    upstreamUpdatedAt: rating.updated_at,
+    properties: {
+      Comment: Builder.title(rating.comment ?? "(no comment)"),
+      "Rating ID": Builder.richText(String(rating.id)),
+      "Ticket ID": Builder.richText(String(rating.ticket_id)),
+      Score: Builder.select(scoreLabel),
+      ...(rating.reason
+        ? { Reason: Builder.richText(rating.reason) }
+        : {}),
+      "Requester ID": Builder.richText(String(rating.requester_id)),
+      "Assignee ID": Builder.richText(String(rating.assignee_id)),
+      "Created at": Builder.date(dateOnly(rating.created_at)),
+    },
+  }
+}

--- a/examples/workers/syncs/zendesk/src/satisfaction-ratings.ts
+++ b/examples/workers/syncs/zendesk/src/satisfaction-ratings.ts
@@ -7,6 +7,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
 import type { ZendeskSatisfactionRating } from "./zendesk.js"
 import { dateOnly } from "./transform.js"
 
@@ -20,12 +21,9 @@ export const INITIAL_TITLE = "Zendesk CSAT Ratings"
 export const PRIMARY_KEY = "Rating ID"
 
 export const satisfactionRatingSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("thumbs-up"),
   properties: {
     Comment: Schema.title(),
-
-    "Rating ID": Schema.richText(),
-
-    "Ticket ID": Schema.richText(),
 
     Score: Schema.select([
       { name: "Satisfied" },
@@ -33,13 +31,17 @@ export const satisfactionRatingSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Pending" },
     ]),
 
+    "Ticket ID": Schema.richText(),
+
     Reason: Schema.richText(),
+
+    "Created at": Schema.date(),
+
+    "Rating ID": Schema.richText(),
 
     "Requester ID": Schema.richText(),
 
     "Assignee ID": Schema.richText(),
-
-    "Created at": Schema.date(),
   },
 }
 

--- a/examples/workers/syncs/zendesk/src/schema.ts
+++ b/examples/workers/syncs/zendesk/src/schema.ts
@@ -21,6 +21,7 @@
 //   Schema.checkbox()         — boolean
 
 import * as Schema from "@notionhq/workers/schema"
+import { notionIcon } from "@notionhq/workers"
 
 export const INITIAL_TITLE =
   process.env.ZENDESK_SYNC_DB_TITLE ?? "Support Tickets"
@@ -31,19 +32,9 @@ export const INITIAL_TITLE =
 export const PRIMARY_KEY = "Ticket ID"
 
 export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("ticket"),
   properties: {
     Subject: Schema.title(),
-
-    "Ticket ID": Schema.richText(),
-
-    "Ticket link": Schema.url(),
-
-    Type: Schema.select([
-      { name: "Problem" },
-      { name: "Incident" },
-      { name: "Question" },
-      { name: "Task" },
-    ]),
 
     Status: Schema.select([
       { name: "New" },
@@ -59,6 +50,23 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "High" },
       { name: "Normal" },
       { name: "Low" },
+    ]),
+
+    Assignee: Schema.richText(),
+
+    Requester: Schema.richText(),
+
+    "Updated at": Schema.date(),
+
+    "Ticket ID": Schema.richText(),
+
+    "Ticket link": Schema.url(),
+
+    Type: Schema.select([
+      { name: "Problem" },
+      { name: "Incident" },
+      { name: "Question" },
+      { name: "Task" },
     ]),
 
     "CSAT score": Schema.select([
@@ -81,12 +89,6 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Mobile" },
     ]),
 
-    Assignee: Schema.richText(),
-
-    Requester: Schema.richText(),
-
     "Created at": Schema.date(),
-
-    "Updated at": Schema.date(),
   },
 }

--- a/examples/workers/syncs/zendesk/src/schema.ts
+++ b/examples/workers/syncs/zendesk/src/schema.ts
@@ -1,13 +1,38 @@
+// Schema defines the Notion database structure. Each property here becomes a
+// column in the managed database.
+//
+// IMPORTANT: This file and transform.ts must stay in sync. Every property name
+// here needs a matching Builder.* call in ticketToChange(), and vice versa.
+//
+// To add a new Zendesk field:
+//   1. Add the field to ZendeskTicket in zendesk.ts
+//   2. Add a property here with the appropriate Schema type
+//   3. Add a Builder.* call in transform.ts
+//
+// Available Schema types:
+//   Schema.title()            — page title (exactly one required)
+//   Schema.richText()         — free-form text
+//   Schema.number()           — numeric value
+//   Schema.select([...])      — single-select; options auto-create if not listed
+//   Schema.multiSelect([...]) — multi-select; options auto-create if not listed
+//   Schema.date()             — date or datetime
+//   Schema.url()              — URL link
+//   Schema.email()            — email address
+//   Schema.checkbox()         — boolean
+
 import * as Schema from "@notionhq/workers/schema"
 
 export const INITIAL_TITLE =
   process.env.ZENDESK_SYNC_DB_TITLE ?? "Support Tickets"
 
+// Ticket ID is the upsert key — the platform matches incoming changes against
+// this property to decide whether to create or update a page. The `key` field
+// in each change (see transform.ts) must contain the value for this property.
 export const PRIMARY_KEY = "Ticket ID"
 
 export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
   properties: {
-    Tickets: Schema.title(),
+    Subject: Schema.title(),
 
     "Ticket ID": Schema.richText(),
 
@@ -37,24 +62,22 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     ]),
 
     "CSAT score": Schema.select([
-      { name: "Good" },
-      { name: "Bad" },
-      { name: "Offered" },
+      { name: "Satisfied" },
+      { name: "Not satisfied" },
+      { name: "Pending" },
     ]),
 
-    "Feature tags": Schema.multiSelect([
-      { name: "Account access" },
-      { name: "Billing" },
-      { name: "Bug report" },
-      { name: "Feature request" },
-      { name: "Integration" },
-    ]),
+    // Options are created automatically from your Zendesk tags — no need to
+    // list them here. Add seed values if you want them pre-created.
+    Tags: Schema.multiSelect([]),
 
+    // Common channels are seeded below. If your Zendesk uses additional
+    // channels (e.g. "Mobile SDK"), the select option is created automatically.
     Channel: Schema.select([
       { name: "Web" },
       { name: "Email" },
       { name: "Chat" },
-      { name: "Api" },
+      { name: "API" },
       { name: "Mobile" },
     ]),
 
@@ -63,5 +86,7 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     Requester: Schema.richText(),
 
     "Created at": Schema.date(),
+
+    "Updated at": Schema.date(),
   },
 }

--- a/examples/workers/syncs/zendesk/src/schema.ts
+++ b/examples/workers/syncs/zendesk/src/schema.ts
@@ -54,13 +54,15 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Assignee: Schema.richText(),
 
-    Requester: Schema.richText(),
+    Group: Schema.richText(),
+
+    "Ticket link": Schema.url(),
 
     "Updated at": Schema.date(),
 
-    "Ticket ID": Schema.richText(),
+    Requester: Schema.richText(),
 
-    "Ticket link": Schema.url(),
+    Organization: Schema.richText(),
 
     Type: Schema.select([
       { name: "Problem" },
@@ -68,16 +70,6 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Question" },
       { name: "Task" },
     ]),
-
-    "CSAT score": Schema.select([
-      { name: "Satisfied" },
-      { name: "Not satisfied" },
-      { name: "Pending" },
-    ]),
-
-    // Options are created automatically from your Zendesk tags — no need to
-    // list them here. Add seed values if you want them pre-created.
-    Tags: Schema.multiSelect([]),
 
     // Common channels are seeded below. If your Zendesk uses additional
     // channels (e.g. "Mobile SDK"), the select option is created automatically.
@@ -89,6 +81,18 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Mobile" },
     ]),
 
+    // Options are created automatically from your Zendesk tags — no need to
+    // list them here. Add seed values if you want them pre-created.
+    Tags: Schema.multiSelect([]),
+
+    "CSAT score": Schema.select([
+      { name: "Satisfied" },
+      { name: "Not satisfied" },
+      { name: "Pending" },
+    ]),
+
     "Created at": Schema.date(),
+
+    "Ticket ID": Schema.richText(),
   },
 }

--- a/examples/workers/syncs/zendesk/src/schema.ts
+++ b/examples/workers/syncs/zendesk/src/schema.ts
@@ -58,9 +58,9 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Mobile" },
     ]),
 
-    "Assignee ID": Schema.richText(),
+    Assignee: Schema.richText(),
 
-    "Requester ID": Schema.richText(),
+    Requester: Schema.richText(),
 
     "Created at": Schema.date(),
   },

--- a/examples/workers/syncs/zendesk/src/schema.ts
+++ b/examples/workers/syncs/zendesk/src/schema.ts
@@ -13,6 +13,13 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Ticket link": Schema.url(),
 
+    Type: Schema.select([
+      { name: "Problem" },
+      { name: "Incident" },
+      { name: "Question" },
+      { name: "Task" },
+    ]),
+
     Status: Schema.select([
       { name: "New" },
       { name: "Open" },
@@ -42,6 +49,18 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Feature request" },
       { name: "Integration" },
     ]),
+
+    Channel: Schema.select([
+      { name: "Web" },
+      { name: "Email" },
+      { name: "Chat" },
+      { name: "Api" },
+      { name: "Mobile" },
+    ]),
+
+    "Assignee ID": Schema.richText(),
+
+    "Requester ID": Schema.richText(),
 
     "Created at": Schema.date(),
   },

--- a/examples/workers/syncs/zendesk/src/schema.ts
+++ b/examples/workers/syncs/zendesk/src/schema.ts
@@ -1,0 +1,48 @@
+import * as Schema from "@notionhq/workers/schema"
+
+export const INITIAL_TITLE =
+  process.env.ZENDESK_SYNC_DB_TITLE ?? "Support Tickets"
+
+export const PRIMARY_KEY = "Ticket ID"
+
+export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    Tickets: Schema.title(),
+
+    "Ticket ID": Schema.richText(),
+
+    "Ticket link": Schema.url(),
+
+    Status: Schema.select([
+      { name: "New" },
+      { name: "Open" },
+      { name: "Pending" },
+      { name: "Hold" },
+      { name: "Solved" },
+      { name: "Closed" },
+    ]),
+
+    Priority: Schema.select([
+      { name: "Urgent" },
+      { name: "High" },
+      { name: "Normal" },
+      { name: "Low" },
+    ]),
+
+    "CSAT score": Schema.select([
+      { name: "Good" },
+      { name: "Bad" },
+      { name: "Offered" },
+    ]),
+
+    "Feature tags": Schema.multiSelect([
+      { name: "Account access" },
+      { name: "Billing" },
+      { name: "Bug report" },
+      { name: "Feature request" },
+      { name: "Integration" },
+    ]),
+
+    "Created at": Schema.date(),
+  },
+}

--- a/examples/workers/syncs/zendesk/src/sla-policies.ts
+++ b/examples/workers/syncs/zendesk/src/sla-policies.ts
@@ -6,6 +6,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
 import type { ZendeskSlaPolicy, ZendeskSlaPolicyMetric } from "./zendesk.js"
 import { dateOnly } from "./transform.js"
 
@@ -13,16 +14,17 @@ export const INITIAL_TITLE = "Zendesk SLA Policies"
 export const PRIMARY_KEY = "Policy ID"
 
 export const slaPolicySchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("shield"),
   properties: {
     Title: Schema.title(),
 
-    "Policy ID": Schema.richText(),
-
     Position: Schema.number(),
 
-    "Created at": Schema.date(),
-
     "Updated at": Schema.date(),
+
+    "Policy ID": Schema.richText(),
+
+    "Created at": Schema.date(),
   },
 }
 

--- a/examples/workers/syncs/zendesk/src/sla-policies.ts
+++ b/examples/workers/syncs/zendesk/src/sla-policies.ts
@@ -1,0 +1,66 @@
+// SLA Policies sync — a reference table of your SLA definitions.
+// Requires Zendesk Professional+ plan.
+//
+// This is a small, rarely-changing dataset (typically <20 policies), so
+// it uses a manual schedule and fetches everything in one call.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import type { ZendeskSlaPolicy, ZendeskSlaPolicyMetric } from "./zendesk.js"
+import { dateOnly } from "./transform.js"
+
+export const INITIAL_TITLE = "Zendesk SLA Policies"
+export const PRIMARY_KEY = "Policy ID"
+
+export const slaPolicySchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    Title: Schema.title(),
+
+    "Policy ID": Schema.richText(),
+
+    Position: Schema.number(),
+
+    "Created at": Schema.date(),
+
+    "Updated at": Schema.date(),
+  },
+}
+
+// Formats the policy_metrics array into a readable markdown table for the
+// page body, so users can see the SLA targets at a glance.
+function formatPolicyMetrics(metrics: ZendeskSlaPolicyMetric[]): string {
+  if (!metrics.length) return ""
+
+  const lines = [
+    "| Priority | Metric | Target (min) | Business hours |",
+    "| --- | --- | --- | --- |",
+  ]
+
+  for (const m of metrics) {
+    lines.push(
+      `| ${m.priority} | ${m.metric} | ${m.target} | ${m.business_hours ? "Yes" : "No"} |`
+    )
+  }
+
+  return lines.join("\n")
+}
+
+export function slaPolicyToChange(policy: ZendeskSlaPolicy) {
+  const description = policy.description ?? ""
+  const metricsTable = formatPolicyMetrics(policy.policy_metrics ?? [])
+  const body = [description, metricsTable].filter(Boolean).join("\n\n")
+
+  return {
+    type: "upsert" as const,
+    key: String(policy.id),
+    upstreamUpdatedAt: policy.updated_at,
+    pageContentMarkdown: body,
+    properties: {
+      Title: Builder.title(policy.title ?? ""),
+      "Policy ID": Builder.richText(String(policy.id)),
+      Position: Builder.number(policy.position),
+      "Created at": Builder.date(dateOnly(policy.created_at)),
+      "Updated at": Builder.date(dateOnly(policy.updated_at)),
+    },
+  }
+}

--- a/examples/workers/syncs/zendesk/src/sla-policies.ts
+++ b/examples/workers/syncs/zendesk/src/sla-policies.ts
@@ -1,4 +1,5 @@
-// SLA Policies sync — a reference table of your SLA definitions.
+// SLA Policies sync — a reference table of your SLA definitions with targets
+// flattened into columns for at-a-glance comparison.
 // Requires Zendesk Professional+ plan.
 //
 // This is a small, rarely-changing dataset (typically <20 policies), so
@@ -18,49 +19,90 @@ export const slaPolicySchema: Schema.Schema<typeof PRIMARY_KEY> = {
   properties: {
     Title: Schema.title(),
 
+    "Urgent First Reply (min)": Schema.number(),
+
+    "High First Reply (min)": Schema.number(),
+
+    "Normal First Reply (min)": Schema.number(),
+
+    "Low First Reply (min)": Schema.number(),
+
     Position: Schema.number(),
 
-    "Updated at": Schema.date(),
+    "Urgent Resolution (min)": Schema.number(),
+
+    "High Resolution (min)": Schema.number(),
+
+    "Normal Resolution (min)": Schema.number(),
+
+    "Low Resolution (min)": Schema.number(),
 
     "Policy ID": Schema.richText(),
+
+    "Updated at": Schema.date(),
 
     "Created at": Schema.date(),
   },
 }
 
-// Formats the policy_metrics array into a readable markdown table for the
-// page body, so users can see the SLA targets at a glance.
-function formatPolicyMetrics(metrics: ZendeskSlaPolicyMetric[]): string {
-  if (!metrics.length) return ""
-
-  const lines = [
-    "| Priority | Metric | Target (min) | Business hours |",
-    "| --- | --- | --- | --- |",
-  ]
-
-  for (const m of metrics) {
-    lines.push(
-      `| ${m.priority} | ${m.metric} | ${m.target} | ${m.business_hours ? "Yes" : "No"} |`
-    )
-  }
-
-  return lines.join("\n")
+function findTarget(
+  metrics: ZendeskSlaPolicyMetric[],
+  metric: string,
+  priority: string
+): number | undefined {
+  const match = metrics.find(
+    (m) => m.metric === metric && m.priority === priority
+  )
+  return match?.target
 }
 
 export function slaPolicyToChange(policy: ZendeskSlaPolicy) {
+  const metrics = policy.policy_metrics ?? []
   const description = policy.description ?? ""
-  const metricsTable = formatPolicyMetrics(policy.policy_metrics ?? [])
-  const body = [description, metricsTable].filter(Boolean).join("\n\n")
+
+  const urgentReply = findTarget(metrics, "first_reply_time", "urgent")
+  const highReply = findTarget(metrics, "first_reply_time", "high")
+  const normalReply = findTarget(metrics, "first_reply_time", "normal")
+  const lowReply = findTarget(metrics, "first_reply_time", "low")
+
+  const urgentRes = findTarget(metrics, "total_resolution_time", "urgent")
+  const highRes = findTarget(metrics, "total_resolution_time", "high")
+  const normalRes = findTarget(metrics, "total_resolution_time", "normal")
+  const lowRes = findTarget(metrics, "total_resolution_time", "low")
 
   return {
     type: "upsert" as const,
     key: String(policy.id),
     upstreamUpdatedAt: policy.updated_at,
-    pageContentMarkdown: body,
+    pageContentMarkdown: description,
     properties: {
       Title: Builder.title(policy.title ?? ""),
       "Policy ID": Builder.richText(String(policy.id)),
       Position: Builder.number(policy.position),
+      ...(urgentReply != null
+        ? { "Urgent First Reply (min)": Builder.number(urgentReply) }
+        : {}),
+      ...(highReply != null
+        ? { "High First Reply (min)": Builder.number(highReply) }
+        : {}),
+      ...(normalReply != null
+        ? { "Normal First Reply (min)": Builder.number(normalReply) }
+        : {}),
+      ...(lowReply != null
+        ? { "Low First Reply (min)": Builder.number(lowReply) }
+        : {}),
+      ...(urgentRes != null
+        ? { "Urgent Resolution (min)": Builder.number(urgentRes) }
+        : {}),
+      ...(highRes != null
+        ? { "High Resolution (min)": Builder.number(highRes) }
+        : {}),
+      ...(normalRes != null
+        ? { "Normal Resolution (min)": Builder.number(normalRes) }
+        : {}),
+      ...(lowRes != null
+        ? { "Low Resolution (min)": Builder.number(lowRes) }
+        : {}),
       "Created at": Builder.date(dateOnly(policy.created_at)),
       "Updated at": Builder.date(dateOnly(policy.updated_at)),
     },

--- a/examples/workers/syncs/zendesk/src/ticket-metrics.ts
+++ b/examples/workers/syncs/zendesk/src/ticket-metrics.ts
@@ -7,6 +7,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
 import type { ZendeskTicketMetric } from "./zendesk.js"
 import { dateOnly } from "./transform.js"
 
@@ -14,26 +15,27 @@ export const INITIAL_TITLE = "Zendesk Ticket Metrics"
 export const PRIMARY_KEY = "Ticket ID"
 
 export const ticketMetricSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("stopwatch"),
   properties: {
     "Ticket ID": Schema.title(),
 
     "First Reply (min)": Schema.number(),
 
-    "First Resolution (min)": Schema.number(),
-
     "Full Resolution (min)": Schema.number(),
-
-    "Agent Wait (min)": Schema.number(),
-
-    "Requester Wait (min)": Schema.number(),
 
     Reopens: Schema.number(),
 
     Replies: Schema.number(),
 
-    "Created at": Schema.date(),
-
     "Updated at": Schema.date(),
+
+    "First Resolution (min)": Schema.number(),
+
+    "Agent Wait (min)": Schema.number(),
+
+    "Requester Wait (min)": Schema.number(),
+
+    "Created at": Schema.date(),
   },
 }
 

--- a/examples/workers/syncs/zendesk/src/ticket-metrics.ts
+++ b/examples/workers/syncs/zendesk/src/ticket-metrics.ts
@@ -25,15 +25,23 @@ export const ticketMetricSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Reopens: Schema.number(),
 
-    Replies: Schema.number(),
+    "Agents Touched": Schema.number(),
 
-    "Updated at": Schema.date(),
+    "Groups Touched": Schema.number(),
+
+    "Solved at": Schema.date(),
 
     "First Resolution (min)": Schema.number(),
+
+    Replies: Schema.number(),
+
+    "On Hold (min)": Schema.number(),
 
     "Agent Wait (min)": Schema.number(),
 
     "Requester Wait (min)": Schema.number(),
+
+    "Updated at": Schema.date(),
 
     "Created at": Schema.date(),
   },
@@ -62,9 +70,17 @@ export function ticketMetricToChange(metric: ZendeskTicketMetric) {
         metric.requester_wait_time_in_minutes.calendar
       ),
       Reopens: Builder.number(metric.reopens),
+      "Agents Touched": Builder.number(metric.assignee_stations),
+      "Groups Touched": Builder.number(metric.group_stations),
+      ...(metric.solved_at
+        ? { "Solved at": Builder.date(dateOnly(metric.solved_at)) }
+        : {}),
       Replies: Builder.number(metric.replies),
-      "Created at": Builder.date(dateOnly(metric.created_at)),
+      "On Hold (min)": Builder.number(
+        metric.on_hold_time_in_minutes.calendar
+      ),
       "Updated at": Builder.date(dateOnly(metric.updated_at)),
+      "Created at": Builder.date(dateOnly(metric.created_at)),
     },
   }
 }

--- a/examples/workers/syncs/zendesk/src/ticket-metrics.ts
+++ b/examples/workers/syncs/zendesk/src/ticket-metrics.ts
@@ -1,0 +1,68 @@
+// Ticket Metrics sync — tracks performance data per ticket (response times,
+// resolution times, reopens, replies). Powers SLA compliance views and
+// team performance dashboards.
+//
+// Time values use calendar minutes (not business hours). To use business
+// hours instead, change the .calendar references to .business below.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import type { ZendeskTicketMetric } from "./zendesk.js"
+import { dateOnly } from "./transform.js"
+
+export const INITIAL_TITLE = "Zendesk Ticket Metrics"
+export const PRIMARY_KEY = "Ticket ID"
+
+export const ticketMetricSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    "Ticket ID": Schema.title(),
+
+    "First Reply (min)": Schema.number(),
+
+    "First Resolution (min)": Schema.number(),
+
+    "Full Resolution (min)": Schema.number(),
+
+    "Agent Wait (min)": Schema.number(),
+
+    "Requester Wait (min)": Schema.number(),
+
+    Reopens: Schema.number(),
+
+    Replies: Schema.number(),
+
+    "Created at": Schema.date(),
+
+    "Updated at": Schema.date(),
+  },
+}
+
+export function ticketMetricToChange(metric: ZendeskTicketMetric) {
+  return {
+    type: "upsert" as const,
+    key: String(metric.ticket_id),
+    upstreamUpdatedAt: metric.updated_at,
+    properties: {
+      "Ticket ID": Builder.title(String(metric.ticket_id)),
+      "First Reply (min)": Builder.number(
+        metric.reply_time_in_minutes.calendar
+      ),
+      "First Resolution (min)": Builder.number(
+        metric.first_resolution_time_in_minutes.calendar
+      ),
+      "Full Resolution (min)": Builder.number(
+        metric.full_resolution_time_in_minutes.calendar
+      ),
+      "Agent Wait (min)": Builder.number(
+        metric.agent_wait_time_in_minutes.calendar
+      ),
+      "Requester Wait (min)": Builder.number(
+        metric.requester_wait_time_in_minutes.calendar
+      ),
+      Reopens: Builder.number(metric.reopens),
+      Replies: Builder.number(metric.replies),
+      "Created at": Builder.date(dateOnly(metric.created_at)),
+      "Updated at": Builder.date(dateOnly(metric.updated_at)),
+    },
+  }
+}

--- a/examples/workers/syncs/zendesk/src/transform.ts
+++ b/examples/workers/syncs/zendesk/src/transform.ts
@@ -1,0 +1,46 @@
+import * as Builder from "@notionhq/workers/builder"
+import type { ZendeskTicket } from "./zendesk.js"
+
+export function ticketToChange(ticket: ZendeskTicket, subdomain: string) {
+  const csatScore = ticket.satisfaction_rating?.score
+  const hasKnownCsat =
+    csatScore === "good" || csatScore === "bad" || csatScore === "offered"
+
+  return {
+    type: "upsert" as const,
+    key: String(ticket.id),
+    upstreamUpdatedAt: ticket.updated_at,
+    pageContentMarkdown: ticket.description ?? "",
+    properties: {
+      Tickets: Builder.title(ticket.subject ?? ""),
+      "Ticket ID": Builder.richText(String(ticket.id)),
+      "Ticket link": Builder.url(ticketUrl(subdomain, ticket.id)),
+      Status: Builder.select(capitalize(ticket.status ?? "new")),
+      ...(ticket.priority
+        ? { Priority: Builder.select(capitalize(ticket.priority)) }
+        : {}),
+      ...(hasKnownCsat
+        ? { "CSAT score": Builder.select(capitalize(csatScore!)) }
+        : {}),
+      ...(ticket.tags.length > 0
+        ? { "Feature tags": Builder.multiSelect(...ticket.tags) }
+        : {}),
+      "Created at": Builder.date(dateOnly(ticket.created_at)),
+    },
+  }
+}
+
+export function ticketUrl(subdomain: string, ticketId: number): string {
+  return `https://${subdomain}.zendesk.com/agent/tickets/${ticketId}`
+}
+
+function capitalize(s: string): string {
+  if (!s) return s
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function dateOnly(value: string): string {
+  if (!value) return ""
+  if (value.includes("T")) return value.slice(0, 10)
+  return value.slice(0, 10)
+}

--- a/examples/workers/syncs/zendesk/src/transform.ts
+++ b/examples/workers/syncs/zendesk/src/transform.ts
@@ -15,6 +15,9 @@ export function ticketToChange(ticket: ZendeskTicket, subdomain: string) {
       Tickets: Builder.title(ticket.subject ?? ""),
       "Ticket ID": Builder.richText(String(ticket.id)),
       "Ticket link": Builder.url(ticketUrl(subdomain, ticket.id)),
+      ...(ticket.type
+        ? { Type: Builder.select(capitalize(ticket.type)) }
+        : {}),
       Status: Builder.select(capitalize(ticket.status ?? "new")),
       ...(ticket.priority
         ? { Priority: Builder.select(capitalize(ticket.priority)) }
@@ -25,6 +28,11 @@ export function ticketToChange(ticket: ZendeskTicket, subdomain: string) {
       ...(ticket.tags.length > 0
         ? { "Feature tags": Builder.multiSelect(...ticket.tags) }
         : {}),
+      Channel: Builder.select(capitalize(ticket.via?.channel ?? "web")),
+      ...(ticket.assignee_id
+        ? { "Assignee ID": Builder.richText(String(ticket.assignee_id)) }
+        : {}),
+      "Requester ID": Builder.richText(String(ticket.requester_id)),
       "Created at": Builder.date(dateOnly(ticket.created_at)),
     },
   }

--- a/examples/workers/syncs/zendesk/src/transform.ts
+++ b/examples/workers/syncs/zendesk/src/transform.ts
@@ -1,10 +1,20 @@
 import * as Builder from "@notionhq/workers/builder"
-import type { ZendeskTicket } from "./zendesk.js"
+import type { ZendeskTicket, UserLookup } from "./zendesk.js"
 
-export function ticketToChange(ticket: ZendeskTicket, subdomain: string) {
+export function ticketToChange(
+  ticket: ZendeskTicket,
+  subdomain: string,
+  users: UserLookup
+) {
   const csatScore = ticket.satisfaction_rating?.score
   const hasKnownCsat =
     csatScore === "good" || csatScore === "bad" || csatScore === "offered"
+
+  const assigneeName = ticket.assignee_id
+    ? users.get(ticket.assignee_id)?.name ?? String(ticket.assignee_id)
+    : null
+  const requesterName =
+    users.get(ticket.requester_id)?.name ?? String(ticket.requester_id)
 
   return {
     type: "upsert" as const,
@@ -29,10 +39,10 @@ export function ticketToChange(ticket: ZendeskTicket, subdomain: string) {
         ? { "Feature tags": Builder.multiSelect(...ticket.tags) }
         : {}),
       Channel: Builder.select(capitalize(ticket.via?.channel ?? "web")),
-      ...(ticket.assignee_id
-        ? { "Assignee ID": Builder.richText(String(ticket.assignee_id)) }
+      ...(assigneeName
+        ? { Assignee: Builder.richText(assigneeName) }
         : {}),
-      "Requester ID": Builder.richText(String(ticket.requester_id)),
+      Requester: Builder.richText(requesterName),
       "Created at": Builder.date(dateOnly(ticket.created_at)),
     },
   }

--- a/examples/workers/syncs/zendesk/src/transform.ts
+++ b/examples/workers/syncs/zendesk/src/transform.ts
@@ -10,7 +10,7 @@
 // clean and avoids overwriting user edits with blanks.
 
 import * as Builder from "@notionhq/workers/builder"
-import type { ZendeskTicket, UserLookup } from "./zendesk.js"
+import type { ZendeskTicket, UserLookup, GroupLookup, OrgLookup } from "./zendesk.js"
 
 // Use explicit label maps when Zendesk's raw values don't match what users
 // expect to see in Notion. For values not in the map, formatLabel() is used
@@ -33,7 +33,9 @@ const CHANNEL_LABELS: Record<string, string> = {
 export function ticketToChange(
   ticket: ZendeskTicket,
   subdomain: string,
-  users: UserLookup
+  users: UserLookup,
+  groups: GroupLookup,
+  orgs: OrgLookup
 ) {
   const csatLabel = CSAT_LABELS[ticket.satisfaction_rating?.score ?? ""]
 
@@ -42,37 +44,43 @@ export function ticketToChange(
     : null
   const requesterName =
     users.get(ticket.requester_id)?.name ?? String(ticket.requester_id)
+  const groupName = ticket.group_id
+    ? groups.get(ticket.group_id)?.name ?? String(ticket.group_id)
+    : null
+  const orgName = ticket.organization_id
+    ? orgs.get(ticket.organization_id)?.name ?? null
+    : null
 
   return {
     type: "upsert" as const,
-    // key must match the PRIMARY_KEY property value — the platform uses this
-    // to find the existing page to update, or creates a new one if not found.
     key: String(ticket.id),
     upstreamUpdatedAt: ticket.updated_at,
     pageContentMarkdown: ticket.description ?? "",
     properties: {
       Subject: Builder.title(ticket.subject ?? ""),
-      "Ticket ID": Builder.richText(String(ticket.id)),
-      "Ticket link": Builder.url(ticketUrl(subdomain, ticket.id)),
-      ...(ticket.type
-        ? { Type: Builder.select(formatLabel(ticket.type)) }
-        : {}),
       Status: Builder.select(formatLabel(ticket.status ?? "new")),
       ...(ticket.priority
         ? { Priority: Builder.select(formatLabel(ticket.priority)) }
         : {}),
-      ...(csatLabel ? { "CSAT score": Builder.select(csatLabel) } : {}),
-      ...(ticket.tags.length > 0
-        ? { Tags: Builder.multiSelect(...ticket.tags) }
+      ...(assigneeName ? { Assignee: Builder.richText(assigneeName) } : {}),
+      ...(groupName ? { Group: Builder.richText(groupName) } : {}),
+      "Ticket link": Builder.url(ticketUrl(subdomain, ticket.id)),
+      "Updated at": Builder.date(dateOnly(ticket.updated_at)),
+      Requester: Builder.richText(requesterName),
+      ...(orgName ? { Organization: Builder.richText(orgName) } : {}),
+      ...(ticket.type
+        ? { Type: Builder.select(formatLabel(ticket.type)) }
         : {}),
       Channel: Builder.select(
         CHANNEL_LABELS[ticket.via?.channel ?? "web"] ??
           formatLabel(ticket.via?.channel ?? "web")
       ),
-      ...(assigneeName ? { Assignee: Builder.richText(assigneeName) } : {}),
-      Requester: Builder.richText(requesterName),
+      ...(ticket.tags.length > 0
+        ? { Tags: Builder.multiSelect(...ticket.tags) }
+        : {}),
+      ...(csatLabel ? { "CSAT score": Builder.select(csatLabel) } : {}),
       "Created at": Builder.date(dateOnly(ticket.created_at)),
-      "Updated at": Builder.date(dateOnly(ticket.updated_at)),
+      "Ticket ID": Builder.richText(String(ticket.id)),
     },
   }
 }

--- a/examples/workers/syncs/zendesk/src/transform.ts
+++ b/examples/workers/syncs/zendesk/src/transform.ts
@@ -1,14 +1,41 @@
+// Transform maps each Zendesk ticket to a sync change that the platform
+// applies to the managed Notion database.
+//
+// IMPORTANT: Property names here must exactly match the keys in schema.ts.
+// If you add, rename, or remove a property in schema.ts, update this file too.
+//
+// Nullable fields use conditional spread: ...(value ? { Prop: Builder.x(value) } : {})
+// This omits the property entirely when the source field is null, rather than
+// writing an empty value. Omitting is preferred — it keeps the Notion database
+// clean and avoids overwriting user edits with blanks.
+
 import * as Builder from "@notionhq/workers/builder"
 import type { ZendeskTicket, UserLookup } from "./zendesk.js"
+
+// Use explicit label maps when Zendesk's raw values don't match what users
+// expect to see in Notion. For values not in the map, formatLabel() is used
+// as a fallback (replaces underscores with spaces and title-cases each word).
+
+const CSAT_LABELS: Record<string, string> = {
+  good: "Satisfied",
+  bad: "Not satisfied",
+  offered: "Pending",
+}
+
+const CHANNEL_LABELS: Record<string, string> = {
+  web: "Web",
+  email: "Email",
+  chat: "Chat",
+  api: "API",
+  mobile: "Mobile",
+}
 
 export function ticketToChange(
   ticket: ZendeskTicket,
   subdomain: string,
   users: UserLookup
 ) {
-  const csatScore = ticket.satisfaction_rating?.score
-  const hasKnownCsat =
-    csatScore === "good" || csatScore === "bad" || csatScore === "offered"
+  const csatLabel = CSAT_LABELS[ticket.satisfaction_rating?.score ?? ""]
 
   const assigneeName = ticket.assignee_id
     ? users.get(ticket.assignee_id)?.name ?? String(ticket.assignee_id)
@@ -18,32 +45,34 @@ export function ticketToChange(
 
   return {
     type: "upsert" as const,
+    // key must match the PRIMARY_KEY property value — the platform uses this
+    // to find the existing page to update, or creates a new one if not found.
     key: String(ticket.id),
     upstreamUpdatedAt: ticket.updated_at,
     pageContentMarkdown: ticket.description ?? "",
     properties: {
-      Tickets: Builder.title(ticket.subject ?? ""),
+      Subject: Builder.title(ticket.subject ?? ""),
       "Ticket ID": Builder.richText(String(ticket.id)),
       "Ticket link": Builder.url(ticketUrl(subdomain, ticket.id)),
       ...(ticket.type
-        ? { Type: Builder.select(capitalize(ticket.type)) }
+        ? { Type: Builder.select(formatLabel(ticket.type)) }
         : {}),
-      Status: Builder.select(capitalize(ticket.status ?? "new")),
+      Status: Builder.select(formatLabel(ticket.status ?? "new")),
       ...(ticket.priority
-        ? { Priority: Builder.select(capitalize(ticket.priority)) }
+        ? { Priority: Builder.select(formatLabel(ticket.priority)) }
         : {}),
-      ...(hasKnownCsat
-        ? { "CSAT score": Builder.select(capitalize(csatScore!)) }
-        : {}),
+      ...(csatLabel ? { "CSAT score": Builder.select(csatLabel) } : {}),
       ...(ticket.tags.length > 0
-        ? { "Feature tags": Builder.multiSelect(...ticket.tags) }
+        ? { Tags: Builder.multiSelect(...ticket.tags) }
         : {}),
-      Channel: Builder.select(capitalize(ticket.via?.channel ?? "web")),
-      ...(assigneeName
-        ? { Assignee: Builder.richText(assigneeName) }
-        : {}),
+      Channel: Builder.select(
+        CHANNEL_LABELS[ticket.via?.channel ?? "web"] ??
+          formatLabel(ticket.via?.channel ?? "web")
+      ),
+      ...(assigneeName ? { Assignee: Builder.richText(assigneeName) } : {}),
       Requester: Builder.richText(requesterName),
       "Created at": Builder.date(dateOnly(ticket.created_at)),
+      "Updated at": Builder.date(dateOnly(ticket.updated_at)),
     },
   }
 }
@@ -52,9 +81,14 @@ export function ticketUrl(subdomain: string, ticketId: number): string {
   return `https://${subdomain}.zendesk.com/agent/tickets/${ticketId}`
 }
 
-function capitalize(s: string): string {
+// Converts Zendesk API values (e.g. "mobile_sdk") to display labels
+// (e.g. "Mobile Sdk"). Use CHANNEL_LABELS or CSAT_LABELS instead when the
+// raw value needs a specific mapping (e.g. "api" → "API", not "Api").
+export function formatLabel(s: string): string {
   if (!s) return s
-  return s.charAt(0).toUpperCase() + s.slice(1)
+  return s
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 export function dateOnly(value: string): string {

--- a/examples/workers/syncs/zendesk/src/users.ts
+++ b/examples/workers/syncs/zendesk/src/users.ts
@@ -1,0 +1,63 @@
+// Users sync — tracks agents and end-users in your Zendesk instance.
+// Creates an agent roster for workload planning, or an end-user directory
+// showing your most active requesters.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import type { ZendeskFullUser } from "./zendesk.js"
+import { formatLabel, dateOnly } from "./transform.js"
+
+export const INITIAL_TITLE = "Zendesk Users"
+export const PRIMARY_KEY = "User ID"
+
+export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  properties: {
+    Name: Schema.title(),
+
+    "User ID": Schema.richText(),
+
+    Email: Schema.email(),
+
+    Role: Schema.select([
+      { name: "End-user" },
+      { name: "Agent" },
+      { name: "Admin" },
+    ]),
+
+    Phone: Schema.richText(),
+
+    Tags: Schema.multiSelect([]),
+
+    Suspended: Schema.checkbox(),
+
+    "Last login": Schema.date(),
+
+    "Created at": Schema.date(),
+
+    "Updated at": Schema.date(),
+  },
+}
+
+export function userToChange(user: ZendeskFullUser) {
+  return {
+    type: "upsert" as const,
+    key: String(user.id),
+    upstreamUpdatedAt: user.updated_at,
+    properties: {
+      Name: Builder.title(user.name ?? ""),
+      "User ID": Builder.richText(String(user.id)),
+      ...(user.email ? { Email: Builder.email(user.email) } : {}),
+      Role: Builder.select(formatLabel(user.role ?? "end-user")),
+      ...(user.phone ? { Phone: Builder.richText(user.phone) } : {}),
+      ...(user.tags.length > 0
+        ? { Tags: Builder.multiSelect(...user.tags) }
+        : {}),
+      Suspended: Builder.checkbox(user.suspended),
+      ...(user.last_login_at
+        ? { "Last login": Builder.date(dateOnly(user.last_login_at)) }
+        : {}),
+      "Created at": Builder.date(dateOnly(user.created_at)),
+      "Updated at": Builder.date(dateOnly(user.updated_at)),
+    },
+  }
+}

--- a/examples/workers/syncs/zendesk/src/users.ts
+++ b/examples/workers/syncs/zendesk/src/users.ts
@@ -30,11 +30,13 @@ export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Updated at": Schema.date(),
 
-    "User ID": Schema.richText(),
+    "Organization ID": Schema.richText(),
 
     Phone: Schema.richText(),
 
     Suspended: Schema.checkbox(),
+
+    "User ID": Schema.richText(),
 
     "Created at": Schema.date(),
   },
@@ -50,6 +52,9 @@ export function userToChange(user: ZendeskFullUser) {
       "User ID": Builder.richText(String(user.id)),
       ...(user.email ? { Email: Builder.email(user.email) } : {}),
       Role: Builder.select(formatLabel(user.role ?? "end-user")),
+      ...(user.organization_id
+        ? { "Organization ID": Builder.richText(String(user.organization_id)) }
+        : {}),
       ...(user.phone ? { Phone: Builder.richText(user.phone) } : {}),
       ...(user.tags.length > 0
         ? { Tags: Builder.multiSelect(...user.tags) }

--- a/examples/workers/syncs/zendesk/src/users.ts
+++ b/examples/workers/syncs/zendesk/src/users.ts
@@ -4,6 +4,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
 import type { ZendeskFullUser } from "./zendesk.js"
 import { formatLabel, dateOnly } from "./transform.js"
 
@@ -11,12 +12,9 @@ export const INITIAL_TITLE = "Zendesk Users"
 export const PRIMARY_KEY = "User ID"
 
 export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("people"),
   properties: {
     Name: Schema.title(),
-
-    "User ID": Schema.richText(),
-
-    Email: Schema.email(),
 
     Role: Schema.select([
       { name: "End-user" },
@@ -24,17 +22,21 @@ export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Admin" },
     ]),
 
-    Phone: Schema.richText(),
-
-    Tags: Schema.multiSelect([]),
-
-    Suspended: Schema.checkbox(),
+    Email: Schema.email(),
 
     "Last login": Schema.date(),
 
-    "Created at": Schema.date(),
+    Tags: Schema.multiSelect([]),
 
     "Updated at": Schema.date(),
+
+    "User ID": Schema.richText(),
+
+    Phone: Schema.richText(),
+
+    Suspended: Schema.checkbox(),
+
+    "Created at": Schema.date(),
   },
 }
 

--- a/examples/workers/syncs/zendesk/src/zendesk.ts
+++ b/examples/workers/syncs/zendesk/src/zendesk.ts
@@ -1,10 +1,116 @@
-// Zendesk API client. Handles authentication and paginated ticket fetching.
+// Zendesk API client. Handles authentication and paginated fetching for all
+// synced resources (tickets, organizations, users, satisfaction ratings,
+// ticket metrics, SLA policies).
 //
-// To sync additional related data (e.g. group names, organization names),
-// add them to the `include` parameter in buildTicketsUrl:
-//   include: "users,groups,organizations"
-// Then add the corresponding types and extend the return value of
-// fetchTicketsPage to include the new lookup maps.
+// To add a new resource:
+//   1. Add a type for the API response shape
+//   2. Add a fetchXxxPage() function using fetchPage()
+//   3. Wire it into index.ts
+
+// ---------------------------------------------------------------------------
+// Shared types and helpers
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 100
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`${name} is not set.`)
+  }
+  return value
+}
+
+export function requireSubdomain(): string {
+  return requireEnv("ZENDESK_SUBDOMAIN")
+}
+
+// Zendesk API tokens use Basic auth as email/token:apitoken (not Bearer).
+export function getAuthorizationHeader(): string {
+  const apiToken = process.env.ZENDESK_API_TOKEN?.trim()
+  if (apiToken) {
+    const email = requireEnv("ZENDESK_API_USER_EMAIL")
+    return `Basic ${Buffer.from(`${email}/token:${apiToken}`).toString("base64")}`
+  }
+
+  const basicAuth = process.env.ZENDESK_BASIC_AUTH_TOKEN?.trim()
+  if (basicAuth) {
+    return /^basic /i.test(basicAuth) ? basicAuth : `Basic ${basicAuth}`
+  }
+
+  throw new Error(
+    "Zendesk API credentials not configured. " +
+      "Set ZENDESK_API_TOKEN + ZENDESK_API_USER_EMAIL, or ZENDESK_BASIC_AUTH_TOKEN."
+  )
+}
+
+// Generic paginated fetch for any Zendesk list endpoint.
+export async function fetchPage<T>(
+  subdomain: string,
+  path: string,
+  extraParams?: Record<string, string>,
+  cursor?: string
+): Promise<{ data: T; hasMore: boolean; nextCursor: string | undefined }> {
+  const base = `https://${subdomain}.zendesk.com${path}`
+  const params = new URLSearchParams({
+    "page[size]": String(PAGE_SIZE),
+    ...extraParams,
+  })
+  if (cursor) {
+    params.set("page[after]", cursor)
+  }
+  const url = `${base}?${params.toString()}`
+
+  const authorization = getAuthorizationHeader()
+  const response = await fetch(url, {
+    headers: { Authorization: authorization, Accept: "application/json" },
+    redirect: "error",
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Zendesk API error (${response.status}): ${text || "No response body"}`
+    )
+  }
+
+  const body = JSON.parse(text) as T & {
+    meta: { has_more: boolean; after_cursor: string }
+  }
+
+  return {
+    data: body,
+    hasMore: body.meta.has_more,
+    nextCursor: body.meta.has_more ? body.meta.after_cursor : undefined,
+  }
+}
+
+// Non-paginated fetch for small collections (e.g. SLA policies).
+export async function fetchAll<T>(
+  subdomain: string,
+  path: string
+): Promise<T> {
+  const url = `https://${subdomain}.zendesk.com${path}`
+  const authorization = getAuthorizationHeader()
+
+  const response = await fetch(url, {
+    headers: { Authorization: authorization, Accept: "application/json" },
+    redirect: "error",
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Zendesk API error (${response.status}): ${text || "No response body"}`
+    )
+  }
+
+  return JSON.parse(text) as T
+}
+
+// ---------------------------------------------------------------------------
+// Tickets
+// ---------------------------------------------------------------------------
 
 // Add fields here when extending the sync — the Zendesk Tickets API returns
 // many more fields than we use. See:
@@ -31,45 +137,14 @@ export type ZendeskUser = {
   email: string
 }
 
+export type UserLookup = Map<number, ZendeskUser>
+
 type ListTicketsResponse = {
   tickets: ZendeskTicket[]
   users: ZendeskUser[]
-  meta: { has_more: boolean; after_cursor: string }
 }
 
-export type UserLookup = Map<number, ZendeskUser>
-
-const PAGE_SIZE = 100
-
-function requireEnv(name: string): string {
-  const value = process.env[name]?.trim()
-  if (!value) {
-    throw new Error(`${name} is not set.`)
-  }
-  return value
-}
-
-// Zendesk API tokens use Basic auth as email/token:apitoken (not Bearer).
-export function getAuthorizationHeader(): string {
-  const apiToken = process.env.ZENDESK_API_TOKEN?.trim()
-  if (apiToken) {
-    const email = requireEnv("ZENDESK_API_USER_EMAIL")
-    return `Basic ${Buffer.from(`${email}/token:${apiToken}`).toString("base64")}`
-  }
-
-  const basicAuth = process.env.ZENDESK_BASIC_AUTH_TOKEN?.trim()
-  if (basicAuth) {
-    return /^basic /i.test(basicAuth) ? basicAuth : `Basic ${basicAuth}`
-  }
-
-  throw new Error(
-    "Zendesk API credentials not configured. " +
-      "Set ZENDESK_API_TOKEN + ZENDESK_API_USER_EMAIL, or ZENDESK_BASIC_AUTH_TOKEN."
-  )
-}
-
-// Sideloading (include=users) embeds user objects in the ticket response so
-// we can resolve assignee/requester IDs to names without extra API calls.
+// Kept for backward compatibility with tests.
 export function buildTicketsUrl(
   subdomain: string,
   cursor?: string
@@ -85,43 +160,219 @@ export function buildTicketsUrl(
   return `${base}?${params.toString()}`
 }
 
-export function requireSubdomain(): string {
-  return requireEnv("ZENDESK_SUBDOMAIN")
-}
-
+// Sideloading (include=users) embeds user objects in the ticket response so
+// we can resolve assignee/requester IDs to names without extra API calls.
 export async function fetchTicketsPage(cursor?: string): Promise<{
   tickets: ZendeskTicket[]
   users: UserLookup
   hasMore: boolean
   nextCursor: string | undefined
 }> {
-  const subdomain = requireEnv("ZENDESK_SUBDOMAIN")
-  const authorization = getAuthorizationHeader()
-  const url = buildTicketsUrl(subdomain, cursor)
-
-  const response = await fetch(url, {
-    headers: { Authorization: authorization, Accept: "application/json" },
-    redirect: "error",
-  })
-
-  const text = await response.text()
-  if (!response.ok) {
-    throw new Error(
-      `Zendesk API error (${response.status}): ${text || "No response body"}`
-    )
-  }
-
-  const data = JSON.parse(text) as ListTicketsResponse
+  const subdomain = requireSubdomain()
+  const { data, hasMore, nextCursor } = await fetchPage<ListTicketsResponse>(
+    subdomain,
+    "/api/v2/tickets.json",
+    { include: "users" },
+    cursor
+  )
 
   const users: UserLookup = new Map()
   for (const user of data.users ?? []) {
     users.set(user.id, user)
   }
 
-  return {
-    tickets: data.tickets,
-    users,
-    hasMore: data.meta.has_more,
-    nextCursor: data.meta.has_more ? data.meta.after_cursor : undefined,
-  }
+  return { tickets: data.tickets, users, hasMore, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Organizations
+// https://developer.zendesk.com/api-reference/ticketing/organizations/organizations/
+// ---------------------------------------------------------------------------
+
+export type ZendeskOrganization = {
+  id: number
+  name: string
+  domain_names: string[]
+  details: string | null
+  notes: string | null
+  tags: string[]
+  group_id: number | null
+  created_at: string
+  updated_at: string
+}
+
+type ListOrganizationsResponse = {
+  organizations: ZendeskOrganization[]
+}
+
+export async function fetchOrganizationsPage(cursor?: string): Promise<{
+  organizations: ZendeskOrganization[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const subdomain = requireSubdomain()
+  const { data, hasMore, nextCursor } =
+    await fetchPage<ListOrganizationsResponse>(
+      subdomain,
+      "/api/v2/organizations.json",
+      undefined,
+      cursor
+    )
+
+  return { organizations: data.organizations, hasMore, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Users
+// https://developer.zendesk.com/api-reference/ticketing/users/users/
+// ---------------------------------------------------------------------------
+
+export type ZendeskFullUser = {
+  id: number
+  name: string
+  email: string
+  role: string
+  phone: string | null
+  organization_id: number | null
+  tags: string[]
+  suspended: boolean
+  last_login_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+type ListUsersResponse = {
+  users: ZendeskFullUser[]
+}
+
+export async function fetchUsersPage(cursor?: string): Promise<{
+  users: ZendeskFullUser[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const subdomain = requireSubdomain()
+  const { data, hasMore, nextCursor } = await fetchPage<ListUsersResponse>(
+    subdomain,
+    "/api/v2/users.json",
+    undefined,
+    cursor
+  )
+
+  return { users: data.users, hasMore, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Satisfaction Ratings (Professional+ plans)
+// https://developer.zendesk.com/api-reference/ticketing/ticket-management/satisfaction_ratings/
+// ---------------------------------------------------------------------------
+
+export type ZendeskSatisfactionRating = {
+  id: number
+  ticket_id: number
+  score: string
+  comment: string | null
+  requester_id: number
+  assignee_id: number
+  group_id: number | null
+  reason: string | null
+  created_at: string
+  updated_at: string
+}
+
+type ListSatisfactionRatingsResponse = {
+  satisfaction_ratings: ZendeskSatisfactionRating[]
+}
+
+export async function fetchSatisfactionRatingsPage(cursor?: string): Promise<{
+  ratings: ZendeskSatisfactionRating[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const subdomain = requireSubdomain()
+  const { data, hasMore, nextCursor } =
+    await fetchPage<ListSatisfactionRatingsResponse>(
+      subdomain,
+      "/api/v2/satisfaction_ratings.json",
+      undefined,
+      cursor
+    )
+
+  return { ratings: data.satisfaction_ratings, hasMore, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Ticket Metrics
+// https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metrics/
+// ---------------------------------------------------------------------------
+
+export type ZendeskTicketMetric = {
+  id: number
+  ticket_id: number
+  reopens: number
+  replies: number
+  reply_time_in_minutes: { calendar: number; business: number }
+  first_resolution_time_in_minutes: { calendar: number; business: number }
+  full_resolution_time_in_minutes: { calendar: number; business: number }
+  agent_wait_time_in_minutes: { calendar: number; business: number }
+  requester_wait_time_in_minutes: { calendar: number; business: number }
+  created_at: string
+  updated_at: string
+}
+
+type ListTicketMetricsResponse = {
+  ticket_metrics: ZendeskTicketMetric[]
+}
+
+export async function fetchTicketMetricsPage(cursor?: string): Promise<{
+  metrics: ZendeskTicketMetric[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const subdomain = requireSubdomain()
+  const { data, hasMore, nextCursor } =
+    await fetchPage<ListTicketMetricsResponse>(
+      subdomain,
+      "/api/v2/ticket_metrics.json",
+      undefined,
+      cursor
+    )
+
+  return { metrics: data.ticket_metrics, hasMore, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// SLA Policies (Professional+ plans)
+// https://developer.zendesk.com/api-reference/ticketing/business-rules/sla_policies/
+// ---------------------------------------------------------------------------
+
+export type ZendeskSlaPolicyMetric = {
+  priority: string
+  metric: string
+  target: number
+  business_hours: boolean
+}
+
+export type ZendeskSlaPolicy = {
+  id: number
+  title: string
+  description: string | null
+  position: number
+  policy_metrics: ZendeskSlaPolicyMetric[]
+  created_at: string
+  updated_at: string
+}
+
+type ListSlaPoliciesResponse = {
+  sla_policies: ZendeskSlaPolicy[]
+}
+
+// SLA policies are a small collection (typically <20) — no pagination needed.
+export async function fetchSlaPolicies(): Promise<ZendeskSlaPolicy[]> {
+  const subdomain = requireSubdomain()
+  const data = await fetchAll<ListSlaPoliciesResponse>(
+    subdomain,
+    "/api/v2/slas/policies"
+  )
+
+  return data.sla_policies
 }

--- a/examples/workers/syncs/zendesk/src/zendesk.ts
+++ b/examples/workers/syncs/zendesk/src/zendesk.ts
@@ -14,10 +14,19 @@ export type ZendeskTicket = {
   updated_at: string
 }
 
+export type ZendeskUser = {
+  id: number
+  name: string
+  email: string
+}
+
 type ListTicketsResponse = {
   tickets: ZendeskTicket[]
+  users: ZendeskUser[]
   meta: { has_more: boolean; after_cursor: string }
 }
+
+export type UserLookup = Map<number, ZendeskUser>
 
 const PAGE_SIZE = 100
 
@@ -52,7 +61,10 @@ export function buildTicketsUrl(
   cursor?: string
 ): string {
   const base = `https://${subdomain}.zendesk.com/api/v2/tickets.json`
-  const params = new URLSearchParams({ "page[size]": String(PAGE_SIZE) })
+  const params = new URLSearchParams({
+    "page[size]": String(PAGE_SIZE),
+    include: "users",
+  })
   if (cursor) {
     params.set("page[after]", cursor)
   }
@@ -65,6 +77,7 @@ export function requireSubdomain(): string {
 
 export async function fetchTicketsPage(cursor?: string): Promise<{
   tickets: ZendeskTicket[]
+  users: UserLookup
   hasMore: boolean
   nextCursor: string | undefined
 }> {
@@ -86,8 +99,14 @@ export async function fetchTicketsPage(cursor?: string): Promise<{
 
   const data = JSON.parse(text) as ListTicketsResponse
 
+  const users: UserLookup = new Map()
+  for (const user of data.users ?? []) {
+    users.set(user.id, user)
+  }
+
   return {
     tickets: data.tickets,
+    users,
     hasMore: data.meta.has_more,
     nextCursor: data.meta.has_more ? data.meta.after_cursor : undefined,
   }

--- a/examples/workers/syncs/zendesk/src/zendesk.ts
+++ b/examples/workers/syncs/zendesk/src/zendesk.ts
@@ -124,6 +124,8 @@ export type ZendeskTicket = {
   priority: string | null
   assignee_id: number | null
   requester_id: number
+  group_id: number | null
+  organization_id: number | null
   tags: string[]
   satisfaction_rating: { score: string } | null
   via: { channel: string }
@@ -137,11 +139,25 @@ export type ZendeskUser = {
   email: string
 }
 
+export type ZendeskGroup = {
+  id: number
+  name: string
+}
+
+export type ZendeskOrganizationRef = {
+  id: number
+  name: string
+}
+
 export type UserLookup = Map<number, ZendeskUser>
+export type GroupLookup = Map<number, ZendeskGroup>
+export type OrgLookup = Map<number, ZendeskOrganizationRef>
 
 type ListTicketsResponse = {
   tickets: ZendeskTicket[]
   users: ZendeskUser[]
+  groups: ZendeskGroup[]
+  organizations: ZendeskOrganizationRef[]
 }
 
 // Kept for backward compatibility with tests.
@@ -160,11 +176,13 @@ export function buildTicketsUrl(
   return `${base}?${params.toString()}`
 }
 
-// Sideloading (include=users) embeds user objects in the ticket response so
-// we can resolve assignee/requester IDs to names without extra API calls.
+// Sideloading embeds related objects in the ticket response so we can
+// resolve IDs to names without extra API calls.
 export async function fetchTicketsPage(cursor?: string): Promise<{
   tickets: ZendeskTicket[]
   users: UserLookup
+  groups: GroupLookup
+  orgs: OrgLookup
   hasMore: boolean
   nextCursor: string | undefined
 }> {
@@ -172,7 +190,7 @@ export async function fetchTicketsPage(cursor?: string): Promise<{
   const { data, hasMore, nextCursor } = await fetchPage<ListTicketsResponse>(
     subdomain,
     "/api/v2/tickets.json",
-    { include: "users" },
+    { include: "users,groups,organizations" },
     cursor
   )
 
@@ -181,7 +199,17 @@ export async function fetchTicketsPage(cursor?: string): Promise<{
     users.set(user.id, user)
   }
 
-  return { tickets: data.tickets, users, hasMore, nextCursor }
+  const groups: GroupLookup = new Map()
+  for (const group of data.groups ?? []) {
+    groups.set(group.id, group)
+  }
+
+  const orgs: OrgLookup = new Map()
+  for (const org of data.organizations ?? []) {
+    orgs.set(org.id, org)
+  }
+
+  return { tickets: data.tickets, users, groups, orgs, hasMore, nextCursor }
 }
 
 // ---------------------------------------------------------------------------
@@ -310,9 +338,13 @@ export type ZendeskTicketMetric = {
   ticket_id: number
   reopens: number
   replies: number
+  assignee_stations: number
+  group_stations: number
+  solved_at: string | null
   reply_time_in_minutes: { calendar: number; business: number }
   first_resolution_time_in_minutes: { calendar: number; business: number }
   full_resolution_time_in_minutes: { calendar: number; business: number }
+  on_hold_time_in_minutes: { calendar: number; business: number }
   agent_wait_time_in_minutes: { calendar: number; business: number }
   requester_wait_time_in_minutes: { calendar: number; business: number }
   created_at: string

--- a/examples/workers/syncs/zendesk/src/zendesk.ts
+++ b/examples/workers/syncs/zendesk/src/zendesk.ts
@@ -1,3 +1,14 @@
+// Zendesk API client. Handles authentication and paginated ticket fetching.
+//
+// To sync additional related data (e.g. group names, organization names),
+// add them to the `include` parameter in buildTicketsUrl:
+//   include: "users,groups,organizations"
+// Then add the corresponding types and extend the return value of
+// fetchTicketsPage to include the new lookup maps.
+
+// Add fields here when extending the sync — the Zendesk Tickets API returns
+// many more fields than we use. See:
+// https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#json-format
 export type ZendeskTicket = {
   id: number
   subject: string
@@ -38,6 +49,7 @@ function requireEnv(name: string): string {
   return value
 }
 
+// Zendesk API tokens use Basic auth as email/token:apitoken (not Bearer).
 export function getAuthorizationHeader(): string {
   const apiToken = process.env.ZENDESK_API_TOKEN?.trim()
   if (apiToken) {
@@ -56,6 +68,8 @@ export function getAuthorizationHeader(): string {
   )
 }
 
+// Sideloading (include=users) embeds user objects in the ticket response so
+// we can resolve assignee/requester IDs to names without extra API calls.
 export function buildTicketsUrl(
   subdomain: string,
   cursor?: string

--- a/examples/workers/syncs/zendesk/src/zendesk.ts
+++ b/examples/workers/syncs/zendesk/src/zendesk.ts
@@ -1,0 +1,90 @@
+export type ZendeskTicket = {
+  id: number
+  subject: string
+  description: string
+  status: string
+  priority: string | null
+  tags: string[]
+  satisfaction_rating: { score: string } | null
+  created_at: string
+  updated_at: string
+}
+
+type ListTicketsResponse = {
+  tickets: ZendeskTicket[]
+  meta: { has_more: boolean; after_cursor: string }
+}
+
+const PAGE_SIZE = 100
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`${name} is not set.`)
+  }
+  return value
+}
+
+export function getAuthorizationHeader(): string {
+  const apiToken = process.env.ZENDESK_API_TOKEN?.trim()
+  if (apiToken) {
+    const email = requireEnv("ZENDESK_API_USER_EMAIL")
+    return `Basic ${Buffer.from(`${email}/token:${apiToken}`).toString("base64")}`
+  }
+
+  const basicAuth = process.env.ZENDESK_BASIC_AUTH_TOKEN?.trim()
+  if (basicAuth) {
+    return /^basic /i.test(basicAuth) ? basicAuth : `Basic ${basicAuth}`
+  }
+
+  throw new Error(
+    "Zendesk API credentials not configured. " +
+      "Set ZENDESK_API_TOKEN + ZENDESK_API_USER_EMAIL, or ZENDESK_BASIC_AUTH_TOKEN."
+  )
+}
+
+export function buildTicketsUrl(
+  subdomain: string,
+  cursor?: string
+): string {
+  const base = `https://${subdomain}.zendesk.com/api/v2/tickets.json`
+  const params = new URLSearchParams({ "page[size]": String(PAGE_SIZE) })
+  if (cursor) {
+    params.set("page[after]", cursor)
+  }
+  return `${base}?${params.toString()}`
+}
+
+export function requireSubdomain(): string {
+  return requireEnv("ZENDESK_SUBDOMAIN")
+}
+
+export async function fetchTicketsPage(cursor?: string): Promise<{
+  tickets: ZendeskTicket[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const subdomain = requireEnv("ZENDESK_SUBDOMAIN")
+  const authorization = getAuthorizationHeader()
+  const url = buildTicketsUrl(subdomain, cursor)
+
+  const response = await fetch(url, {
+    headers: { Authorization: authorization, Accept: "application/json" },
+    redirect: "error",
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Zendesk API error (${response.status}): ${text || "No response body"}`
+    )
+  }
+
+  const data = JSON.parse(text) as ListTicketsResponse
+
+  return {
+    tickets: data.tickets,
+    hasMore: data.meta.has_more,
+    nextCursor: data.meta.has_more ? data.meta.after_cursor : undefined,
+  }
+}

--- a/examples/workers/syncs/zendesk/src/zendesk.ts
+++ b/examples/workers/syncs/zendesk/src/zendesk.ts
@@ -2,10 +2,14 @@ export type ZendeskTicket = {
   id: number
   subject: string
   description: string
+  type: string | null
   status: string
   priority: string | null
+  assignee_id: number | null
+  requester_id: number
   tags: string[]
   satisfaction_rating: { score: string } | null
+  via: { channel: string }
   created_at: string
   updated_at: string
 }

--- a/examples/workers/syncs/zendesk/test.ts
+++ b/examples/workers/syncs/zendesk/test.ts
@@ -2,7 +2,12 @@
 // No Zendesk connection is made — all assertions run against pure functions.
 // Run: npm test  (or: npx tsx test.ts)
 
-import { ticketToChange, ticketUrl, dateOnly } from "./src/transform.js"
+import {
+  ticketToChange,
+  ticketUrl,
+  formatLabel,
+  dateOnly,
+} from "./src/transform.js"
 import { buildTicketsUrl, getAuthorizationHeader } from "./src/zendesk.js"
 import type { ZendeskTicket, UserLookup } from "./src/zendesk.js"
 
@@ -54,8 +59,8 @@ const change = ticketToChange(standardTicket, SUBDOMAIN, users)
 ok("type is upsert", change.type === "upsert")
 ok("key is ticket id as string", change.key === "42")
 ok(
-  "Tickets contains subject",
-  JSON.stringify(change.properties.Tickets).includes(
+  "Subject contains ticket subject",
+  JSON.stringify(change.properties.Subject).includes(
     "Cannot log in to my account"
   )
 )
@@ -64,41 +69,27 @@ ok(
   JSON.stringify(change.properties["Ticket ID"]).includes("42")
 )
 ok(
-  "Status is capitalized",
-  JSON.stringify(change.properties.Status).includes("Open")
-)
-ok(
-  "Priority is capitalized",
-  JSON.stringify(change.properties.Priority).includes("High")
-)
-ok(
-  "CSAT score is capitalized",
-  JSON.stringify(change.properties["CSAT score"]).includes("Good")
-)
-ok(
-  "Feature tags contains tags",
-  JSON.stringify(change.properties["Feature tags"]).includes("account_access")
-)
-ok(
   "Ticket link contains URL",
   JSON.stringify(change.properties["Ticket link"]).includes(
     "https://acme.zendesk.com/agent/tickets/42"
   )
 )
+ok("Type is formatted", JSON.stringify(change.properties.Type).includes("Problem"))
+ok("Status is formatted", JSON.stringify(change.properties.Status).includes("Open"))
 ok(
-  "upstreamUpdatedAt is set",
-  change.upstreamUpdatedAt === "2024-06-16T14:00:00Z"
+  "Priority is formatted",
+  JSON.stringify(change.properties.Priority).includes("High")
 )
 ok(
-  "pageContentMarkdown contains description",
-  change.pageContentMarkdown.includes("403 error")
+  "CSAT maps good to Satisfied",
+  JSON.stringify(change.properties["CSAT score"]).includes("Satisfied")
 )
 ok(
-  "Type is capitalized",
-  JSON.stringify(change.properties.Type).includes("Problem")
+  "Tags contains raw tag values",
+  JSON.stringify(change.properties.Tags).includes("account_access")
 )
 ok(
-  "Channel is capitalized",
+  "Channel maps email to Email",
   JSON.stringify(change.properties.Channel).includes("Email")
 )
 ok(
@@ -112,6 +103,18 @@ ok(
 ok(
   "Created at contains date",
   JSON.stringify(change.properties["Created at"]).includes("2024-06-15")
+)
+ok(
+  "Updated at contains date",
+  JSON.stringify(change.properties["Updated at"]).includes("2024-06-16")
+)
+ok(
+  "upstreamUpdatedAt is set",
+  change.upstreamUpdatedAt === "2024-06-16T14:00:00Z"
+)
+ok(
+  "pageContentMarkdown contains description",
+  change.pageContentMarkdown.includes("403 error")
 )
 
 // ---------------------------------------------------------------------------
@@ -139,48 +142,54 @@ const minimalTicket: ZendeskTicket = {
 const minimalChange = ticketToChange(minimalTicket, SUBDOMAIN, users)
 
 ok("key is ticket id", minimalChange.key === "99")
-ok(
-  "null priority omits Priority property",
-  minimalChange.properties.Priority === undefined
-)
+ok("null type omits Type", minimalChange.properties.Type === undefined)
+ok("null priority omits Priority", minimalChange.properties.Priority === undefined)
 ok(
   "null satisfaction_rating omits CSAT score",
   minimalChange.properties["CSAT score"] === undefined
 )
-ok(
-  "empty tags omits Feature tags",
-  minimalChange.properties["Feature tags"] === undefined
-)
-ok(
-  "null type omits Type property",
-  minimalChange.properties.Type === undefined
-)
-ok(
-  "null assignee_id omits Assignee",
-  minimalChange.properties.Assignee === undefined
-)
+ok("empty tags omits Tags", minimalChange.properties.Tags === undefined)
+ok("null assignee_id omits Assignee", minimalChange.properties.Assignee === undefined)
 ok(
   "requester resolved to name",
   JSON.stringify(minimalChange.properties.Requester).includes("Alice Requester")
 )
 
 // ---------------------------------------------------------------------------
-// ticketToChange — unknown CSAT score is omitted
+// ticketToChange — CSAT score mapping
 // ---------------------------------------------------------------------------
 
-console.log("ticketToChange — unknown CSAT score:")
+console.log("ticketToChange — CSAT score mapping:")
 
-const unofferedTicket: ZendeskTicket = {
-  ...standardTicket,
-  id: 50,
-  satisfaction_rating: { score: "unoffered" },
+function csatChange(score: string) {
+  const t: ZendeskTicket = {
+    ...standardTicket,
+    satisfaction_rating: { score },
+  }
+  return ticketToChange(t, SUBDOMAIN, users)
 }
 
-const unofferedChange = ticketToChange(unofferedTicket, SUBDOMAIN, users)
-
 ok(
-  "unoffered CSAT score is omitted",
-  unofferedChange.properties["CSAT score"] === undefined
+  "good maps to Satisfied",
+  JSON.stringify(csatChange("good").properties["CSAT score"]).includes(
+    "Satisfied"
+  )
+)
+ok(
+  "bad maps to Not satisfied",
+  JSON.stringify(csatChange("bad").properties["CSAT score"]).includes(
+    "Not satisfied"
+  )
+)
+ok(
+  "offered maps to Pending",
+  JSON.stringify(csatChange("offered").properties["CSAT score"]).includes(
+    "Pending"
+  )
+)
+ok(
+  "unoffered is omitted",
+  csatChange("unoffered").properties["CSAT score"] === undefined
 )
 
 // ---------------------------------------------------------------------------
@@ -200,6 +209,17 @@ ok(
   "requester falls back to numeric ID",
   JSON.stringify(fallbackChange.properties.Requester).includes("2001")
 )
+
+// ---------------------------------------------------------------------------
+// formatLabel — handles underscores and capitalization
+// ---------------------------------------------------------------------------
+
+console.log("formatLabel:")
+
+ok("simple word", formatLabel("open") === "Open")
+ok("underscore separated", formatLabel("mobile_sdk") === "Mobile Sdk")
+ok("single letter", formatLabel("a") === "A")
+ok("empty string", formatLabel("") === "")
 
 // ---------------------------------------------------------------------------
 // dateOnly — extracts YYYY-MM-DD from various formats
@@ -226,10 +246,15 @@ ok(
 )
 
 // ---------------------------------------------------------------------------
-// buildTicketsUrl — constructs Zendesk API URL
+// buildTicketsUrl — constructs Zendesk API URL with sideloading
 // ---------------------------------------------------------------------------
 
 console.log("buildTicketsUrl:")
+
+ok(
+  "includes users sideload",
+  buildTicketsUrl("acme").includes("include=users")
+)
 
 ok(
   "builds URL without cursor",

--- a/examples/workers/syncs/zendesk/test.ts
+++ b/examples/workers/syncs/zendesk/test.ts
@@ -9,7 +9,7 @@ import {
   dateOnly,
 } from "./src/transform.js"
 import { buildTicketsUrl, getAuthorizationHeader } from "./src/zendesk.js"
-import type { ZendeskTicket, UserLookup } from "./src/zendesk.js"
+import type { ZendeskTicket, UserLookup, GroupLookup, OrgLookup } from "./src/zendesk.js"
 
 let passed = 0
 let failed = 0
@@ -38,6 +38,14 @@ const users: UserLookup = new Map([
   [3001, { id: 3001, name: "Alice Requester", email: "alice@example.com" }],
 ])
 
+const groups: GroupLookup = new Map([
+  [100, { id: 100, name: "Billing Support" }],
+])
+
+const orgs: OrgLookup = new Map([
+  [500, { id: 500, name: "Acme Corp" }],
+])
+
 const standardTicket: ZendeskTicket = {
   id: 42,
   subject: "Cannot log in to my account",
@@ -47,6 +55,8 @@ const standardTicket: ZendeskTicket = {
   priority: "high",
   assignee_id: 1001,
   requester_id: 2001,
+  group_id: 100,
+  organization_id: 500,
   tags: ["account_access", "login"],
   satisfaction_rating: { score: "good" },
   via: { channel: "email" },
@@ -54,7 +64,7 @@ const standardTicket: ZendeskTicket = {
   updated_at: "2024-06-16T14:00:00Z",
 }
 
-const change = ticketToChange(standardTicket, SUBDOMAIN, users)
+const change = ticketToChange(standardTicket, SUBDOMAIN, users, groups, orgs)
 
 ok("type is upsert", change.type === "upsert")
 ok("key is ticket id as string", change.key === "42")
@@ -97,8 +107,16 @@ ok(
   JSON.stringify(change.properties.Assignee).includes("Jane Smith")
 )
 ok(
+  "Group resolved to name",
+  JSON.stringify(change.properties.Group).includes("Billing Support")
+)
+ok(
   "Requester resolved to name",
   JSON.stringify(change.properties.Requester).includes("Bob Customer")
+)
+ok(
+  "Organization resolved to name",
+  JSON.stringify(change.properties.Organization).includes("Acme Corp")
 )
 ok(
   "Created at contains date",
@@ -132,6 +150,8 @@ const minimalTicket: ZendeskTicket = {
   priority: null,
   assignee_id: null,
   requester_id: 3001,
+  group_id: null,
+  organization_id: null,
   tags: [],
   satisfaction_rating: null,
   via: { channel: "web" },
@@ -139,7 +159,7 @@ const minimalTicket: ZendeskTicket = {
   updated_at: "2024-01-01",
 }
 
-const minimalChange = ticketToChange(minimalTicket, SUBDOMAIN, users)
+const minimalChange = ticketToChange(minimalTicket, SUBDOMAIN, users, groups, orgs)
 
 ok("key is ticket id", minimalChange.key === "99")
 ok("null type omits Type", minimalChange.properties.Type === undefined)
@@ -150,6 +170,8 @@ ok(
 )
 ok("empty tags omits Tags", minimalChange.properties.Tags === undefined)
 ok("null assignee_id omits Assignee", minimalChange.properties.Assignee === undefined)
+ok("null group_id omits Group", minimalChange.properties.Group === undefined)
+ok("null organization_id omits Organization", minimalChange.properties.Organization === undefined)
 ok(
   "requester resolved to name",
   JSON.stringify(minimalChange.properties.Requester).includes("Alice Requester")
@@ -166,7 +188,7 @@ function csatChange(score: string) {
     ...standardTicket,
     satisfaction_rating: { score },
   }
-  return ticketToChange(t, SUBDOMAIN, users)
+  return ticketToChange(t, SUBDOMAIN, users, groups, orgs)
 }
 
 ok(
@@ -199,7 +221,9 @@ ok(
 console.log("ticketToChange — unknown user ID falls back to numeric string:")
 
 const emptyUsers: UserLookup = new Map()
-const fallbackChange = ticketToChange(standardTicket, SUBDOMAIN, emptyUsers)
+const emptyGroups: GroupLookup = new Map()
+const emptyOrgs: OrgLookup = new Map()
+const fallbackChange = ticketToChange(standardTicket, SUBDOMAIN, emptyUsers, emptyGroups, emptyOrgs)
 
 ok(
   "assignee falls back to numeric ID",
@@ -208,6 +232,14 @@ ok(
 ok(
   "requester falls back to numeric ID",
   JSON.stringify(fallbackChange.properties.Requester).includes("2001")
+)
+ok(
+  "group falls back to numeric ID",
+  JSON.stringify(fallbackChange.properties.Group).includes("100")
+)
+ok(
+  "unknown org omits Organization",
+  fallbackChange.properties.Organization === undefined
 )
 
 // ---------------------------------------------------------------------------

--- a/examples/workers/syncs/zendesk/test.ts
+++ b/examples/workers/syncs/zendesk/test.ts
@@ -4,7 +4,7 @@
 
 import { ticketToChange, ticketUrl, dateOnly } from "./src/transform.js"
 import { buildTicketsUrl, getAuthorizationHeader } from "./src/zendesk.js"
-import type { ZendeskTicket } from "./src/zendesk.js"
+import type { ZendeskTicket, UserLookup } from "./src/zendesk.js"
 
 let passed = 0
 let failed = 0
@@ -27,6 +27,12 @@ console.log("ticketToChange — standard ticket:")
 
 const SUBDOMAIN = "acme"
 
+const users: UserLookup = new Map([
+  [1001, { id: 1001, name: "Jane Smith", email: "jane@acme.com" }],
+  [2001, { id: 2001, name: "Bob Customer", email: "bob@example.com" }],
+  [3001, { id: 3001, name: "Alice Requester", email: "alice@example.com" }],
+])
+
 const standardTicket: ZendeskTicket = {
   id: 42,
   subject: "Cannot log in to my account",
@@ -43,7 +49,7 @@ const standardTicket: ZendeskTicket = {
   updated_at: "2024-06-16T14:00:00Z",
 }
 
-const change = ticketToChange(standardTicket, SUBDOMAIN)
+const change = ticketToChange(standardTicket, SUBDOMAIN, users)
 
 ok("type is upsert", change.type === "upsert")
 ok("key is ticket id as string", change.key === "42")
@@ -96,12 +102,12 @@ ok(
   JSON.stringify(change.properties.Channel).includes("Email")
 )
 ok(
-  "Assignee ID is set",
-  JSON.stringify(change.properties["Assignee ID"]).includes("1001")
+  "Assignee resolved to name",
+  JSON.stringify(change.properties.Assignee).includes("Jane Smith")
 )
 ok(
-  "Requester ID is set",
-  JSON.stringify(change.properties["Requester ID"]).includes("2001")
+  "Requester resolved to name",
+  JSON.stringify(change.properties.Requester).includes("Bob Customer")
 )
 ok(
   "Created at contains date",
@@ -130,7 +136,7 @@ const minimalTicket: ZendeskTicket = {
   updated_at: "2024-01-01",
 }
 
-const minimalChange = ticketToChange(minimalTicket, SUBDOMAIN)
+const minimalChange = ticketToChange(minimalTicket, SUBDOMAIN, users)
 
 ok("key is ticket id", minimalChange.key === "99")
 ok(
@@ -150,12 +156,12 @@ ok(
   minimalChange.properties.Type === undefined
 )
 ok(
-  "null assignee_id omits Assignee ID",
-  minimalChange.properties["Assignee ID"] === undefined
+  "null assignee_id omits Assignee",
+  minimalChange.properties.Assignee === undefined
 )
 ok(
-  "requester_id is always set",
-  JSON.stringify(minimalChange.properties["Requester ID"]).includes("3001")
+  "requester resolved to name",
+  JSON.stringify(minimalChange.properties.Requester).includes("Alice Requester")
 )
 
 // ---------------------------------------------------------------------------
@@ -170,11 +176,29 @@ const unofferedTicket: ZendeskTicket = {
   satisfaction_rating: { score: "unoffered" },
 }
 
-const unofferedChange = ticketToChange(unofferedTicket, SUBDOMAIN)
+const unofferedChange = ticketToChange(unofferedTicket, SUBDOMAIN, users)
 
 ok(
   "unoffered CSAT score is omitted",
   unofferedChange.properties["CSAT score"] === undefined
+)
+
+// ---------------------------------------------------------------------------
+// ticketToChange — user ID fallback when not in lookup
+// ---------------------------------------------------------------------------
+
+console.log("ticketToChange — unknown user ID falls back to numeric string:")
+
+const emptyUsers: UserLookup = new Map()
+const fallbackChange = ticketToChange(standardTicket, SUBDOMAIN, emptyUsers)
+
+ok(
+  "assignee falls back to numeric ID",
+  JSON.stringify(fallbackChange.properties.Assignee).includes("1001")
+)
+ok(
+  "requester falls back to numeric ID",
+  JSON.stringify(fallbackChange.properties.Requester).includes("2001")
 )
 
 // ---------------------------------------------------------------------------
@@ -210,13 +234,13 @@ console.log("buildTicketsUrl:")
 ok(
   "builds URL without cursor",
   buildTicketsUrl("acme") ===
-    "https://acme.zendesk.com/api/v2/tickets.json?page%5Bsize%5D=100"
+    "https://acme.zendesk.com/api/v2/tickets.json?page%5Bsize%5D=100&include=users"
 )
 
 ok(
   "builds URL with cursor",
   buildTicketsUrl("acme", "abc123") ===
-    "https://acme.zendesk.com/api/v2/tickets.json?page%5Bsize%5D=100&page%5Bafter%5D=abc123"
+    "https://acme.zendesk.com/api/v2/tickets.json?page%5Bsize%5D=100&include=users&page%5Bafter%5D=abc123"
 )
 
 // ---------------------------------------------------------------------------

--- a/examples/workers/syncs/zendesk/test.ts
+++ b/examples/workers/syncs/zendesk/test.ts
@@ -31,10 +31,14 @@ const standardTicket: ZendeskTicket = {
   id: 42,
   subject: "Cannot log in to my account",
   description: "I keep getting a 403 error when I try to log in.",
+  type: "problem",
   status: "open",
   priority: "high",
+  assignee_id: 1001,
+  requester_id: 2001,
   tags: ["account_access", "login"],
   satisfaction_rating: { score: "good" },
+  via: { channel: "email" },
   created_at: "2024-06-15T10:30:00Z",
   updated_at: "2024-06-16T14:00:00Z",
 }
@@ -84,6 +88,22 @@ ok(
   change.pageContentMarkdown.includes("403 error")
 )
 ok(
+  "Type is capitalized",
+  JSON.stringify(change.properties.Type).includes("Problem")
+)
+ok(
+  "Channel is capitalized",
+  JSON.stringify(change.properties.Channel).includes("Email")
+)
+ok(
+  "Assignee ID is set",
+  JSON.stringify(change.properties["Assignee ID"]).includes("1001")
+)
+ok(
+  "Requester ID is set",
+  JSON.stringify(change.properties["Requester ID"]).includes("2001")
+)
+ok(
   "Created at contains date",
   JSON.stringify(change.properties["Created at"]).includes("2024-06-15")
 )
@@ -98,10 +118,14 @@ const minimalTicket: ZendeskTicket = {
   id: 99,
   subject: "Quick question",
   description: "",
+  type: null,
   status: "new",
   priority: null,
+  assignee_id: null,
+  requester_id: 3001,
   tags: [],
   satisfaction_rating: null,
+  via: { channel: "web" },
   created_at: "2024-01-01",
   updated_at: "2024-01-01",
 }
@@ -120,6 +144,18 @@ ok(
 ok(
   "empty tags omits Feature tags",
   minimalChange.properties["Feature tags"] === undefined
+)
+ok(
+  "null type omits Type property",
+  minimalChange.properties.Type === undefined
+)
+ok(
+  "null assignee_id omits Assignee ID",
+  minimalChange.properties["Assignee ID"] === undefined
+)
+ok(
+  "requester_id is always set",
+  JSON.stringify(minimalChange.properties["Requester ID"]).includes("3001")
 )
 
 // ---------------------------------------------------------------------------

--- a/examples/workers/syncs/zendesk/test.ts
+++ b/examples/workers/syncs/zendesk/test.ts
@@ -1,0 +1,229 @@
+// Offline tests for the zendesk-sync worker.
+// No Zendesk connection is made — all assertions run against pure functions.
+// Run: npm test  (or: npx tsx test.ts)
+
+import { ticketToChange, ticketUrl, dateOnly } from "./src/transform.js"
+import { buildTicketsUrl, getAuthorizationHeader } from "./src/zendesk.js"
+import type { ZendeskTicket } from "./src/zendesk.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ticketToChange — maps a Zendesk ticket to a sync upsert change
+// ---------------------------------------------------------------------------
+
+console.log("ticketToChange — standard ticket:")
+
+const SUBDOMAIN = "acme"
+
+const standardTicket: ZendeskTicket = {
+  id: 42,
+  subject: "Cannot log in to my account",
+  description: "I keep getting a 403 error when I try to log in.",
+  status: "open",
+  priority: "high",
+  tags: ["account_access", "login"],
+  satisfaction_rating: { score: "good" },
+  created_at: "2024-06-15T10:30:00Z",
+  updated_at: "2024-06-16T14:00:00Z",
+}
+
+const change = ticketToChange(standardTicket, SUBDOMAIN)
+
+ok("type is upsert", change.type === "upsert")
+ok("key is ticket id as string", change.key === "42")
+ok(
+  "Tickets contains subject",
+  JSON.stringify(change.properties.Tickets).includes(
+    "Cannot log in to my account"
+  )
+)
+ok(
+  "Ticket ID contains id",
+  JSON.stringify(change.properties["Ticket ID"]).includes("42")
+)
+ok(
+  "Status is capitalized",
+  JSON.stringify(change.properties.Status).includes("Open")
+)
+ok(
+  "Priority is capitalized",
+  JSON.stringify(change.properties.Priority).includes("High")
+)
+ok(
+  "CSAT score is capitalized",
+  JSON.stringify(change.properties["CSAT score"]).includes("Good")
+)
+ok(
+  "Feature tags contains tags",
+  JSON.stringify(change.properties["Feature tags"]).includes("account_access")
+)
+ok(
+  "Ticket link contains URL",
+  JSON.stringify(change.properties["Ticket link"]).includes(
+    "https://acme.zendesk.com/agent/tickets/42"
+  )
+)
+ok(
+  "upstreamUpdatedAt is set",
+  change.upstreamUpdatedAt === "2024-06-16T14:00:00Z"
+)
+ok(
+  "pageContentMarkdown contains description",
+  change.pageContentMarkdown.includes("403 error")
+)
+ok(
+  "Created at contains date",
+  JSON.stringify(change.properties["Created at"]).includes("2024-06-15")
+)
+
+// ---------------------------------------------------------------------------
+// ticketToChange — ticket with missing optional fields
+// ---------------------------------------------------------------------------
+
+console.log("ticketToChange — minimal ticket:")
+
+const minimalTicket: ZendeskTicket = {
+  id: 99,
+  subject: "Quick question",
+  description: "",
+  status: "new",
+  priority: null,
+  tags: [],
+  satisfaction_rating: null,
+  created_at: "2024-01-01",
+  updated_at: "2024-01-01",
+}
+
+const minimalChange = ticketToChange(minimalTicket, SUBDOMAIN)
+
+ok("key is ticket id", minimalChange.key === "99")
+ok(
+  "null priority omits Priority property",
+  minimalChange.properties.Priority === undefined
+)
+ok(
+  "null satisfaction_rating omits CSAT score",
+  minimalChange.properties["CSAT score"] === undefined
+)
+ok(
+  "empty tags omits Feature tags",
+  minimalChange.properties["Feature tags"] === undefined
+)
+
+// ---------------------------------------------------------------------------
+// ticketToChange — unknown CSAT score is omitted
+// ---------------------------------------------------------------------------
+
+console.log("ticketToChange — unknown CSAT score:")
+
+const unofferedTicket: ZendeskTicket = {
+  ...standardTicket,
+  id: 50,
+  satisfaction_rating: { score: "unoffered" },
+}
+
+const unofferedChange = ticketToChange(unofferedTicket, SUBDOMAIN)
+
+ok(
+  "unoffered CSAT score is omitted",
+  unofferedChange.properties["CSAT score"] === undefined
+)
+
+// ---------------------------------------------------------------------------
+// dateOnly — extracts YYYY-MM-DD from various formats
+// ---------------------------------------------------------------------------
+
+console.log("dateOnly:")
+
+ok(
+  "ISO timestamp returns date part",
+  dateOnly("2024-03-15T12:00:00Z") === "2024-03-15"
+)
+ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
+ok("empty string returns empty", dateOnly("") === "")
+
+// ---------------------------------------------------------------------------
+// ticketUrl — builds Zendesk agent URL
+// ---------------------------------------------------------------------------
+
+console.log("ticketUrl:")
+
+ok(
+  "builds correct URL",
+  ticketUrl("acme", 42) === "https://acme.zendesk.com/agent/tickets/42"
+)
+
+// ---------------------------------------------------------------------------
+// buildTicketsUrl — constructs Zendesk API URL
+// ---------------------------------------------------------------------------
+
+console.log("buildTicketsUrl:")
+
+ok(
+  "builds URL without cursor",
+  buildTicketsUrl("acme") ===
+    "https://acme.zendesk.com/api/v2/tickets.json?page%5Bsize%5D=100"
+)
+
+ok(
+  "builds URL with cursor",
+  buildTicketsUrl("acme", "abc123") ===
+    "https://acme.zendesk.com/api/v2/tickets.json?page%5Bsize%5D=100&page%5Bafter%5D=abc123"
+)
+
+// ---------------------------------------------------------------------------
+// getAuthorizationHeader — requires env vars
+// ---------------------------------------------------------------------------
+
+console.log("getAuthorizationHeader:")
+
+const origToken = process.env.ZENDESK_API_TOKEN
+const origEmail = process.env.ZENDESK_API_USER_EMAIL
+const origBasic = process.env.ZENDESK_BASIC_AUTH_TOKEN
+
+// Clean up env for isolated tests
+delete process.env.ZENDESK_API_TOKEN
+delete process.env.ZENDESK_API_USER_EMAIL
+delete process.env.ZENDESK_BASIC_AUTH_TOKEN
+
+let threw = false
+try {
+  getAuthorizationHeader()
+} catch {
+  threw = true
+}
+ok("throws when no credentials configured", threw)
+
+process.env.ZENDESK_API_TOKEN = "test-token"
+process.env.ZENDESK_API_USER_EMAIL = "agent@example.com"
+
+const header = getAuthorizationHeader()
+ok("returns Basic auth header", header.startsWith("Basic "))
+ok(
+  "encodes email/token:apitoken",
+  Buffer.from(header.replace("Basic ", ""), "base64").toString() ===
+    "agent@example.com/token:test-token"
+)
+
+// Restore env
+if (origToken) process.env.ZENDESK_API_TOKEN = origToken
+else delete process.env.ZENDESK_API_TOKEN
+if (origEmail) process.env.ZENDESK_API_USER_EMAIL = origEmail
+else delete process.env.ZENDESK_API_USER_EMAIL
+if (origBasic) process.env.ZENDESK_BASIC_AUTH_TOKEN = origBasic
+else delete process.env.ZENDESK_BASIC_AUTH_TOKEN
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/syncs/zendesk/tsconfig.json
+++ b/examples/workers/syncs/zendesk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a Zendesk sync worker at `examples/workers/syncs/zendesk` that syncs six Zendesk resources into managed Notion databases:
  - **Tickets** (every 5 min) — subject, status, priority, type, tags, channel, CSAT score, assignee/requester names (resolved via sideloading), ticket description as page body
  - **Organizations** (every 1 hr) — company name, domains, tags, details, notes as page body
  - **Users** (every 1 hr) — agents and end-users with email, role, phone, suspended status, last login
  - **Satisfaction Ratings** (every 30 min) — CSAT responses with customer comments and scores (Professional+ plans)
  - **Ticket Metrics** (every 30 min) — first reply time, resolution times, reopens, replies in calendar minutes
  - **SLA Policies** (manual trigger) — policy definitions with targets rendered as a markdown table (Professional+ plans)
- All syncs share a single `worker.pacer()` to respect Zendesk's 400 req/min rate limit
- Uses Zendesk cursor-based pagination and `mode: "replace"` for automatic cleanup of deleted records
- Includes offline tests, `.env.example`, and a comprehensive README with setup instructions

## Test plan

- [ ] `npm run check` passes (typecheck)
- [ ] `npm test` passes (offline tests for ticket transform, URL building, auth, CSAT mapping, user ID fallback)
- [ ] `ntn workers sync trigger ticketsSync --preview` returns expected ticket data
- [ ] `ntn workers sync trigger organizationsSync --preview` returns expected org data
- [ ] Verify managed databases appear in Notion workspace after first sync
- [ ] Verify Professional+ syncs (CSAT, SLA) return clear errors on lower-tier plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)