### PR TITLE
feat(workers): add hubspot sync example

### DIFF
--- a/examples/workers/syncs/hubspot/.env.example
+++ b/examples/workers/syncs/hubspot/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Required
+# A HubSpot private app access token. Create one in Settings > Integrations >
+# Private Apps with scopes: crm.objects.contacts.read, crm.objects.deals.read,
+# crm.objects.companies.read, crm.objects.owners.read.
+HUBSPOT_ACCESS_TOKEN=
+
+# Your HubSpot portal (account) ID. Find it in Settings > Account Management,
+# or in the URL when logged in (app.hubspot.com/contacts/{portalId}).
+HUBSPOT_PORTAL_ID=

--- a/examples/workers/syncs/hubspot/.gitignore
+++ b/examples/workers/syncs/hubspot/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/hubspot/README.md
+++ b/examples/workers/syncs/hubspot/README.md
@@ -1,0 +1,232 @@
+# Worker sync: HubSpot
+
+Syncs HubSpot CRM contacts, deals, and companies into Notion databases that
+stay up to date automatically. Once deployed, the worker checks HubSpot every
+5 minutes and creates or updates a Notion page for each record.
+
+You don't need to create the Notion databases yourself. The worker declares the
+schemas and Notion creates and manages each database for you (these are called
+"managed databases").
+
+## What you get
+
+| Database | HubSpot resource | Schedule |
+| --- | --- | --- |
+| **HubSpot Contacts** | Contacts | Every 5 min |
+| **HubSpot Deals** | Deals | Every 5 min |
+| **HubSpot Companies** | Companies | Every 5 min |
+
+### HubSpot Contacts
+
+| Notion property | HubSpot field | Type |
+| --- | --- | --- |
+| Name | `firstname` + `lastname` | title |
+| Lifecycle Stage | `lifecyclestage` | select |
+| Lead Status | `hs_lead_status` | select |
+| Email | `email` | email |
+| Company | `company` | richText |
+| Last Activity | `notes_last_updated` | date |
+| Owner | `hubspot_owner_id` (resolved) | richText |
+| Job Title | `jobtitle` | richText |
+| Phone | `phone` | richText |
+| Created | `createdate` | date |
+| Contact Link | link to HubSpot record | url |
+| Contact ID | `hs_object_id` | richText |
+
+### HubSpot Deals
+
+| Notion property | HubSpot field | Type |
+| --- | --- | --- |
+| Deal Name | `dealname` | title |
+| Stage | `dealstage` | select |
+| Amount | `amount` | number |
+| Close Date | `closedate` | date |
+| Owner | `hubspot_owner_id` (resolved) | richText |
+| Deal Link | link to HubSpot record | url |
+| Pipeline | `pipeline` | richText |
+| Deal Type | `dealtype` | select |
+| Created | `createdate` | date |
+| Deal ID | `hs_object_id` | richText |
+
+### HubSpot Companies
+
+| Notion property | HubSpot field | Type |
+| --- | --- | --- |
+| Name | `name` | title |
+| Industry | `industry` | select |
+| Domain | `domain` | url |
+| Annual Revenue | `annualrevenue` | number |
+| Number of Employees | `numberofemployees` | number |
+| Owner | `hubspot_owner_id` (resolved) | richText |
+| Type | `type` | select |
+| City | `city` | richText |
+| Country | `country` | richText |
+| Phone | `phone` | richText |
+| Created | `createdate` | date |
+| Company Link | link to HubSpot record | url |
+| Company ID | `hs_object_id` | richText |
+
+Owner IDs are resolved to names by fetching all HubSpot owners once per sync
+cycle — no extra API call per record.
+
+## Project structure
+
+```text
+src/
+├── index.ts       — registers all databases and syncs
+├── hubspot.ts     — API client (auth, pagination, types, owner resolution)
+├── contacts.ts    — contact schema + transform
+├── deals.ts       — deal schema + transform
+├── companies.ts   — company schema + transform
+└── helpers.ts     — shared utilities (dateOnly)
+```
+
+## How it works
+
+1. Every 5 minutes, the worker fetches each CRM object type using HubSpot's
+   list endpoint with cursor-based pagination (100 records per page).
+2. Owner IDs are resolved to names by fetching all owners once at the start
+   of each sync cycle and building a lookup map.
+3. Each record is converted to an `upsert` keyed by HubSpot's record ID, so
+   records are never duplicated.
+4. All three syncs share a single rate-limit pacer (90 requests per 10 seconds)
+   to stay within HubSpot's 100/10s limit on Free/Starter plans.
+5. Because all syncs use `mode: "replace"`, records deleted in HubSpot are
+   automatically removed from the Notion database on the next full sync.
+
+## Prerequisites
+
+- Node >= 22, npm >= 10.9.2
+- A HubSpot account with CRM data
+- The `ntn` CLI installed and authenticated (`ntn auth login`)
+
+### Getting a HubSpot access token
+
+1. Go to **Settings > Integrations > Private Apps**
+2. Click **Create a private app**
+3. Under **Scopes**, add:
+   - `crm.objects.contacts.read`
+   - `crm.objects.deals.read`
+   - `crm.objects.companies.read`
+   - `crm.objects.owners.read`
+4. Click **Create app** and copy the access token
+
+### Finding your portal ID
+
+Your portal ID is visible in **Settings > Account Management**, or in the URL
+when logged into HubSpot: `app.hubspot.com/contacts/{portalId}`.
+
+## Environment variables
+
+### Required
+
+| Variable | Description |
+| --- | --- |
+| `HUBSPOT_ACCESS_TOKEN` | Private app access token with CRM read scopes |
+| `HUBSPOT_PORTAL_ID` | Your HubSpot account (portal) ID |
+
+No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
+automatically.
+
+## Setup and deploy
+
+1. Install the Notion Workers CLI:
+
+   ```sh
+   npm install -g @notionhq/ntn
+   ```
+
+2. Clone and install:
+
+   ```sh
+   cd examples/workers/syncs/hubspot
+   npm install
+   ```
+
+3. Typecheck and test:
+
+   ```sh
+   npm run check
+   npm test
+   ```
+
+4. Log in to Notion:
+
+   ```sh
+   ntn auth login
+   ```
+
+5. Deploy the worker:
+
+   ```sh
+   ntn workers deploy
+   ```
+
+6. Set environment variables on the deployed worker:
+
+   ```sh
+   ntn workers env set HUBSPOT_ACCESS_TOKEN=pat-na1-your-token-here
+   ntn workers env set HUBSPOT_PORTAL_ID=12345678
+   ```
+
+7. Preview a sync without writing to Notion:
+
+   ```sh
+   ntn workers sync trigger contactsSync --preview
+   ntn workers sync trigger dealsSync --preview
+   ntn workers sync trigger companiesSync --preview
+   ```
+
+8. Run a real sync:
+
+   ```sh
+   ntn workers sync trigger contactsSync
+   ntn workers sync trigger dealsSync
+   ntn workers sync trigger companiesSync
+   ```
+
+Once deployed, all three syncs run automatically every 5 minutes. Three
+databases will appear in your Notion workspace after the first run.
+
+## Adapting the schema
+
+Each resource has its own file with a schema and transform function:
+
+| Resource | File |
+| --- | --- |
+| Contacts | `src/contacts.ts` |
+| Deals | `src/deals.ts` |
+| Companies | `src/companies.ts` |
+
+To add a new HubSpot property:
+
+1. Add the property name to the properties list in `src/hubspot.ts`
+2. Add the field to the resource's type in `src/hubspot.ts`
+3. Add a property to the schema with the appropriate `Schema.*` type
+4. Add a `Builder.*` call in the transform function
+
+HubSpot only returns properties you explicitly request — adding a field to the
+type without adding it to the properties list will return null.
+
+## Local testing
+
+Run offline tests (no HubSpot connection needed):
+
+```sh
+npm test
+```
+
+Test a sync locally against a real HubSpot account:
+
+```sh
+ntn workers exec contactsSync --local
+```
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [HubSpot CRM API — Contacts](https://developers.hubspot.com/docs/api/crm/contacts)
+- [HubSpot CRM API — Deals](https://developers.hubspot.com/docs/api/crm/deals)
+- [HubSpot CRM API — Companies](https://developers.hubspot.com/docs/api/crm/companies)
+- [HubSpot Private Apps](https://developers.hubspot.com/docs/api/private-apps)
+- [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/hubspot/package.json
+++ b/examples/workers/syncs/hubspot/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hubspot",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/hubspot/src/companies.ts
+++ b/examples/workers/syncs/hubspot/src/companies.ts
@@ -23,6 +23,20 @@ export const companySchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Owner: Schema.richText(),
 
+    "Open Deals": Schema.number(),
+
+    "Total Revenue": Schema.number(),
+
+    "Lifecycle Stage": Schema.select([
+      { name: "Subscriber" },
+      { name: "Lead" },
+      { name: "Marketing Qualified Lead" },
+      { name: "Sales Qualified Lead" },
+      { name: "Opportunity" },
+      { name: "Customer" },
+      { name: "Evangelist" },
+    ]),
+
     Type: Schema.select([
       { name: "Prospect" },
       { name: "Partner" },
@@ -37,12 +51,24 @@ export const companySchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Phone: Schema.richText(),
 
+    Updated: Schema.date(),
+
     Created: Schema.date(),
 
     "Company Link": Schema.url(),
 
     "Company ID": Schema.richText(),
   },
+}
+
+const LIFECYCLE_LABELS: Record<string, string> = {
+  subscriber: "Subscriber",
+  lead: "Lead",
+  marketingqualifiedlead: "Marketing Qualified Lead",
+  salesqualifiedlead: "Sales Qualified Lead",
+  opportunity: "Opportunity",
+  customer: "Customer",
+  evangelist: "Evangelist",
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -62,17 +88,25 @@ export function companyToChange(
 ) {
   const owner = ownerName(owners, company.hubspot_owner_id)
   const companyType = TYPE_LABELS[company.type?.toUpperCase() ?? ""]
+  const lifecycle = LIFECYCLE_LABELS[company.lifecyclestage ?? ""]
   const employees = company.numberofemployees
     ? Number(company.numberofemployees)
     : null
   const revenue = company.annualrevenue
     ? Number(company.annualrevenue)
     : null
+  const openDeals = company.hs_num_open_deals
+    ? Number(company.hs_num_open_deals)
+    : null
+  const totalRevenue = company.total_revenue
+    ? Number(company.total_revenue)
+    : null
 
   return {
     type: "upsert" as const,
     key: id,
     upstreamUpdatedAt: updatedAt,
+    pageContentMarkdown: company.description ?? "",
     properties: {
       Name: Builder.title(company.name ?? ""),
       ...(company.industry
@@ -88,6 +122,15 @@ export function companyToChange(
         ? { "Number of Employees": Builder.number(employees) }
         : {}),
       ...(owner ? { Owner: Builder.richText(owner) } : {}),
+      ...(openDeals != null && !isNaN(openDeals)
+        ? { "Open Deals": Builder.number(openDeals) }
+        : {}),
+      ...(totalRevenue != null && !isNaN(totalRevenue)
+        ? { "Total Revenue": Builder.number(totalRevenue) }
+        : {}),
+      ...(lifecycle
+        ? { "Lifecycle Stage": Builder.select(lifecycle) }
+        : {}),
       ...(companyType ? { Type: Builder.select(companyType) } : {}),
       ...(company.city
         ? { City: Builder.richText(company.city) }
@@ -98,6 +141,7 @@ export function companyToChange(
       ...(company.phone
         ? { Phone: Builder.richText(company.phone) }
         : {}),
+      Updated: Builder.date(dateOnly(updatedAt)),
       ...(company.createdate
         ? { Created: Builder.date(dateOnly(company.createdate)) }
         : {}),

--- a/examples/workers/syncs/hubspot/src/companies.ts
+++ b/examples/workers/syncs/hubspot/src/companies.ts
@@ -1,0 +1,110 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import type { HubSpotCompany, OwnerLookup } from "./hubspot.js"
+import { ownerName } from "./hubspot.js"
+import { dateOnly } from "./helpers.js"
+
+export const INITIAL_TITLE = "HubSpot Companies"
+export const PRIMARY_KEY = "Company ID"
+
+export const companySchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("briefcase"),
+  properties: {
+    Name: Schema.title(),
+
+    Industry: Schema.select([]),
+
+    Domain: Schema.url(),
+
+    "Annual Revenue": Schema.number(),
+
+    "Number of Employees": Schema.number(),
+
+    Owner: Schema.richText(),
+
+    Type: Schema.select([
+      { name: "Prospect" },
+      { name: "Partner" },
+      { name: "Reseller" },
+      { name: "Vendor" },
+      { name: "Customer" },
+    ]),
+
+    City: Schema.richText(),
+
+    Country: Schema.richText(),
+
+    Phone: Schema.richText(),
+
+    Created: Schema.date(),
+
+    "Company Link": Schema.url(),
+
+    "Company ID": Schema.richText(),
+  },
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  PROSPECT: "Prospect",
+  PARTNER: "Partner",
+  RESELLER: "Reseller",
+  VENDOR: "Vendor",
+  CUSTOMER: "Customer",
+}
+
+export function companyToChange(
+  id: string,
+  company: HubSpotCompany,
+  updatedAt: string,
+  portalId: string,
+  owners: OwnerLookup
+) {
+  const owner = ownerName(owners, company.hubspot_owner_id)
+  const companyType = TYPE_LABELS[company.type?.toUpperCase() ?? ""]
+  const employees = company.numberofemployees
+    ? Number(company.numberofemployees)
+    : null
+  const revenue = company.annualrevenue
+    ? Number(company.annualrevenue)
+    : null
+
+  return {
+    type: "upsert" as const,
+    key: id,
+    upstreamUpdatedAt: updatedAt,
+    properties: {
+      Name: Builder.title(company.name ?? ""),
+      ...(company.industry
+        ? { Industry: Builder.select(company.industry) }
+        : {}),
+      ...(company.domain
+        ? { Domain: Builder.url(`https://${company.domain}`) }
+        : {}),
+      ...(revenue != null && !isNaN(revenue)
+        ? { "Annual Revenue": Builder.number(revenue) }
+        : {}),
+      ...(employees != null && !isNaN(employees)
+        ? { "Number of Employees": Builder.number(employees) }
+        : {}),
+      ...(owner ? { Owner: Builder.richText(owner) } : {}),
+      ...(companyType ? { Type: Builder.select(companyType) } : {}),
+      ...(company.city
+        ? { City: Builder.richText(company.city) }
+        : {}),
+      ...(company.country
+        ? { Country: Builder.richText(company.country) }
+        : {}),
+      ...(company.phone
+        ? { Phone: Builder.richText(company.phone) }
+        : {}),
+      ...(company.createdate
+        ? { Created: Builder.date(dateOnly(company.createdate)) }
+        : {}),
+      "Company Link": Builder.url(
+        `https://app.hubspot.com/contacts/${portalId}/company/${id}`
+      ),
+      "Company ID": Builder.richText(id),
+    },
+  }
+}

--- a/examples/workers/syncs/hubspot/src/contacts.ts
+++ b/examples/workers/syncs/hubspot/src/contacts.ts
@@ -1,0 +1,123 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import type { HubSpotContact, OwnerLookup } from "./hubspot.js"
+import { ownerName } from "./hubspot.js"
+import { dateOnly } from "./helpers.js"
+
+export const INITIAL_TITLE = "HubSpot Contacts"
+export const PRIMARY_KEY = "Contact ID"
+
+export const contactSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("people"),
+  properties: {
+    Name: Schema.title(),
+
+    "Lifecycle Stage": Schema.select([
+      { name: "Subscriber" },
+      { name: "Lead" },
+      { name: "Marketing Qualified Lead" },
+      { name: "Sales Qualified Lead" },
+      { name: "Opportunity" },
+      { name: "Customer" },
+      { name: "Evangelist" },
+    ]),
+
+    "Lead Status": Schema.select([
+      { name: "New" },
+      { name: "Open" },
+      { name: "In Progress" },
+      { name: "Unqualified" },
+    ]),
+
+    Email: Schema.email(),
+
+    Company: Schema.richText(),
+
+    "Last Activity": Schema.date(),
+
+    Owner: Schema.richText(),
+
+    "Job Title": Schema.richText(),
+
+    Phone: Schema.richText(),
+
+    Created: Schema.date(),
+
+    "Contact Link": Schema.url(),
+
+    "Contact ID": Schema.richText(),
+  },
+}
+
+const LIFECYCLE_LABELS: Record<string, string> = {
+  subscriber: "Subscriber",
+  lead: "Lead",
+  marketingqualifiedlead: "Marketing Qualified Lead",
+  salesqualifiedlead: "Sales Qualified Lead",
+  opportunity: "Opportunity",
+  customer: "Customer",
+  evangelist: "Evangelist",
+}
+
+const LEAD_STATUS_LABELS: Record<string, string> = {
+  NEW: "New",
+  OPEN: "Open",
+  IN_PROGRESS: "In Progress",
+  UNQUALIFIED: "Unqualified",
+}
+
+function contactName(contact: HubSpotContact): string {
+  const parts = [contact.firstname, contact.lastname].filter(Boolean)
+  return parts.join(" ") || "(no name)"
+}
+
+export function contactToChange(
+  id: string,
+  contact: HubSpotContact,
+  updatedAt: string,
+  portalId: string,
+  owners: OwnerLookup
+) {
+  const lifecycle = LIFECYCLE_LABELS[contact.lifecyclestage ?? ""]
+  const leadStatus = LEAD_STATUS_LABELS[contact.hs_lead_status ?? ""]
+  const owner = ownerName(owners, contact.hubspot_owner_id)
+
+  return {
+    type: "upsert" as const,
+    key: id,
+    upstreamUpdatedAt: updatedAt,
+    properties: {
+      Name: Builder.title(contactName(contact)),
+      ...(lifecycle
+        ? { "Lifecycle Stage": Builder.select(lifecycle) }
+        : {}),
+      ...(leadStatus
+        ? { "Lead Status": Builder.select(leadStatus) }
+        : {}),
+      ...(contact.email
+        ? { Email: Builder.email(contact.email) }
+        : {}),
+      ...(contact.company
+        ? { Company: Builder.richText(contact.company) }
+        : {}),
+      ...(contact.notes_last_updated
+        ? { "Last Activity": Builder.date(dateOnly(contact.notes_last_updated)) }
+        : {}),
+      ...(owner ? { Owner: Builder.richText(owner) } : {}),
+      ...(contact.jobtitle
+        ? { "Job Title": Builder.richText(contact.jobtitle) }
+        : {}),
+      ...(contact.phone
+        ? { Phone: Builder.richText(contact.phone) }
+        : {}),
+      ...(contact.createdate
+        ? { Created: Builder.date(dateOnly(contact.createdate)) }
+        : {}),
+      "Contact Link": Builder.url(
+        `https://app.hubspot.com/contacts/${portalId}/contact/${id}`
+      ),
+      "Contact ID": Builder.richText(id),
+    },
+  }
+}

--- a/examples/workers/syncs/hubspot/src/contacts.ts
+++ b/examples/workers/syncs/hubspot/src/contacts.ts
@@ -36,11 +36,17 @@ export const contactSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Last Activity": Schema.date(),
 
-    Owner: Schema.richText(),
-
     "Job Title": Schema.richText(),
 
+    Owner: Schema.richText(),
+
     Phone: Schema.richText(),
+
+    "Associated Deals": Schema.number(),
+
+    "Recent Deal Amount": Schema.number(),
+
+    Updated: Schema.date(),
 
     Created: Schema.date(),
 
@@ -82,6 +88,12 @@ export function contactToChange(
   const lifecycle = LIFECYCLE_LABELS[contact.lifecyclestage ?? ""]
   const leadStatus = LEAD_STATUS_LABELS[contact.hs_lead_status ?? ""]
   const owner = ownerName(owners, contact.hubspot_owner_id)
+  const numDeals = contact.num_associated_deals
+    ? Number(contact.num_associated_deals)
+    : null
+  const recentDeal = contact.recent_deal_amount
+    ? Number(contact.recent_deal_amount)
+    : null
 
   return {
     type: "upsert" as const,
@@ -101,16 +113,23 @@ export function contactToChange(
       ...(contact.company
         ? { Company: Builder.richText(contact.company) }
         : {}),
-      ...(contact.notes_last_updated
-        ? { "Last Activity": Builder.date(dateOnly(contact.notes_last_updated)) }
+      ...(contact.hs_last_sales_activity_timestamp
+        ? { "Last Activity": Builder.date(dateOnly(contact.hs_last_sales_activity_timestamp)) }
         : {}),
-      ...(owner ? { Owner: Builder.richText(owner) } : {}),
       ...(contact.jobtitle
         ? { "Job Title": Builder.richText(contact.jobtitle) }
         : {}),
+      ...(owner ? { Owner: Builder.richText(owner) } : {}),
       ...(contact.phone
         ? { Phone: Builder.richText(contact.phone) }
         : {}),
+      ...(numDeals != null && !isNaN(numDeals)
+        ? { "Associated Deals": Builder.number(numDeals) }
+        : {}),
+      ...(recentDeal != null && !isNaN(recentDeal)
+        ? { "Recent Deal Amount": Builder.number(recentDeal) }
+        : {}),
+      Updated: Builder.date(dateOnly(updatedAt)),
       ...(contact.createdate
         ? { Created: Builder.date(dateOnly(contact.createdate)) }
         : {}),

--- a/examples/workers/syncs/hubspot/src/deals.ts
+++ b/examples/workers/syncs/hubspot/src/deals.ts
@@ -1,0 +1,86 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import type { HubSpotDeal, OwnerLookup } from "./hubspot.js"
+import { ownerName } from "./hubspot.js"
+import { dateOnly } from "./helpers.js"
+
+export const INITIAL_TITLE = "HubSpot Deals"
+export const PRIMARY_KEY = "Deal ID"
+
+export const dealSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("currency"),
+  properties: {
+    "Deal Name": Schema.title(),
+
+    Stage: Schema.select([]),
+
+    Amount: Schema.number(),
+
+    "Close Date": Schema.date(),
+
+    Owner: Schema.richText(),
+
+    "Deal Link": Schema.url(),
+
+    Pipeline: Schema.richText(),
+
+    "Deal Type": Schema.select([
+      { name: "New Business" },
+      { name: "Existing Business" },
+    ]),
+
+    Created: Schema.date(),
+
+    "Deal ID": Schema.richText(),
+  },
+}
+
+const DEAL_TYPE_LABELS: Record<string, string> = {
+  newbusiness: "New Business",
+  existingbusiness: "Existing Business",
+}
+
+export function dealToChange(
+  id: string,
+  deal: HubSpotDeal,
+  updatedAt: string,
+  portalId: string,
+  owners: OwnerLookup
+) {
+  const owner = ownerName(owners, deal.hubspot_owner_id)
+  const dealType = DEAL_TYPE_LABELS[deal.dealtype ?? ""]
+  const amount = deal.amount ? Number(deal.amount) : null
+
+  return {
+    type: "upsert" as const,
+    key: id,
+    upstreamUpdatedAt: updatedAt,
+    properties: {
+      "Deal Name": Builder.title(deal.dealname ?? ""),
+      ...(deal.dealstage
+        ? { Stage: Builder.select(deal.dealstage) }
+        : {}),
+      ...(amount != null && !isNaN(amount)
+        ? { Amount: Builder.number(amount) }
+        : {}),
+      ...(deal.closedate
+        ? { "Close Date": Builder.date(dateOnly(deal.closedate)) }
+        : {}),
+      ...(owner ? { Owner: Builder.richText(owner) } : {}),
+      "Deal Link": Builder.url(
+        `https://app.hubspot.com/contacts/${portalId}/deal/${id}`
+      ),
+      ...(deal.pipeline
+        ? { Pipeline: Builder.richText(deal.pipeline) }
+        : {}),
+      ...(dealType
+        ? { "Deal Type": Builder.select(dealType) }
+        : {}),
+      ...(deal.createdate
+        ? { Created: Builder.date(dateOnly(deal.createdate)) }
+        : {}),
+      "Deal ID": Builder.richText(id),
+    },
+  }
+}

--- a/examples/workers/syncs/hubspot/src/deals.ts
+++ b/examples/workers/syncs/hubspot/src/deals.ts
@@ -1,7 +1,7 @@
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
 import { notionIcon } from "@notionhq/workers"
-import type { HubSpotDeal, OwnerLookup } from "./hubspot.js"
+import type { HubSpotDeal, OwnerLookup, PipelineLookup } from "./hubspot.js"
 import { ownerName } from "./hubspot.js"
 import { dateOnly } from "./helpers.js"
 
@@ -9,7 +9,7 @@ export const INITIAL_TITLE = "HubSpot Deals"
 export const PRIMARY_KEY = "Deal ID"
 
 export const dealSchema: Schema.Schema<typeof PRIMARY_KEY> = {
-  databaseIcon: notionIcon("currency"),
+  databaseIcon: notionIcon("cash"),
   properties: {
     "Deal Name": Schema.title(),
 
@@ -19,18 +19,34 @@ export const dealSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Close Date": Schema.date(),
 
+    Pipeline: Schema.richText(),
+
     Owner: Schema.richText(),
 
-    "Deal Link": Schema.url(),
+    Company: Schema.richText(),
 
-    Pipeline: Schema.richText(),
+    Contact: Schema.richText(),
+
+    "Forecast Amount": Schema.number(),
+
+    "Forecast Category": Schema.select([]),
+
+    "Closed Won": Schema.checkbox(),
 
     "Deal Type": Schema.select([
       { name: "New Business" },
       { name: "Existing Business" },
     ]),
 
+    Updated: Schema.date(),
+
     Created: Schema.date(),
+
+    "Deal Link": Schema.url(),
+
+    "Stage ID": Schema.richText(),
+
+    "Pipeline ID": Schema.richText(),
 
     "Deal ID": Schema.richText(),
   },
@@ -41,44 +57,89 @@ const DEAL_TYPE_LABELS: Record<string, string> = {
   existingbusiness: "Existing Business",
 }
 
+export type DealContext = {
+  portalId: string
+  owners: OwnerLookup
+  pipelines: PipelineLookup
+  companyNames: Map<string, string>
+  contactNames: Map<string, string>
+}
+
 export function dealToChange(
   id: string,
   deal: HubSpotDeal,
   updatedAt: string,
-  portalId: string,
-  owners: OwnerLookup
+  associations: Record<string, string[]>,
+  ctx: DealContext
 ) {
-  const owner = ownerName(owners, deal.hubspot_owner_id)
+  const owner = ownerName(ctx.owners, deal.hubspot_owner_id)
   const dealType = DEAL_TYPE_LABELS[deal.dealtype ?? ""]
   const amount = deal.amount ? Number(deal.amount) : null
+  const forecastAmount = deal.hs_forecast_amount
+    ? Number(deal.hs_forecast_amount)
+    : null
+  const closedWon = deal.hs_is_closed_won === "true"
+
+  const stageName = ctx.pipelines.stageName(deal.dealstage ?? "")
+  const pipelineName = ctx.pipelines.pipelineName(deal.pipeline ?? "")
+
+  const companyId = associations["companies"]?.[0]
+  const contactId = associations["contacts"]?.[0]
+  const companyName = companyId ? ctx.companyNames.get(companyId) ?? null : null
+  const contactName = contactId ? ctx.contactNames.get(contactId) ?? null : null
 
   return {
     type: "upsert" as const,
     key: id,
     upstreamUpdatedAt: updatedAt,
+    pageContentMarkdown: deal.description ?? "",
     properties: {
       "Deal Name": Builder.title(deal.dealname ?? ""),
-      ...(deal.dealstage
-        ? { Stage: Builder.select(deal.dealstage) }
-        : {}),
+      ...(stageName
+        ? { Stage: Builder.select(stageName) }
+        : deal.dealstage
+          ? { Stage: Builder.select(deal.dealstage) }
+          : {}),
       ...(amount != null && !isNaN(amount)
         ? { Amount: Builder.number(amount) }
         : {}),
       ...(deal.closedate
         ? { "Close Date": Builder.date(dateOnly(deal.closedate)) }
         : {}),
+      ...(pipelineName
+        ? { Pipeline: Builder.richText(pipelineName) }
+        : deal.pipeline
+          ? { Pipeline: Builder.richText(deal.pipeline) }
+          : {}),
       ...(owner ? { Owner: Builder.richText(owner) } : {}),
-      "Deal Link": Builder.url(
-        `https://app.hubspot.com/contacts/${portalId}/deal/${id}`
-      ),
-      ...(deal.pipeline
-        ? { Pipeline: Builder.richText(deal.pipeline) }
+      ...(companyName
+        ? { Company: Builder.richText(companyName) }
         : {}),
+      ...(contactName
+        ? { Contact: Builder.richText(contactName) }
+        : {}),
+      ...(forecastAmount != null && !isNaN(forecastAmount)
+        ? { "Forecast Amount": Builder.number(forecastAmount) }
+        : {}),
+      ...(deal.hs_forecast_category
+        ? { "Forecast Category": Builder.select(deal.hs_forecast_category) }
+        : {}),
+      "Closed Won": Builder.checkbox(closedWon),
       ...(dealType
         ? { "Deal Type": Builder.select(dealType) }
         : {}),
+      Updated: Builder.date(dateOnly(updatedAt)),
       ...(deal.createdate
         ? { Created: Builder.date(dateOnly(deal.createdate)) }
+        : {}),
+      "Deal Link": Builder.url(
+        `https://app.hubspot.com/contacts/${ctx.portalId}/deal/${id}`
+      ),
+      ...(deal.dealstage
+        ? { "Stage ID": Builder.richText(deal.dealstage) }
+        : {}),
+      ...(deal.pipeline
+        ? { "Pipeline ID": Builder.richText(deal.pipeline) }
         : {}),
       "Deal ID": Builder.richText(id),
     },

--- a/examples/workers/syncs/hubspot/src/helpers.ts
+++ b/examples/workers/syncs/hubspot/src/helpers.ts
@@ -1,0 +1,5 @@
+export function dateOnly(value: string): string {
+  if (!value) return ""
+  if (value.includes("T")) return value.slice(0, 10)
+  return value.slice(0, 10)
+}

--- a/examples/workers/syncs/hubspot/src/hubspot.ts
+++ b/examples/workers/syncs/hubspot/src/hubspot.ts
@@ -1,0 +1,276 @@
+// HubSpot CRM API client. Handles authentication and paginated fetching
+// for contacts, deals, companies, and owners.
+//
+// To add a new resource:
+//   1. Add a type for the properties you need
+//   2. Add a fetchXxxPage() function with the right properties list
+//   3. Wire it into index.ts
+
+const PER_PAGE = 100
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`${name} is not set.`)
+  }
+  return value
+}
+
+export function getPortalId(): string {
+  return requireEnv("HUBSPOT_PORTAL_ID")
+}
+
+// HubSpot CRM objects share a common response shape.
+type CrmListResponse<T> = {
+  results: {
+    id: string
+    properties: T
+    createdAt: string
+    updatedAt: string
+    archived: boolean
+  }[]
+  paging?: {
+    next?: { after: string }
+  }
+}
+
+type CrmRecord<T> = {
+  id: string
+  properties: T
+  createdAt: string
+  updatedAt: string
+}
+
+async function fetchCrmPage<T>(
+  objectType: string,
+  properties: string[],
+  cursor?: string
+): Promise<{ records: CrmRecord<T>[]; nextCursor: string | undefined }> {
+  const token = requireEnv("HUBSPOT_ACCESS_TOKEN")
+  const url = new URL(`https://api.hubapi.com/crm/v3/objects/${objectType}`)
+  url.searchParams.set("limit", String(PER_PAGE))
+  url.searchParams.set("properties", properties.join(","))
+  if (cursor) {
+    url.searchParams.set("after", cursor)
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `HubSpot API error (${response.status}): ${text || "No response body"}`
+    )
+  }
+
+  const body = JSON.parse(text) as CrmListResponse<T>
+  const records = body.results
+    .filter((r) => !r.archived)
+    .map((r) => ({
+      id: r.id,
+      properties: r.properties,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }))
+
+  return {
+    records,
+    nextCursor: body.paging?.next?.after,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Owners — fetched once per sync cycle to resolve hubspot_owner_id to names
+// ---------------------------------------------------------------------------
+
+export type HubSpotOwner = {
+  id: string
+  firstName: string
+  lastName: string
+  email: string
+}
+
+export type OwnerLookup = Map<string, HubSpotOwner>
+
+export async function fetchAllOwners(): Promise<OwnerLookup> {
+  const token = requireEnv("HUBSPOT_ACCESS_TOKEN")
+  const owners: OwnerLookup = new Map()
+  let after: string | undefined
+
+  do {
+    const url = new URL("https://api.hubapi.com/crm/v3/owners")
+    url.searchParams.set("limit", String(PER_PAGE))
+    if (after) url.searchParams.set("after", after)
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    })
+
+    const text = await response.text()
+    if (!response.ok) {
+      throw new Error(
+        `HubSpot API error (${response.status}): ${text || "No response body"}`
+      )
+    }
+
+    const body = JSON.parse(text) as {
+      results: HubSpotOwner[]
+      paging?: { next?: { after: string } }
+    }
+
+    for (const owner of body.results) {
+      owners.set(owner.id, owner)
+    }
+
+    after = body.paging?.next?.after
+  } while (after)
+
+  return owners
+}
+
+export function ownerName(owners: OwnerLookup, id: string | null): string | null {
+  if (!id) return null
+  const owner = owners.get(id)
+  if (!owner) return null
+  const name = `${owner.firstName} ${owner.lastName}`.trim()
+  return name || owner.email || null
+}
+
+// ---------------------------------------------------------------------------
+// Contacts
+// https://developers.hubspot.com/docs/api/crm/contacts
+// ---------------------------------------------------------------------------
+
+export type HubSpotContact = {
+  firstname: string | null
+  lastname: string | null
+  email: string | null
+  phone: string | null
+  company: string | null
+  jobtitle: string | null
+  lifecyclestage: string | null
+  hs_lead_status: string | null
+  hubspot_owner_id: string | null
+  notes_last_updated: string | null
+  createdate: string | null
+}
+
+const CONTACT_PROPERTIES = [
+  "firstname",
+  "lastname",
+  "email",
+  "phone",
+  "company",
+  "jobtitle",
+  "lifecyclestage",
+  "hs_lead_status",
+  "hubspot_owner_id",
+  "notes_last_updated",
+  "createdate",
+]
+
+export async function fetchContactsPage(cursor?: string): Promise<{
+  contacts: CrmRecord<HubSpotContact>[]
+  nextCursor: string | undefined
+}> {
+  const { records, nextCursor } = await fetchCrmPage<HubSpotContact>(
+    "contacts",
+    CONTACT_PROPERTIES,
+    cursor
+  )
+  return { contacts: records, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Deals
+// https://developers.hubspot.com/docs/api/crm/deals
+// ---------------------------------------------------------------------------
+
+export type HubSpotDeal = {
+  dealname: string | null
+  dealstage: string | null
+  pipeline: string | null
+  amount: string | null
+  closedate: string | null
+  hubspot_owner_id: string | null
+  dealtype: string | null
+  createdate: string | null
+}
+
+const DEAL_PROPERTIES = [
+  "dealname",
+  "dealstage",
+  "pipeline",
+  "amount",
+  "closedate",
+  "hubspot_owner_id",
+  "dealtype",
+  "createdate",
+]
+
+export async function fetchDealsPage(cursor?: string): Promise<{
+  deals: CrmRecord<HubSpotDeal>[]
+  nextCursor: string | undefined
+}> {
+  const { records, nextCursor } = await fetchCrmPage<HubSpotDeal>(
+    "deals",
+    DEAL_PROPERTIES,
+    cursor
+  )
+  return { deals: records, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Companies
+// https://developers.hubspot.com/docs/api/crm/companies
+// ---------------------------------------------------------------------------
+
+export type HubSpotCompany = {
+  name: string | null
+  domain: string | null
+  industry: string | null
+  numberofemployees: string | null
+  annualrevenue: string | null
+  hubspot_owner_id: string | null
+  type: string | null
+  city: string | null
+  country: string | null
+  phone: string | null
+  lifecyclestage: string | null
+  createdate: string | null
+}
+
+const COMPANY_PROPERTIES = [
+  "name",
+  "domain",
+  "industry",
+  "numberofemployees",
+  "annualrevenue",
+  "hubspot_owner_id",
+  "type",
+  "city",
+  "country",
+  "phone",
+  "lifecyclestage",
+  "createdate",
+]
+
+export async function fetchCompaniesPage(cursor?: string): Promise<{
+  companies: CrmRecord<HubSpotCompany>[]
+  nextCursor: string | undefined
+}> {
+  const { records, nextCursor } = await fetchCrmPage<HubSpotCompany>(
+    "companies",
+    COMPANY_PROPERTIES,
+    cursor
+  )
+  return { companies: records, nextCursor }
+}

--- a/examples/workers/syncs/hubspot/src/hubspot.ts
+++ b/examples/workers/syncs/hubspot/src/hubspot.ts
@@ -1,5 +1,5 @@
 // HubSpot CRM API client. Handles authentication and paginated fetching
-// for contacts, deals, companies, and owners.
+// for contacts, deals, companies, owners, and pipeline definitions.
 //
 // To add a new resource:
 //   1. Add a type for the properties you need
@@ -20,43 +20,14 @@ export function getPortalId(): string {
   return requireEnv("HUBSPOT_PORTAL_ID")
 }
 
-// HubSpot CRM objects share a common response shape.
-type CrmListResponse<T> = {
-  results: {
-    id: string
-    properties: T
-    createdAt: string
-    updatedAt: string
-    archived: boolean
-  }[]
-  paging?: {
-    next?: { after: string }
-  }
+function getToken(): string {
+  return requireEnv("HUBSPOT_ACCESS_TOKEN")
 }
 
-type CrmRecord<T> = {
-  id: string
-  properties: T
-  createdAt: string
-  updatedAt: string
-}
-
-async function fetchCrmPage<T>(
-  objectType: string,
-  properties: string[],
-  cursor?: string
-): Promise<{ records: CrmRecord<T>[]; nextCursor: string | undefined }> {
-  const token = requireEnv("HUBSPOT_ACCESS_TOKEN")
-  const url = new URL(`https://api.hubapi.com/crm/v3/objects/${objectType}`)
-  url.searchParams.set("limit", String(PER_PAGE))
-  url.searchParams.set("properties", properties.join(","))
-  if (cursor) {
-    url.searchParams.set("after", cursor)
-  }
-
-  const response = await fetch(url.toString(), {
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${getToken()}`,
       Accept: "application/json",
     },
   })
@@ -68,15 +39,66 @@ async function fetchCrmPage<T>(
     )
   }
 
-  const body = JSON.parse(text) as CrmListResponse<T>
+  return JSON.parse(text) as T
+}
+
+// HubSpot CRM objects share a common response shape.
+type CrmListResponse<T> = {
+  results: {
+    id: string
+    properties: T
+    associations?: Record<string, { results: { id: string }[] }>
+    createdAt: string
+    updatedAt: string
+    archived: boolean
+  }[]
+  paging?: {
+    next?: { after: string }
+  }
+}
+
+export type CrmRecord<T> = {
+  id: string
+  properties: T
+  associations: Record<string, string[]>
+  createdAt: string
+  updatedAt: string
+}
+
+async function fetchCrmPage<T>(
+  objectType: string,
+  properties: string[],
+  cursor?: string,
+  associations?: string[]
+): Promise<{ records: CrmRecord<T>[]; nextCursor: string | undefined }> {
+  const url = new URL(`https://api.hubapi.com/crm/v3/objects/${objectType}`)
+  url.searchParams.set("limit", String(PER_PAGE))
+  url.searchParams.set("properties", properties.join(","))
+  if (associations?.length) {
+    url.searchParams.set("associations", associations.join(","))
+  }
+  if (cursor) {
+    url.searchParams.set("after", cursor)
+  }
+
+  const body = await fetchJson<CrmListResponse<T>>(url.toString())
   const records = body.results
     .filter((r) => !r.archived)
-    .map((r) => ({
-      id: r.id,
-      properties: r.properties,
-      createdAt: r.createdAt,
-      updatedAt: r.updatedAt,
-    }))
+    .map((r) => {
+      const assoc: Record<string, string[]> = {}
+      if (r.associations) {
+        for (const [key, val] of Object.entries(r.associations)) {
+          assoc[key] = val.results.map((a) => a.id)
+        }
+      }
+      return {
+        id: r.id,
+        properties: r.properties,
+        associations: assoc,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+      }
+    })
 
   return {
     records,
@@ -98,7 +120,6 @@ export type HubSpotOwner = {
 export type OwnerLookup = Map<string, HubSpotOwner>
 
 export async function fetchAllOwners(): Promise<OwnerLookup> {
-  const token = requireEnv("HUBSPOT_ACCESS_TOKEN")
   const owners: OwnerLookup = new Map()
   let after: string | undefined
 
@@ -107,24 +128,10 @@ export async function fetchAllOwners(): Promise<OwnerLookup> {
     url.searchParams.set("limit", String(PER_PAGE))
     if (after) url.searchParams.set("after", after)
 
-    const response = await fetch(url.toString(), {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
-    })
-
-    const text = await response.text()
-    if (!response.ok) {
-      throw new Error(
-        `HubSpot API error (${response.status}): ${text || "No response body"}`
-      )
-    }
-
-    const body = JSON.parse(text) as {
+    const body = await fetchJson<{
       results: HubSpotOwner[]
       paging?: { next?: { after: string } }
-    }
+    }>(url.toString())
 
     for (const owner of body.results) {
       owners.set(owner.id, owner)
@@ -145,6 +152,98 @@ export function ownerName(owners: OwnerLookup, id: string | null): string | null
 }
 
 // ---------------------------------------------------------------------------
+// Batch read — resolve a set of record IDs to their properties in one call
+// https://developers.hubspot.com/docs/api/crm/contacts#batch
+// ---------------------------------------------------------------------------
+
+export type NameLookup = Map<string, string>
+
+export async function batchReadNames(
+  objectType: string,
+  ids: string[],
+  nameProperties: string[],
+  formatter?: (props: Record<string, string | null>) => string | null
+): Promise<NameLookup> {
+  const names: NameLookup = new Map()
+  if (ids.length === 0) return names
+
+  const unique = [...new Set(ids)]
+  const url = `https://api.hubapi.com/crm/v3/objects/${objectType}/batch/read`
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${getToken()}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      properties: nameProperties,
+      inputs: unique.map((id) => ({ id })),
+    }),
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `HubSpot API error (${response.status}): ${text || "No response body"}`
+    )
+  }
+
+  const body = JSON.parse(text) as {
+    results: { id: string; properties: Record<string, string | null> }[]
+  }
+
+  for (const record of body.results) {
+    const name = formatter
+      ? formatter(record.properties)
+      : record.properties[nameProperties[0]]
+    if (name) names.set(record.id, name)
+  }
+
+  return names
+}
+
+// ---------------------------------------------------------------------------
+// Pipelines — fetched once per sync cycle to resolve stage/pipeline IDs
+// https://developers.hubspot.com/docs/reference/api/crm/pipelines
+// ---------------------------------------------------------------------------
+
+export type PipelineLookup = {
+  pipelineName: (id: string) => string | null
+  stageName: (stageId: string) => string | null
+}
+
+type PipelineResponse = {
+  results: {
+    id: string
+    label: string
+    stages: { id: string; label: string }[]
+  }[]
+}
+
+export async function fetchDealPipelines(): Promise<PipelineLookup> {
+  const body = await fetchJson<PipelineResponse>(
+    "https://api.hubapi.com/crm/v3/pipelines/deals"
+  )
+
+  const pipelines = new Map<string, string>()
+  const stages = new Map<string, string>()
+
+  for (const pipeline of body.results) {
+    pipelines.set(pipeline.id, pipeline.label)
+    for (const stage of pipeline.stages) {
+      stages.set(stage.id, stage.label)
+    }
+  }
+
+  return {
+    pipelineName: (id) => pipelines.get(id) ?? null,
+    stageName: (id) => stages.get(id) ?? null,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Contacts
 // https://developers.hubspot.com/docs/api/crm/contacts
 // ---------------------------------------------------------------------------
@@ -159,7 +258,9 @@ export type HubSpotContact = {
   lifecyclestage: string | null
   hs_lead_status: string | null
   hubspot_owner_id: string | null
-  notes_last_updated: string | null
+  hs_last_sales_activity_timestamp: string | null
+  num_associated_deals: string | null
+  recent_deal_amount: string | null
   createdate: string | null
 }
 
@@ -173,7 +274,9 @@ const CONTACT_PROPERTIES = [
   "lifecyclestage",
   "hs_lead_status",
   "hubspot_owner_id",
-  "notes_last_updated",
+  "hs_last_sales_activity_timestamp",
+  "num_associated_deals",
+  "recent_deal_amount",
   "createdate",
 ]
 
@@ -202,6 +305,10 @@ export type HubSpotDeal = {
   closedate: string | null
   hubspot_owner_id: string | null
   dealtype: string | null
+  hs_forecast_amount: string | null
+  hs_forecast_category: string | null
+  hs_is_closed_won: string | null
+  description: string | null
   createdate: string | null
 }
 
@@ -213,6 +320,10 @@ const DEAL_PROPERTIES = [
   "closedate",
   "hubspot_owner_id",
   "dealtype",
+  "hs_forecast_amount",
+  "hs_forecast_category",
+  "hs_is_closed_won",
+  "description",
   "createdate",
 ]
 
@@ -223,7 +334,8 @@ export async function fetchDealsPage(cursor?: string): Promise<{
   const { records, nextCursor } = await fetchCrmPage<HubSpotDeal>(
     "deals",
     DEAL_PROPERTIES,
-    cursor
+    cursor,
+    ["companies", "contacts"]
   )
   return { deals: records, nextCursor }
 }
@@ -236,6 +348,7 @@ export async function fetchDealsPage(cursor?: string): Promise<{
 export type HubSpotCompany = {
   name: string | null
   domain: string | null
+  description: string | null
   industry: string | null
   numberofemployees: string | null
   annualrevenue: string | null
@@ -245,12 +358,15 @@ export type HubSpotCompany = {
   country: string | null
   phone: string | null
   lifecyclestage: string | null
+  hs_num_open_deals: string | null
+  total_revenue: string | null
   createdate: string | null
 }
 
 const COMPANY_PROPERTIES = [
   "name",
   "domain",
+  "description",
   "industry",
   "numberofemployees",
   "annualrevenue",
@@ -260,6 +376,8 @@ const COMPANY_PROPERTIES = [
   "country",
   "phone",
   "lifecyclestage",
+  "hs_num_open_deals",
+  "total_revenue",
   "createdate",
 ]
 

--- a/examples/workers/syncs/hubspot/src/index.ts
+++ b/examples/workers/syncs/hubspot/src/index.ts
@@ -1,0 +1,176 @@
+// Entry point — syncs HubSpot CRM contacts, deals, and companies into
+// managed Notion databases.
+//
+// Three databases are created:
+//   1. Contacts   — lifecycle stage, lead status, owner (every 5 min)
+//   2. Deals      — pipeline stage, amount, close date, owner (every 5 min)
+//   3. Companies  — industry, revenue, employees, owner (every 5 min)
+//
+// Owner IDs are resolved to names by fetching all owners once per sync cycle.
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  getPortalId,
+  fetchAllOwners,
+  fetchContactsPage,
+  fetchDealsPage,
+  fetchCompaniesPage,
+} from "./hubspot.js"
+import type { OwnerLookup } from "./hubspot.js"
+import {
+  INITIAL_TITLE as CONTACTS_TITLE,
+  PRIMARY_KEY as CONTACTS_PK,
+  contactSchema,
+  contactToChange,
+} from "./contacts.js"
+import {
+  INITIAL_TITLE as DEALS_TITLE,
+  PRIMARY_KEY as DEALS_PK,
+  dealSchema,
+  dealToChange,
+} from "./deals.js"
+import {
+  INITIAL_TITLE as COMPANIES_TITLE,
+  PRIMARY_KEY as COMPANIES_PK,
+  companySchema,
+  companyToChange,
+} from "./companies.js"
+
+type SyncState = {
+  cursor: string
+}
+
+const worker = new Worker()
+
+// HubSpot rate-limits to 100 requests per 10 seconds on Free/Starter plans.
+const pacer = worker.pacer("hubspot", {
+  allowedRequests: 90,
+  intervalMs: 10_000,
+})
+
+// Owners are fetched once per sync cycle and shared across all transforms.
+let cachedOwners: OwnerLookup | undefined
+
+async function getOwners(): Promise<OwnerLookup> {
+  if (!cachedOwners) {
+    cachedOwners = await fetchAllOwners()
+  }
+  return cachedOwners
+}
+
+// ---------------------------------------------------------------------------
+// Contacts
+// ---------------------------------------------------------------------------
+
+const contacts = worker.database("contacts", {
+  type: "managed",
+  initialTitle: CONTACTS_TITLE,
+  primaryKeyProperty: CONTACTS_PK,
+  schema: contactSchema,
+})
+
+worker.sync("contactsSync", {
+  database: contacts,
+  mode: "replace",
+  schedule: "5m",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const portalId = getPortalId()
+    const owners = await getOwners()
+
+    const page = await fetchContactsPage(state?.cursor)
+    const changes = page.contacts.map((c) =>
+      contactToChange(c.id, c.properties, c.updatedAt, portalId, owners)
+    )
+
+    if (page.nextCursor) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { cursor: page.nextCursor },
+      }
+    }
+
+    cachedOwners = undefined
+    return { changes, hasMore: false }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Deals
+// ---------------------------------------------------------------------------
+
+const deals = worker.database("deals", {
+  type: "managed",
+  initialTitle: DEALS_TITLE,
+  primaryKeyProperty: DEALS_PK,
+  schema: dealSchema,
+})
+
+worker.sync("dealsSync", {
+  database: deals,
+  mode: "replace",
+  schedule: "5m",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const portalId = getPortalId()
+    const owners = await getOwners()
+
+    const page = await fetchDealsPage(state?.cursor)
+    const changes = page.deals.map((d) =>
+      dealToChange(d.id, d.properties, d.updatedAt, portalId, owners)
+    )
+
+    if (page.nextCursor) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { cursor: page.nextCursor },
+      }
+    }
+
+    cachedOwners = undefined
+    return { changes, hasMore: false }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Companies
+// ---------------------------------------------------------------------------
+
+const companies = worker.database("companies", {
+  type: "managed",
+  initialTitle: COMPANIES_TITLE,
+  primaryKeyProperty: COMPANIES_PK,
+  schema: companySchema,
+})
+
+worker.sync("companiesSync", {
+  database: companies,
+  mode: "replace",
+  schedule: "5m",
+  execute: async (state: SyncState | undefined) => {
+    await pacer.wait()
+    const portalId = getPortalId()
+    const owners = await getOwners()
+
+    const page = await fetchCompaniesPage(state?.cursor)
+    const changes = page.companies.map((c) =>
+      companyToChange(c.id, c.properties, c.updatedAt, portalId, owners)
+    )
+
+    if (page.nextCursor) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { cursor: page.nextCursor },
+      }
+    }
+
+    cachedOwners = undefined
+    return { changes, hasMore: false }
+  },
+})
+
+export default worker

--- a/examples/workers/syncs/hubspot/src/index.ts
+++ b/examples/workers/syncs/hubspot/src/index.ts
@@ -3,21 +3,25 @@
 //
 // Three databases are created:
 //   1. Contacts   — lifecycle stage, lead status, owner (every 5 min)
-//   2. Deals      — pipeline stage, amount, close date, owner (every 5 min)
-//   3. Companies  — industry, revenue, employees, owner (every 5 min)
+//   2. Deals      — pipeline stage, amount, associations, forecast (every 5 min)
+//   3. Companies  — industry, revenue, employees, open deals (every 5 min)
 //
-// Owner IDs are resolved to names by fetching all owners once per sync cycle.
+// Owner IDs and pipeline/stage IDs are resolved to human-readable names by
+// fetching lookup data once at the start of each sync cycle.
+// Deal associations (company/contact) are resolved per-page using batch reads.
 
 import { Worker } from "@notionhq/workers"
 
 import {
   getPortalId,
   fetchAllOwners,
+  fetchDealPipelines,
   fetchContactsPage,
   fetchDealsPage,
   fetchCompaniesPage,
+  batchReadNames,
 } from "./hubspot.js"
-import type { OwnerLookup } from "./hubspot.js"
+import type { OwnerLookup, PipelineLookup } from "./hubspot.js"
 import {
   INITIAL_TITLE as CONTACTS_TITLE,
   PRIMARY_KEY as CONTACTS_PK,
@@ -30,6 +34,7 @@ import {
   dealSchema,
   dealToChange,
 } from "./deals.js"
+import type { DealContext } from "./deals.js"
 import {
   INITIAL_TITLE as COMPANIES_TITLE,
   PRIMARY_KEY as COMPANIES_PK,
@@ -49,15 +54,11 @@ const pacer = worker.pacer("hubspot", {
   intervalMs: 10_000,
 })
 
-// Owners are fetched once per sync cycle and shared across all transforms.
-let cachedOwners: OwnerLookup | undefined
-
-async function getOwners(): Promise<OwnerLookup> {
-  if (!cachedOwners) {
-    cachedOwners = await fetchAllOwners()
-  }
-  return cachedOwners
-}
+// Per-cycle caches cleared when the last page completes.
+let contactOwners: OwnerLookup | undefined
+let companyOwners: OwnerLookup | undefined
+let dealOwners: OwnerLookup | undefined
+let dealPipelines: PipelineLookup | undefined
 
 // ---------------------------------------------------------------------------
 // Contacts
@@ -77,11 +78,14 @@ worker.sync("contactsSync", {
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const portalId = getPortalId()
-    const owners = await getOwners()
+
+    if (!contactOwners) {
+      contactOwners = await fetchAllOwners()
+    }
 
     const page = await fetchContactsPage(state?.cursor)
     const changes = page.contacts.map((c) =>
-      contactToChange(c.id, c.properties, c.updatedAt, portalId, owners)
+      contactToChange(c.id, c.properties, c.updatedAt, portalId, contactOwners!)
     )
 
     if (page.nextCursor) {
@@ -92,13 +96,13 @@ worker.sync("contactsSync", {
       }
     }
 
-    cachedOwners = undefined
+    contactOwners = undefined
     return { changes, hasMore: false }
   },
 })
 
 // ---------------------------------------------------------------------------
-// Deals
+// Deals — resolves stage/pipeline IDs and association IDs to names
 // ---------------------------------------------------------------------------
 
 const deals = worker.database("deals", {
@@ -111,15 +115,50 @@ const deals = worker.database("deals", {
 worker.sync("dealsSync", {
   database: deals,
   mode: "replace",
-  schedule: "5m",
+  schedule: "2m",
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const portalId = getPortalId()
-    const owners = await getOwners()
+
+    if (!dealOwners) {
+      const [owners, pipelines] = await Promise.all([
+        fetchAllOwners(),
+        fetchDealPipelines(),
+      ])
+      dealOwners = owners
+      dealPipelines = pipelines
+    }
 
     const page = await fetchDealsPage(state?.cursor)
+
+    const companyIds: string[] = []
+    const contactIds: string[] = []
+    for (const d of page.deals) {
+      const cid = d.associations["companies"]?.[0]
+      const tid = d.associations["contacts"]?.[0]
+      if (cid) companyIds.push(cid)
+      if (tid) contactIds.push(tid)
+    }
+
+    await pacer.wait()
+    const [companyNames, contactNames] = await Promise.all([
+      batchReadNames("companies", companyIds, ["name"]),
+      batchReadNames("contacts", contactIds, ["firstname", "lastname"], (props) => {
+        const name = `${props.firstname ?? ""} ${props.lastname ?? ""}`.trim()
+        return name || null
+      }),
+    ])
+
+    const ctx: DealContext = {
+      portalId,
+      owners: dealOwners!,
+      pipelines: dealPipelines!,
+      companyNames,
+      contactNames,
+    }
+
     const changes = page.deals.map((d) =>
-      dealToChange(d.id, d.properties, d.updatedAt, portalId, owners)
+      dealToChange(d.id, d.properties, d.updatedAt, d.associations, ctx)
     )
 
     if (page.nextCursor) {
@@ -130,7 +169,8 @@ worker.sync("dealsSync", {
       }
     }
 
-    cachedOwners = undefined
+    dealOwners = undefined
+    dealPipelines = undefined
     return { changes, hasMore: false }
   },
 })
@@ -153,11 +193,14 @@ worker.sync("companiesSync", {
   execute: async (state: SyncState | undefined) => {
     await pacer.wait()
     const portalId = getPortalId()
-    const owners = await getOwners()
+
+    if (!companyOwners) {
+      companyOwners = await fetchAllOwners()
+    }
 
     const page = await fetchCompaniesPage(state?.cursor)
     const changes = page.companies.map((c) =>
-      companyToChange(c.id, c.properties, c.updatedAt, portalId, owners)
+      companyToChange(c.id, c.properties, c.updatedAt, portalId, companyOwners!)
     )
 
     if (page.nextCursor) {
@@ -168,7 +211,7 @@ worker.sync("companiesSync", {
       }
     }
 
-    cachedOwners = undefined
+    companyOwners = undefined
     return { changes, hasMore: false }
   },
 })

--- a/examples/workers/syncs/hubspot/test.ts
+++ b/examples/workers/syncs/hubspot/test.ts
@@ -4,6 +4,7 @@
 
 import { contactToChange } from "./src/contacts.js"
 import { dealToChange } from "./src/deals.js"
+import type { DealContext } from "./src/deals.js"
 import { companyToChange } from "./src/companies.js"
 import { ownerName } from "./src/hubspot.js"
 import { dateOnly } from "./src/helpers.js"
@@ -12,6 +13,7 @@ import type {
   HubSpotDeal,
   HubSpotCompany,
   OwnerLookup,
+  PipelineLookup,
 } from "./src/hubspot.js"
 
 let passed = 0
@@ -34,6 +36,26 @@ const owners: OwnerLookup = new Map([
   ["202", { id: "202", firstName: "", lastName: "", email: "sales@acme.com" }],
 ])
 
+const pipelines: PipelineLookup = {
+  pipelineName: (id) => ({ default: "Sales Pipeline", enterprise: "Enterprise" })[id] ?? null,
+  stageName: (id) =>
+    ({
+      appointmentscheduled: "Appointment Scheduled",
+      qualifiedtobuy: "Qualified to Buy",
+      contractsent: "Contract Sent",
+      closedwon: "Closed Won",
+      closedlost: "Closed Lost",
+    })[id] ?? null,
+}
+
+const dealCtx: DealContext = {
+  portalId: PORTAL_ID,
+  owners,
+  pipelines,
+  companyNames: new Map([["500", "Acme Corp"]]),
+  contactNames: new Map([["600", "Alice Johnson"]]),
+}
+
 // ---------------------------------------------------------------------------
 // contactToChange — standard contact
 // ---------------------------------------------------------------------------
@@ -50,7 +72,9 @@ const standardContact: HubSpotContact = {
   lifecyclestage: "salesqualifiedlead",
   hs_lead_status: "OPEN",
   hubspot_owner_id: "101",
-  notes_last_updated: "2024-06-16T14:00:00Z",
+  hs_last_sales_activity_timestamp: "2024-06-16T14:00:00Z",
+  num_associated_deals: "3",
+  recent_deal_amount: "50000",
   createdate: "2024-06-01T10:00:00Z",
 }
 
@@ -79,27 +103,35 @@ ok(
   JSON.stringify(contactChange.properties.Company).includes("Acme Corp")
 )
 ok(
-  "Last Activity date",
+  "Last Activity from sales activity timestamp",
   JSON.stringify(contactChange.properties["Last Activity"]).includes("2024-06-16")
-)
-ok(
-  "Owner resolved to name",
-  JSON.stringify(contactChange.properties.Owner).includes("Jane Smith")
 )
 ok(
   "Job Title is set",
   JSON.stringify(contactChange.properties["Job Title"]).includes("VP of Engineering")
 )
 ok(
-  "Phone is set",
-  JSON.stringify(contactChange.properties.Phone).includes("+1-555-0100")
+  "Owner resolved to name",
+  JSON.stringify(contactChange.properties.Owner).includes("Jane Smith")
+)
+ok(
+  "Associated Deals is 3",
+  JSON.stringify(contactChange.properties["Associated Deals"]).includes("3")
+)
+ok(
+  "Recent Deal Amount is 50000",
+  JSON.stringify(contactChange.properties["Recent Deal Amount"]).includes("50000")
+)
+ok(
+  "Updated is set from updatedAt",
+  JSON.stringify(contactChange.properties.Updated).includes("2024-06-16")
 )
 ok(
   "Contact Link contains portal ID and contact ID",
   JSON.stringify(contactChange.properties["Contact Link"]).includes("12345/contact/42")
 )
 ok(
-  "Contact ID is set",
+  "Contact ID is last",
   JSON.stringify(contactChange.properties["Contact ID"]).includes("42")
 )
 
@@ -119,7 +151,9 @@ const minimalContact: HubSpotContact = {
   lifecyclestage: null,
   hs_lead_status: null,
   hubspot_owner_id: null,
-  notes_last_updated: null,
+  hs_last_sales_activity_timestamp: null,
+  num_associated_deals: null,
+  recent_deal_amount: null,
   createdate: null,
 }
 
@@ -136,6 +170,8 @@ ok("null company omits Company", minimalContactChange.properties.Company === und
 ok("null owner omits Owner", minimalContactChange.properties.Owner === undefined)
 ok("null jobtitle omits Job Title", minimalContactChange.properties["Job Title"] === undefined)
 ok("null phone omits Phone", minimalContactChange.properties.Phone === undefined)
+ok("null deals omits Associated Deals", minimalContactChange.properties["Associated Deals"] === undefined)
+ok("null deal amount omits Recent Deal Amount", minimalContactChange.properties["Recent Deal Amount"] === undefined)
 
 // ---------------------------------------------------------------------------
 // dealToChange — standard deal
@@ -151,10 +187,18 @@ const standardDeal: HubSpotDeal = {
   closedate: "2024-07-15T00:00:00Z",
   hubspot_owner_id: "101",
   dealtype: "newbusiness",
+  hs_forecast_amount: "40000",
+  hs_forecast_category: "commit",
+  hs_is_closed_won: "false",
   createdate: "2024-06-01T10:00:00Z",
 }
 
-const dealChange = dealToChange("99", standardDeal, "2024-06-16T14:00:00Z", PORTAL_ID, owners)
+const dealAssociations = {
+  companies: ["500"],
+  contacts: ["600"],
+}
+
+const dealChange = dealToChange("99", standardDeal, "2024-06-16T14:00:00Z", dealAssociations, dealCtx)
 
 ok("key is deal id", dealChange.key === "99")
 ok(
@@ -162,8 +206,8 @@ ok(
   JSON.stringify(dealChange.properties["Deal Name"]).includes("Enterprise License")
 )
 ok(
-  "Stage is set",
-  JSON.stringify(dealChange.properties.Stage).includes("contractsent")
+  "Stage resolved to label",
+  JSON.stringify(dealChange.properties.Stage).includes("Contract Sent")
 )
 ok(
   "Amount is numeric",
@@ -174,20 +218,79 @@ ok(
   JSON.stringify(dealChange.properties["Close Date"]).includes("2024-07-15")
 )
 ok(
+  "Pipeline resolved to name",
+  JSON.stringify(dealChange.properties.Pipeline).includes("Sales Pipeline")
+)
+ok(
   "Owner resolved to name",
   JSON.stringify(dealChange.properties.Owner).includes("Jane Smith")
 )
 ok(
-  "Deal Link contains portal ID and deal ID",
-  JSON.stringify(dealChange.properties["Deal Link"]).includes("12345/deal/99")
+  "Company resolved from association",
+  JSON.stringify(dealChange.properties.Company).includes("Acme Corp")
 )
 ok(
-  "Pipeline is set",
-  JSON.stringify(dealChange.properties.Pipeline).includes("default")
+  "Contact resolved from association",
+  JSON.stringify(dealChange.properties.Contact).includes("Alice Johnson")
+)
+ok(
+  "Forecast Amount is 40000",
+  JSON.stringify(dealChange.properties["Forecast Amount"]).includes("40000")
+)
+ok(
+  "Forecast Category is set",
+  JSON.stringify(dealChange.properties["Forecast Category"]).includes("commit")
+)
+ok(
+  "Closed Won is false",
+  JSON.stringify(dealChange.properties["Closed Won"]).includes("No")
 )
 ok(
   "Deal Type maps to label",
   JSON.stringify(dealChange.properties["Deal Type"]).includes("New Business")
+)
+ok(
+  "Updated is set",
+  JSON.stringify(dealChange.properties.Updated).includes("2024-06-16")
+)
+ok(
+  "Deal Link contains portal ID",
+  JSON.stringify(dealChange.properties["Deal Link"]).includes("12345/deal/99")
+)
+ok(
+  "Stage ID preserved as raw value",
+  JSON.stringify(dealChange.properties["Stage ID"]).includes("contractsent")
+)
+ok(
+  "Pipeline ID preserved as raw value",
+  JSON.stringify(dealChange.properties["Pipeline ID"]).includes("default")
+)
+ok(
+  "Deal ID is set",
+  JSON.stringify(dealChange.properties["Deal ID"]).includes("99")
+)
+
+// ---------------------------------------------------------------------------
+// dealToChange — unknown stage/pipeline falls back to raw value
+// ---------------------------------------------------------------------------
+
+console.log("dealToChange — unknown stage/pipeline:")
+
+const unknownStageDeal: HubSpotDeal = {
+  ...standardDeal,
+  dealstage: "custom_stage_123",
+  pipeline: "custom_pipeline_456",
+}
+
+const unknownChange = dealToChange("100", unknownStageDeal, "2024-06-16T14:00:00Z", {}, dealCtx)
+
+ok(
+  "unknown stage falls back to raw ID",
+  JSON.stringify(unknownChange.properties.Stage).includes("custom_stage_123")
+)
+ok(
+  "unknown pipeline falls back to raw ID",
+  JSON.stringify(unknownChange.properties.Pipeline).includes("custom_pipeline_456")
 )
 
 // ---------------------------------------------------------------------------
@@ -204,16 +307,49 @@ const minimalDeal: HubSpotDeal = {
   closedate: null,
   hubspot_owner_id: null,
   dealtype: null,
+  hs_forecast_amount: null,
+  hs_forecast_category: null,
+  hs_is_closed_won: null,
   createdate: null,
 }
 
-const minimalDealChange = dealToChange("1", minimalDeal, "2024-01-01", PORTAL_ID, owners)
+const minimalDealChange = dealToChange("1", minimalDeal, "2024-01-01", {}, dealCtx)
 
 ok("null stage omits Stage", minimalDealChange.properties.Stage === undefined)
 ok("null amount omits Amount", minimalDealChange.properties.Amount === undefined)
 ok("null closedate omits Close Date", minimalDealChange.properties["Close Date"] === undefined)
+ok("null pipeline omits Pipeline", minimalDealChange.properties.Pipeline === undefined)
 ok("null owner omits Owner", minimalDealChange.properties.Owner === undefined)
+ok("no associations omits Company", minimalDealChange.properties.Company === undefined)
+ok("no associations omits Contact", minimalDealChange.properties.Contact === undefined)
+ok("null forecast omits Forecast Amount", minimalDealChange.properties["Forecast Amount"] === undefined)
+ok("null forecast category omits Forecast Category", minimalDealChange.properties["Forecast Category"] === undefined)
 ok("null dealtype omits Deal Type", minimalDealChange.properties["Deal Type"] === undefined)
+ok("null stage omits Stage ID", minimalDealChange.properties["Stage ID"] === undefined)
+ok("null pipeline omits Pipeline ID", minimalDealChange.properties["Pipeline ID"] === undefined)
+
+// ---------------------------------------------------------------------------
+// dealToChange — closed won deal
+// ---------------------------------------------------------------------------
+
+console.log("dealToChange — closed won:")
+
+const closedWonDeal: HubSpotDeal = {
+  ...standardDeal,
+  dealstage: "closedwon",
+  hs_is_closed_won: "true",
+}
+
+const closedWonChange = dealToChange("200", closedWonDeal, "2024-07-15", dealAssociations, dealCtx)
+
+ok(
+  "Stage is Closed Won",
+  JSON.stringify(closedWonChange.properties.Stage).includes("Closed Won")
+)
+ok(
+  "Closed Won is true",
+  JSON.stringify(closedWonChange.properties["Closed Won"]).includes("Yes")
+)
 
 // ---------------------------------------------------------------------------
 // companyToChange — standard company
@@ -224,6 +360,7 @@ console.log("companyToChange — standard company:")
 const standardCompany: HubSpotCompany = {
   name: "Acme Corp",
   domain: "acme.com",
+  description: "A leading technology company.",
   industry: "Technology",
   numberofemployees: "250",
   annualrevenue: "10000000",
@@ -233,6 +370,8 @@ const standardCompany: HubSpotCompany = {
   country: "United States",
   phone: "+1-555-0200",
   lifecyclestage: "customer",
+  hs_num_open_deals: "5",
+  total_revenue: "2500000",
   createdate: "2024-01-15T10:00:00Z",
 }
 
@@ -264,6 +403,18 @@ ok(
   JSON.stringify(companyChange.properties.Owner).includes("Jane Smith")
 )
 ok(
+  "Open Deals is 5",
+  JSON.stringify(companyChange.properties["Open Deals"]).includes("5")
+)
+ok(
+  "Total Revenue is 2500000",
+  JSON.stringify(companyChange.properties["Total Revenue"]).includes("2500000")
+)
+ok(
+  "Lifecycle Stage maps to label",
+  JSON.stringify(companyChange.properties["Lifecycle Stage"]).includes("Customer")
+)
+ok(
   "Type maps to label",
   JSON.stringify(companyChange.properties.Type).includes("Customer")
 )
@@ -272,8 +423,20 @@ ok(
   JSON.stringify(companyChange.properties.City).includes("San Francisco")
 )
 ok(
+  "pageContentMarkdown contains description",
+  companyChange.pageContentMarkdown.includes("leading technology")
+)
+ok(
+  "Updated is set",
+  JSON.stringify(companyChange.properties.Updated).includes("2024-06-16")
+)
+ok(
   "Company Link contains portal ID",
   JSON.stringify(companyChange.properties["Company Link"]).includes("12345/company/77")
+)
+ok(
+  "Company ID is set",
+  JSON.stringify(companyChange.properties["Company ID"]).includes("77")
 )
 
 // ---------------------------------------------------------------------------
@@ -285,6 +448,7 @@ console.log("companyToChange — minimal company:")
 const minimalCompany: HubSpotCompany = {
   name: null,
   domain: null,
+  description: null,
   industry: null,
   numberofemployees: null,
   annualrevenue: null,
@@ -294,6 +458,8 @@ const minimalCompany: HubSpotCompany = {
   country: null,
   phone: null,
   lifecyclestage: null,
+  hs_num_open_deals: null,
+  total_revenue: null,
   createdate: null,
 }
 
@@ -303,8 +469,13 @@ ok("null industry omits Industry", minimalCompanyChange.properties.Industry === 
 ok("null domain omits Domain", minimalCompanyChange.properties.Domain === undefined)
 ok("null revenue omits Annual Revenue", minimalCompanyChange.properties["Annual Revenue"] === undefined)
 ok("null employees omits Number of Employees", minimalCompanyChange.properties["Number of Employees"] === undefined)
+ok("null owner omits Owner", minimalCompanyChange.properties.Owner === undefined)
+ok("null open deals omits Open Deals", minimalCompanyChange.properties["Open Deals"] === undefined)
+ok("null total revenue omits Total Revenue", minimalCompanyChange.properties["Total Revenue"] === undefined)
+ok("null lifecycle omits Lifecycle Stage", minimalCompanyChange.properties["Lifecycle Stage"] === undefined)
 ok("null type omits Type", minimalCompanyChange.properties.Type === undefined)
 ok("null city omits City", minimalCompanyChange.properties.City === undefined)
+ok("null description gives empty pageContentMarkdown", minimalCompanyChange.pageContentMarkdown === "")
 
 // ---------------------------------------------------------------------------
 // ownerName — resolves owner IDs

--- a/examples/workers/syncs/hubspot/test.ts
+++ b/examples/workers/syncs/hubspot/test.ts
@@ -1,0 +1,331 @@
+// Offline tests for the hubspot sync worker.
+// No HubSpot connection is made — all assertions run against pure functions.
+// Run: npm test  (or: npx tsx test.ts)
+
+import { contactToChange } from "./src/contacts.js"
+import { dealToChange } from "./src/deals.js"
+import { companyToChange } from "./src/companies.js"
+import { ownerName } from "./src/hubspot.js"
+import { dateOnly } from "./src/helpers.js"
+import type {
+  HubSpotContact,
+  HubSpotDeal,
+  HubSpotCompany,
+  OwnerLookup,
+} from "./src/hubspot.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+const PORTAL_ID = "12345"
+
+const owners: OwnerLookup = new Map([
+  ["101", { id: "101", firstName: "Jane", lastName: "Smith", email: "jane@acme.com" }],
+  ["202", { id: "202", firstName: "", lastName: "", email: "sales@acme.com" }],
+])
+
+// ---------------------------------------------------------------------------
+// contactToChange — standard contact
+// ---------------------------------------------------------------------------
+
+console.log("contactToChange — standard contact:")
+
+const standardContact: HubSpotContact = {
+  firstname: "Alice",
+  lastname: "Johnson",
+  email: "alice@example.com",
+  phone: "+1-555-0100",
+  company: "Acme Corp",
+  jobtitle: "VP of Engineering",
+  lifecyclestage: "salesqualifiedlead",
+  hs_lead_status: "OPEN",
+  hubspot_owner_id: "101",
+  notes_last_updated: "2024-06-16T14:00:00Z",
+  createdate: "2024-06-01T10:00:00Z",
+}
+
+const contactChange = contactToChange("42", standardContact, "2024-06-16T14:00:00Z", PORTAL_ID, owners)
+
+ok("type is upsert", contactChange.type === "upsert")
+ok("key is contact id", contactChange.key === "42")
+ok(
+  "Name combines first and last",
+  JSON.stringify(contactChange.properties.Name).includes("Alice Johnson")
+)
+ok(
+  "Lifecycle Stage maps to label",
+  JSON.stringify(contactChange.properties["Lifecycle Stage"]).includes("Sales Qualified Lead")
+)
+ok(
+  "Lead Status maps to label",
+  JSON.stringify(contactChange.properties["Lead Status"]).includes("Open")
+)
+ok(
+  "Email is set",
+  JSON.stringify(contactChange.properties.Email).includes("alice@example.com")
+)
+ok(
+  "Company is set",
+  JSON.stringify(contactChange.properties.Company).includes("Acme Corp")
+)
+ok(
+  "Last Activity date",
+  JSON.stringify(contactChange.properties["Last Activity"]).includes("2024-06-16")
+)
+ok(
+  "Owner resolved to name",
+  JSON.stringify(contactChange.properties.Owner).includes("Jane Smith")
+)
+ok(
+  "Job Title is set",
+  JSON.stringify(contactChange.properties["Job Title"]).includes("VP of Engineering")
+)
+ok(
+  "Phone is set",
+  JSON.stringify(contactChange.properties.Phone).includes("+1-555-0100")
+)
+ok(
+  "Contact Link contains portal ID and contact ID",
+  JSON.stringify(contactChange.properties["Contact Link"]).includes("12345/contact/42")
+)
+ok(
+  "Contact ID is set",
+  JSON.stringify(contactChange.properties["Contact ID"]).includes("42")
+)
+
+// ---------------------------------------------------------------------------
+// contactToChange — minimal contact
+// ---------------------------------------------------------------------------
+
+console.log("contactToChange — minimal contact:")
+
+const minimalContact: HubSpotContact = {
+  firstname: null,
+  lastname: null,
+  email: null,
+  phone: null,
+  company: null,
+  jobtitle: null,
+  lifecyclestage: null,
+  hs_lead_status: null,
+  hubspot_owner_id: null,
+  notes_last_updated: null,
+  createdate: null,
+}
+
+const minimalContactChange = contactToChange("1", minimalContact, "2024-01-01", PORTAL_ID, owners)
+
+ok(
+  "null names gives (no name)",
+  JSON.stringify(minimalContactChange.properties.Name).includes("(no name)")
+)
+ok("null lifecycle omits Lifecycle Stage", minimalContactChange.properties["Lifecycle Stage"] === undefined)
+ok("null lead status omits Lead Status", minimalContactChange.properties["Lead Status"] === undefined)
+ok("null email omits Email", minimalContactChange.properties.Email === undefined)
+ok("null company omits Company", minimalContactChange.properties.Company === undefined)
+ok("null owner omits Owner", minimalContactChange.properties.Owner === undefined)
+ok("null jobtitle omits Job Title", minimalContactChange.properties["Job Title"] === undefined)
+ok("null phone omits Phone", minimalContactChange.properties.Phone === undefined)
+
+// ---------------------------------------------------------------------------
+// dealToChange — standard deal
+// ---------------------------------------------------------------------------
+
+console.log("dealToChange — standard deal:")
+
+const standardDeal: HubSpotDeal = {
+  dealname: "Acme Corp - Enterprise License",
+  dealstage: "contractsent",
+  pipeline: "default",
+  amount: "50000",
+  closedate: "2024-07-15T00:00:00Z",
+  hubspot_owner_id: "101",
+  dealtype: "newbusiness",
+  createdate: "2024-06-01T10:00:00Z",
+}
+
+const dealChange = dealToChange("99", standardDeal, "2024-06-16T14:00:00Z", PORTAL_ID, owners)
+
+ok("key is deal id", dealChange.key === "99")
+ok(
+  "Deal Name is set",
+  JSON.stringify(dealChange.properties["Deal Name"]).includes("Enterprise License")
+)
+ok(
+  "Stage is set",
+  JSON.stringify(dealChange.properties.Stage).includes("contractsent")
+)
+ok(
+  "Amount is numeric",
+  JSON.stringify(dealChange.properties.Amount).includes("50000")
+)
+ok(
+  "Close Date is set",
+  JSON.stringify(dealChange.properties["Close Date"]).includes("2024-07-15")
+)
+ok(
+  "Owner resolved to name",
+  JSON.stringify(dealChange.properties.Owner).includes("Jane Smith")
+)
+ok(
+  "Deal Link contains portal ID and deal ID",
+  JSON.stringify(dealChange.properties["Deal Link"]).includes("12345/deal/99")
+)
+ok(
+  "Pipeline is set",
+  JSON.stringify(dealChange.properties.Pipeline).includes("default")
+)
+ok(
+  "Deal Type maps to label",
+  JSON.stringify(dealChange.properties["Deal Type"]).includes("New Business")
+)
+
+// ---------------------------------------------------------------------------
+// dealToChange — minimal deal
+// ---------------------------------------------------------------------------
+
+console.log("dealToChange — minimal deal:")
+
+const minimalDeal: HubSpotDeal = {
+  dealname: null,
+  dealstage: null,
+  pipeline: null,
+  amount: null,
+  closedate: null,
+  hubspot_owner_id: null,
+  dealtype: null,
+  createdate: null,
+}
+
+const minimalDealChange = dealToChange("1", minimalDeal, "2024-01-01", PORTAL_ID, owners)
+
+ok("null stage omits Stage", minimalDealChange.properties.Stage === undefined)
+ok("null amount omits Amount", minimalDealChange.properties.Amount === undefined)
+ok("null closedate omits Close Date", minimalDealChange.properties["Close Date"] === undefined)
+ok("null owner omits Owner", minimalDealChange.properties.Owner === undefined)
+ok("null dealtype omits Deal Type", minimalDealChange.properties["Deal Type"] === undefined)
+
+// ---------------------------------------------------------------------------
+// companyToChange — standard company
+// ---------------------------------------------------------------------------
+
+console.log("companyToChange — standard company:")
+
+const standardCompany: HubSpotCompany = {
+  name: "Acme Corp",
+  domain: "acme.com",
+  industry: "Technology",
+  numberofemployees: "250",
+  annualrevenue: "10000000",
+  hubspot_owner_id: "101",
+  type: "CUSTOMER",
+  city: "San Francisco",
+  country: "United States",
+  phone: "+1-555-0200",
+  lifecyclestage: "customer",
+  createdate: "2024-01-15T10:00:00Z",
+}
+
+const companyChange = companyToChange("77", standardCompany, "2024-06-16T14:00:00Z", PORTAL_ID, owners)
+
+ok("key is company id", companyChange.key === "77")
+ok(
+  "Name is set",
+  JSON.stringify(companyChange.properties.Name).includes("Acme Corp")
+)
+ok(
+  "Industry is set",
+  JSON.stringify(companyChange.properties.Industry).includes("Technology")
+)
+ok(
+  "Domain is URL",
+  JSON.stringify(companyChange.properties.Domain).includes("https://acme.com")
+)
+ok(
+  "Annual Revenue is numeric",
+  JSON.stringify(companyChange.properties["Annual Revenue"]).includes("10000000")
+)
+ok(
+  "Number of Employees is numeric",
+  JSON.stringify(companyChange.properties["Number of Employees"]).includes("250")
+)
+ok(
+  "Owner resolved to name",
+  JSON.stringify(companyChange.properties.Owner).includes("Jane Smith")
+)
+ok(
+  "Type maps to label",
+  JSON.stringify(companyChange.properties.Type).includes("Customer")
+)
+ok(
+  "City is set",
+  JSON.stringify(companyChange.properties.City).includes("San Francisco")
+)
+ok(
+  "Company Link contains portal ID",
+  JSON.stringify(companyChange.properties["Company Link"]).includes("12345/company/77")
+)
+
+// ---------------------------------------------------------------------------
+// companyToChange — minimal company
+// ---------------------------------------------------------------------------
+
+console.log("companyToChange — minimal company:")
+
+const minimalCompany: HubSpotCompany = {
+  name: null,
+  domain: null,
+  industry: null,
+  numberofemployees: null,
+  annualrevenue: null,
+  hubspot_owner_id: null,
+  type: null,
+  city: null,
+  country: null,
+  phone: null,
+  lifecyclestage: null,
+  createdate: null,
+}
+
+const minimalCompanyChange = companyToChange("1", minimalCompany, "2024-01-01", PORTAL_ID, owners)
+
+ok("null industry omits Industry", minimalCompanyChange.properties.Industry === undefined)
+ok("null domain omits Domain", minimalCompanyChange.properties.Domain === undefined)
+ok("null revenue omits Annual Revenue", minimalCompanyChange.properties["Annual Revenue"] === undefined)
+ok("null employees omits Number of Employees", minimalCompanyChange.properties["Number of Employees"] === undefined)
+ok("null type omits Type", minimalCompanyChange.properties.Type === undefined)
+ok("null city omits City", minimalCompanyChange.properties.City === undefined)
+
+// ---------------------------------------------------------------------------
+// ownerName — resolves owner IDs
+// ---------------------------------------------------------------------------
+
+console.log("ownerName:")
+
+ok("resolves known owner", ownerName(owners, "101") === "Jane Smith")
+ok("falls back to email when no name", ownerName(owners, "202") === "sales@acme.com")
+ok("null id returns null", ownerName(owners, null) === null)
+ok("unknown id returns null", ownerName(owners, "999") === null)
+
+// ---------------------------------------------------------------------------
+// dateOnly
+// ---------------------------------------------------------------------------
+
+console.log("dateOnly:")
+
+ok("ISO timestamp returns date part", dateOnly("2024-03-15T12:00:00Z") === "2024-03-15")
+ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
+ok("empty string returns empty", dateOnly("") === "")
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/syncs/hubspot/tsconfig.json
+++ b/examples/workers/syncs/hubspot/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a HubSpot CRM sync worker at `examples/workers/syncs/hubspot` that syncs three resources into managed Notion databases:
  - **HubSpot Contacts** (every 5 min) — lifecycle stage, lead status, email, company, owner, job title, associated deals count, recent deal amount
  - **HubSpot Deals** (every 2 min) — stage and pipeline resolved to human-readable labels via pipeline definitions endpoint, amount, close date, owner, associated company and contact names, forecast amount/category, closed won flag, deal description as page body
  - **HubSpot Companies** (every 5 min) — industry, domain, annual revenue, employees, owner, open deals, total revenue, lifecycle stage, company description as page body
- Owner IDs resolved to names by fetching all owners once per sync cycle
- Deal stage and pipeline IDs resolved to labels by fetching pipeline definitions once per sync cycle
- Deal associations (company/contact) resolved per-page using batch reads (2-3 calls per page instead of prefetching entire CRM)
- Contact names resolved in a single batch read call (firstname + lastname together)
- All syncs share a single `worker.pacer()` to respect HubSpot's 100 req/10s rate limit
- Includes offline tests (93 assertions), `.env.example`, and a comprehensive README

## Test plan

- [x] `npm run check` passes (typecheck)
- [x] `npm test` passes (93 offline tests covering standard records, minimal records, stage/pipeline resolution, owner resolution, association resolution, closed won state, unknown stage fallback)
- [ ] `ntn workers sync trigger contactsSync --preview` returns expected contact data
- [ ] `ntn workers sync trigger dealsSync --preview` returns deals with resolved stage labels, pipeline names, and associated company/contact names
- [ ] `ntn workers sync trigger companiesSync --preview` returns expected company data
- [ ] Verify managed databases appear in Notion workspace with correct icons and property order

🤖 Generated with [Claude Code](https://claude.com/claude-code)