### PR TITLE
fix(workers): harden HubSpot sync

### DIFF
--- a/examples/workers/syncs/hubspot/.env.example
+++ b/examples/workers/syncs/hubspot/.env.example
@@ -3,9 +3,9 @@
 # For a deployed worker, set these with `ntn workers env set KEY=value` instead.
 
 # Required
-# A HubSpot private app access token. Create one in Settings > Integrations >
-# Private Apps with scopes: crm.objects.contacts.read, crm.objects.deals.read,
-# crm.objects.companies.read, crm.objects.owners.read.
+# A HubSpot private app access token. As a super admin, create one under
+# Development > Legacy apps with scopes: crm.objects.contacts.read,
+# crm.objects.deals.read, crm.objects.companies.read, crm.objects.owners.read.
 HUBSPOT_ACCESS_TOKEN=
 
 # Your HubSpot portal (account) ID. Find it in Settings > Account Management,

--- a/examples/workers/syncs/hubspot/README.md
+++ b/examples/workers/syncs/hubspot/README.md
@@ -10,71 +10,91 @@ schemas and Notion creates and manages each database for you (these are called
 
 ## What you get
 
-| Database | HubSpot resource | Schedule |
-| --- | --- | --- |
-| **HubSpot Contacts** | Contacts | Every 5 min |
-| **HubSpot Deals** | Deals | Every 5 min |
-| **HubSpot Companies** | Companies | Every 5 min |
+| Database              | HubSpot resource | Schedule    |
+| --------------------- | ---------------- | ----------- |
+| **HubSpot Contacts**  | Contacts         | Every 5 min |
+| **HubSpot Deals**     | Deals            | Every 5 min |
+| **HubSpot Companies** | Companies        | Every 5 min |
 
 ### HubSpot Contacts
 
-| Notion property | HubSpot field | Type |
-| --- | --- | --- |
-| Name | `firstname` + `lastname` | title |
-| Lifecycle Stage | `lifecyclestage` | select |
-| Lead Status | `hs_lead_status` | select |
-| Email | `email` | email |
-| Company | `company` | richText |
-| Last Activity | `notes_last_updated` | date |
-| Owner | `hubspot_owner_id` (resolved) | richText |
-| Job Title | `jobtitle` | richText |
-| Phone | `phone` | richText |
-| Created | `createdate` | date |
-| Contact Link | link to HubSpot record | url |
-| Contact ID | `hs_object_id` | richText |
+| Notion property    | HubSpot field                 | Type        |
+| ------------------ | ----------------------------- | ----------- |
+| Name               | `firstname` + `lastname`      | title       |
+| Lifecycle Stage    | `lifecyclestage`              | select      |
+| Lead Status        | `hs_lead_status`              | select      |
+| Email              | `email`                       | email       |
+| Company            | `company`                     | richText    |
+| Last Activity      | `notes_last_updated`          | date        |
+| Job Title          | `jobtitle`                    | richText    |
+| Owner              | `hubspot_owner_id` (resolved) | richText    |
+| Phone              | `phone`                       | phoneNumber |
+| Associated Deals   | `num_associated_deals`        | number      |
+| Recent Deal Amount | `recent_deal_amount`          | number      |
+| Updated            | HubSpot record `updatedAt`    | date        |
+| Created            | `createdate`                  | date        |
+| Contact Link       | link to HubSpot record        | url         |
+| Contact ID         | `hs_object_id`                | richText    |
 
 ### HubSpot Deals
 
-| Notion property | HubSpot field | Type |
-| --- | --- | --- |
-| Deal Name | `dealname` | title |
-| Stage | `dealstage` | select |
-| Amount | `amount` | number |
-| Close Date | `closedate` | date |
-| Owner | `hubspot_owner_id` (resolved) | richText |
-| Deal Link | link to HubSpot record | url |
-| Pipeline | `pipeline` | richText |
-| Deal Type | `dealtype` | select |
-| Created | `createdate` | date |
-| Deal ID | `hs_object_id` | richText |
+| Notion property   | HubSpot field                 | Type     |
+| ----------------- | ----------------------------- | -------- |
+| Deal Name         | `dealname`                    | title    |
+| Stage             | `dealstage`                   | select   |
+| Amount            | `amount`                      | number   |
+| Close Date        | `closedate`                   | date     |
+| Pipeline          | `pipeline` (resolved)         | richText |
+| Owner             | `hubspot_owner_id` (resolved) | richText |
+| Company           | associated company IDs        | relation |
+| Contact           | associated contact IDs        | relation |
+| Forecast Amount   | `hs_forecast_amount`          | number   |
+| Forecast Category | `hs_forecast_category`        | select   |
+| Closed Won        | `hs_is_closed_won`            | checkbox |
+| Deal Type         | `dealtype`                    | select   |
+| Updated           | HubSpot record `updatedAt`    | date     |
+| Created           | `createdate`                  | date     |
+| Deal Link         | link to HubSpot record        | url      |
+| Stage ID          | `dealstage`                   | richText |
+| Pipeline ID       | `pipeline`                    | richText |
+| Deal ID           | `hs_object_id`                | richText |
+
+Each deal page body contains the HubSpot deal description. Company and contact
+associations are Notion relations, so multiple associated records are retained
+and renames stay in sync with the related managed database.
 
 ### HubSpot Companies
 
-| Notion property | HubSpot field | Type |
-| --- | --- | --- |
-| Name | `name` | title |
-| Industry | `industry` | select |
-| Domain | `domain` | url |
-| Annual Revenue | `annualrevenue` | number |
-| Number of Employees | `numberofemployees` | number |
-| Owner | `hubspot_owner_id` (resolved) | richText |
-| Type | `type` | select |
-| City | `city` | richText |
-| Country | `country` | richText |
-| Phone | `phone` | richText |
-| Created | `createdate` | date |
-| Company Link | link to HubSpot record | url |
-| Company ID | `hs_object_id` | richText |
+| Notion property     | HubSpot field                 | Type        |
+| ------------------- | ----------------------------- | ----------- |
+| Name                | `name`                        | title       |
+| Industry            | `industry`                    | select      |
+| Domain              | `domain`                      | url         |
+| Annual Revenue      | `annualrevenue`               | number      |
+| Number of Employees | `numberofemployees`           | number      |
+| Owner               | `hubspot_owner_id` (resolved) | richText    |
+| Open Deals          | `hs_num_open_deals`           | number      |
+| Total Revenue       | `total_revenue`               | number      |
+| Lifecycle Stage     | `lifecyclestage`              | select      |
+| Type                | `type`                        | select      |
+| City                | `city`                        | richText    |
+| Country             | `country`                     | richText    |
+| Phone               | `phone`                       | phoneNumber |
+| Updated             | HubSpot record `updatedAt`    | date        |
+| Created             | `createdate`                  | date        |
+| Company Link        | link to HubSpot record        | url         |
+| Company ID          | `hs_object_id`                | richText    |
 
-Owner IDs are resolved to names by fetching all HubSpot owners once per sync
-cycle — no extra API call per record.
+Each company page body contains the HubSpot company description. Owner IDs are
+resolved to names by fetching active and deactivated HubSpot owners once per
+sync cycle — no extra API call per record.
 
 ## Project structure
 
 ```text
 src/
 ├── index.ts       — registers all databases and syncs
-├── hubspot.ts     — API client (auth, pagination, types, owner resolution)
+├── hubspot.ts     — API client (auth, pacing, pagination, owner resolution)
 ├── contacts.ts    — contact schema + transform
 ├── deals.ts       — deal schema + transform
 ├── companies.ts   — company schema + transform
@@ -85,25 +105,27 @@ src/
 
 1. Every 5 minutes, the worker fetches each CRM object type using HubSpot's
    list endpoint with cursor-based pagination (100 records per page).
-2. Owner IDs are resolved to names by fetching all owners once at the start
-   of each sync cycle and building a lookup map.
-3. Each record is converted to an `upsert` keyed by HubSpot's record ID, so
+2. Owner IDs are resolved to names by fetching active and deactivated owners.
+   Deal pipeline and stage IDs are resolved from HubSpot's pipeline definitions.
+3. Deal associations become relations to the managed contacts and companies
+   databases, preserving multiple associated records without extra name lookups.
+4. Each record is converted to an `upsert` keyed by HubSpot's record ID, so
    records are never duplicated.
-4. All three syncs share a single rate-limit pacer (90 requests per 10 seconds)
-   to stay within HubSpot's 100/10s limit on Free/Starter plans.
-5. Because all syncs use `mode: "replace"`, records deleted in HubSpot are
+5. Every HubSpot request uses a shared rate-limit pacer (90 requests per 10
+   seconds) to stay within HubSpot's 100/10s limit on Free/Starter plans.
+6. Because all syncs use `mode: "replace"`, records deleted in HubSpot are
    automatically removed from the Notion database on the next full sync.
 
 ## Prerequisites
 
 - Node >= 22, npm >= 10.9.2
-- A HubSpot account with CRM data
-- The `ntn` CLI installed and authenticated (`ntn auth login`)
+- A HubSpot account with CRM data and super-admin access
+- The `ntn` CLI installed and authenticated (`ntn login`)
 
 ### Getting a HubSpot access token
 
-1. Go to **Settings > Integrations > Private Apps**
-2. Click **Create a private app**
+1. In HubSpot, go to **Development > Legacy apps**
+2. Click **Create legacy app**, then select **Private**
 3. Under **Scopes**, add:
    - `crm.objects.contacts.read`
    - `crm.objects.deals.read`
@@ -120,20 +142,20 @@ when logged into HubSpot: `app.hubspot.com/contacts/{portalId}`.
 
 ### Required
 
-| Variable | Description |
-| --- | --- |
+| Variable               | Description                                   |
+| ---------------------- | --------------------------------------------- |
 | `HUBSPOT_ACCESS_TOKEN` | Private app access token with CRM read scopes |
-| `HUBSPOT_PORTAL_ID` | Your HubSpot account (portal) ID |
+| `HUBSPOT_PORTAL_ID`    | Your HubSpot account (portal) ID              |
 
 No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
 automatically.
 
 ## Setup and deploy
 
-1. Install the Notion Workers CLI:
+1. Install the Notion CLI:
 
    ```sh
-   npm install -g @notionhq/ntn
+   curl -fsSL https://ntn.dev | bash
    ```
 
 2. Clone and install:
@@ -153,7 +175,7 @@ automatically.
 4. Log in to Notion:
 
    ```sh
-   ntn auth login
+   ntn login
    ```
 
 5. Deploy the worker:
@@ -192,10 +214,10 @@ databases will appear in your Notion workspace after the first run.
 
 Each resource has its own file with a schema and transform function:
 
-| Resource | File |
-| --- | --- |
-| Contacts | `src/contacts.ts` |
-| Deals | `src/deals.ts` |
+| Resource  | File               |
+| --------- | ------------------ |
+| Contacts  | `src/contacts.ts`  |
+| Deals     | `src/deals.ts`     |
 | Companies | `src/companies.ts` |
 
 To add a new HubSpot property:
@@ -224,9 +246,9 @@ ntn workers exec contactsSync --local
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [HubSpot CRM API — Contacts](https://developers.hubspot.com/docs/api/crm/contacts)
-- [HubSpot CRM API — Deals](https://developers.hubspot.com/docs/api/crm/deals)
-- [HubSpot CRM API — Companies](https://developers.hubspot.com/docs/api/crm/companies)
-- [HubSpot Private Apps](https://developers.hubspot.com/docs/api/private-apps)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [HubSpot CRM API — Contacts](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/contacts/guide)
+- [HubSpot CRM API — Deals](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/deals/guide)
+- [HubSpot CRM API — Companies](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/companies/guide)
+- [HubSpot Private Apps](https://developers.hubspot.com/docs/apps/legacy-apps/private-apps/overview)
 - [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/hubspot/README.md
+++ b/examples/workers/syncs/hubspot/README.md
@@ -107,8 +107,10 @@ src/
    list endpoint with cursor-based pagination (100 records per page).
 2. Owner IDs are resolved to names by fetching active and deactivated owners.
    Deal pipeline and stage IDs are resolved from HubSpot's pipeline definitions.
-3. Deal associations become relations to the managed contacts and companies
-   databases, preserving multiple associated records without extra name lookups.
+3. Deal association IDs are batch-read and followed through each per-deal
+   association cursor before becoming relations to the managed contacts and
+   companies databases. This preserves every associated record without extra
+   name lookups.
 4. Each record is converted to an `upsert` keyed by HubSpot's record ID, so
    records are never duplicated.
 5. Every HubSpot request uses a shared rate-limit pacer (90 requests per 10

--- a/examples/workers/syncs/hubspot/package.json
+++ b/examples/workers/syncs/hubspot/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit",
+    "check": "tsc --project tsconfig.test.json",
     "test": "tsx test.ts"
   },
   "engines": {

--- a/examples/workers/syncs/hubspot/src/companies.ts
+++ b/examples/workers/syncs/hubspot/src/companies.ts
@@ -35,6 +35,7 @@ export const companySchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Opportunity" },
       { name: "Customer" },
       { name: "Evangelist" },
+      { name: "Other" },
     ]),
 
     Type: Schema.select([
@@ -49,7 +50,7 @@ export const companySchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Country: Schema.richText(),
 
-    Phone: Schema.richText(),
+    Phone: Schema.phoneNumber(),
 
     Updated: Schema.date(),
 
@@ -69,6 +70,7 @@ const LIFECYCLE_LABELS: Record<string, string> = {
   opportunity: "Opportunity",
   customer: "Customer",
   evangelist: "Evangelist",
+  other: "Other",
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -87,14 +89,18 @@ export function companyToChange(
   owners: OwnerLookup
 ) {
   const owner = ownerName(owners, company.hubspot_owner_id)
-  const companyType = TYPE_LABELS[company.type?.toUpperCase() ?? ""]
-  const lifecycle = LIFECYCLE_LABELS[company.lifecyclestage ?? ""]
+  const companyTypeValue = company.type?.trim()
+  const lifecycleValue = company.lifecyclestage?.trim()
+  const companyType = companyTypeValue
+    ? TYPE_LABELS[companyTypeValue.toUpperCase()] ?? companyTypeValue
+    : null
+  const lifecycle = lifecycleValue
+    ? LIFECYCLE_LABELS[lifecycleValue] ?? lifecycleValue
+    : null
   const employees = company.numberofemployees
     ? Number(company.numberofemployees)
     : null
-  const revenue = company.annualrevenue
-    ? Number(company.annualrevenue)
-    : null
+  const revenue = company.annualrevenue ? Number(company.annualrevenue) : null
   const openDeals = company.hs_num_open_deals
     ? Number(company.hs_num_open_deals)
     : null
@@ -128,19 +134,13 @@ export function companyToChange(
       ...(totalRevenue != null && !isNaN(totalRevenue)
         ? { "Total Revenue": Builder.number(totalRevenue) }
         : {}),
-      ...(lifecycle
-        ? { "Lifecycle Stage": Builder.select(lifecycle) }
-        : {}),
+      ...(lifecycle ? { "Lifecycle Stage": Builder.select(lifecycle) } : {}),
       ...(companyType ? { Type: Builder.select(companyType) } : {}),
-      ...(company.city
-        ? { City: Builder.richText(company.city) }
-        : {}),
+      ...(company.city ? { City: Builder.richText(company.city) } : {}),
       ...(company.country
         ? { Country: Builder.richText(company.country) }
         : {}),
-      ...(company.phone
-        ? { Phone: Builder.richText(company.phone) }
-        : {}),
+      ...(company.phone ? { Phone: Builder.phoneNumber(company.phone) } : {}),
       Updated: Builder.date(dateOnly(updatedAt)),
       ...(company.createdate
         ? { Created: Builder.date(dateOnly(company.createdate)) }

--- a/examples/workers/syncs/hubspot/src/contacts.ts
+++ b/examples/workers/syncs/hubspot/src/contacts.ts
@@ -21,13 +21,18 @@ export const contactSchema: Schema.Schema<typeof PRIMARY_KEY> = {
       { name: "Opportunity" },
       { name: "Customer" },
       { name: "Evangelist" },
+      { name: "Other" },
     ]),
 
     "Lead Status": Schema.select([
       { name: "New" },
       { name: "Open" },
       { name: "In Progress" },
+      { name: "Open Deal" },
       { name: "Unqualified" },
+      { name: "Attempted to Contact" },
+      { name: "Connected" },
+      { name: "Bad Timing" },
     ]),
 
     Email: Schema.email(),
@@ -40,7 +45,7 @@ export const contactSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Owner: Schema.richText(),
 
-    Phone: Schema.richText(),
+    Phone: Schema.phoneNumber(),
 
     "Associated Deals": Schema.number(),
 
@@ -64,13 +69,18 @@ const LIFECYCLE_LABELS: Record<string, string> = {
   opportunity: "Opportunity",
   customer: "Customer",
   evangelist: "Evangelist",
+  other: "Other",
 }
 
 const LEAD_STATUS_LABELS: Record<string, string> = {
   NEW: "New",
   OPEN: "Open",
   IN_PROGRESS: "In Progress",
+  OPEN_DEAL: "Open Deal",
   UNQUALIFIED: "Unqualified",
+  ATTEMPTED_TO_CONTACT: "Attempted to Contact",
+  CONNECTED: "Connected",
+  BAD_TIMING: "Bad Timing",
 }
 
 function contactName(contact: HubSpotContact): string {
@@ -85,8 +95,14 @@ export function contactToChange(
   portalId: string,
   owners: OwnerLookup
 ) {
-  const lifecycle = LIFECYCLE_LABELS[contact.lifecyclestage ?? ""]
-  const leadStatus = LEAD_STATUS_LABELS[contact.hs_lead_status ?? ""]
+  const lifecycleValue = contact.lifecyclestage?.trim()
+  const leadStatusValue = contact.hs_lead_status?.trim()
+  const lifecycle = lifecycleValue
+    ? LIFECYCLE_LABELS[lifecycleValue] ?? lifecycleValue
+    : null
+  const leadStatus = leadStatusValue
+    ? LEAD_STATUS_LABELS[leadStatusValue] ?? leadStatusValue
+    : null
   const owner = ownerName(owners, contact.hubspot_owner_id)
   const numDeals = contact.num_associated_deals
     ? Number(contact.num_associated_deals)
@@ -101,28 +117,22 @@ export function contactToChange(
     upstreamUpdatedAt: updatedAt,
     properties: {
       Name: Builder.title(contactName(contact)),
-      ...(lifecycle
-        ? { "Lifecycle Stage": Builder.select(lifecycle) }
-        : {}),
-      ...(leadStatus
-        ? { "Lead Status": Builder.select(leadStatus) }
-        : {}),
-      ...(contact.email
-        ? { Email: Builder.email(contact.email) }
-        : {}),
+      ...(lifecycle ? { "Lifecycle Stage": Builder.select(lifecycle) } : {}),
+      ...(leadStatus ? { "Lead Status": Builder.select(leadStatus) } : {}),
+      ...(contact.email ? { Email: Builder.email(contact.email) } : {}),
       ...(contact.company
         ? { Company: Builder.richText(contact.company) }
         : {}),
-      ...(contact.hs_last_sales_activity_timestamp
-        ? { "Last Activity": Builder.date(dateOnly(contact.hs_last_sales_activity_timestamp)) }
+      ...(contact.notes_last_updated
+        ? {
+            "Last Activity": Builder.date(dateOnly(contact.notes_last_updated)),
+          }
         : {}),
       ...(contact.jobtitle
         ? { "Job Title": Builder.richText(contact.jobtitle) }
         : {}),
       ...(owner ? { Owner: Builder.richText(owner) } : {}),
-      ...(contact.phone
-        ? { Phone: Builder.richText(contact.phone) }
-        : {}),
+      ...(contact.phone ? { Phone: Builder.phoneNumber(contact.phone) } : {}),
       ...(numDeals != null && !isNaN(numDeals)
         ? { "Associated Deals": Builder.number(numDeals) }
         : {}),

--- a/examples/workers/syncs/hubspot/src/deals.ts
+++ b/examples/workers/syncs/hubspot/src/deals.ts
@@ -23,9 +23,9 @@ export const dealSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Owner: Schema.richText(),
 
-    Company: Schema.richText(),
+    Company: Schema.relation("companies"),
 
-    Contact: Schema.richText(),
+    Contact: Schema.relation("contacts"),
 
     "Forecast Amount": Schema.number(),
 
@@ -61,8 +61,6 @@ export type DealContext = {
   portalId: string
   owners: OwnerLookup
   pipelines: PipelineLookup
-  companyNames: Map<string, string>
-  contactNames: Map<string, string>
 }
 
 export function dealToChange(
@@ -73,7 +71,10 @@ export function dealToChange(
   ctx: DealContext
 ) {
   const owner = ownerName(ctx.owners, deal.hubspot_owner_id)
-  const dealType = DEAL_TYPE_LABELS[deal.dealtype ?? ""]
+  const dealTypeValue = deal.dealtype?.trim()
+  const dealType = dealTypeValue
+    ? DEAL_TYPE_LABELS[dealTypeValue] ?? dealTypeValue
+    : null
   const amount = deal.amount ? Number(deal.amount) : null
   const forecastAmount = deal.hs_forecast_amount
     ? Number(deal.hs_forecast_amount)
@@ -83,10 +84,8 @@ export function dealToChange(
   const stageName = ctx.pipelines.stageName(deal.dealstage ?? "")
   const pipelineName = ctx.pipelines.pipelineName(deal.pipeline ?? "")
 
-  const companyId = associations["companies"]?.[0]
-  const contactId = associations["contacts"]?.[0]
-  const companyName = companyId ? ctx.companyNames.get(companyId) ?? null : null
-  const contactName = contactId ? ctx.contactNames.get(contactId) ?? null : null
+  const companyIds = [...new Set(associations["companies"] ?? [])]
+  const contactIds = [...new Set(associations["contacts"] ?? [])]
 
   return {
     type: "upsert" as const,
@@ -112,12 +111,8 @@ export function dealToChange(
           ? { Pipeline: Builder.richText(deal.pipeline) }
           : {}),
       ...(owner ? { Owner: Builder.richText(owner) } : {}),
-      ...(companyName
-        ? { Company: Builder.richText(companyName) }
-        : {}),
-      ...(contactName
-        ? { Contact: Builder.richText(contactName) }
-        : {}),
+      Company: companyIds.map((companyId) => Builder.relation(companyId)),
+      Contact: contactIds.map((contactId) => Builder.relation(contactId)),
       ...(forecastAmount != null && !isNaN(forecastAmount)
         ? { "Forecast Amount": Builder.number(forecastAmount) }
         : {}),
@@ -125,9 +120,7 @@ export function dealToChange(
         ? { "Forecast Category": Builder.select(deal.hs_forecast_category) }
         : {}),
       "Closed Won": Builder.checkbox(closedWon),
-      ...(dealType
-        ? { "Deal Type": Builder.select(dealType) }
-        : {}),
+      ...(dealType ? { "Deal Type": Builder.select(dealType) } : {}),
       Updated: Builder.date(dateOnly(updatedAt)),
       ...(deal.createdate
         ? { Created: Builder.date(dateOnly(deal.createdate)) }

--- a/examples/workers/syncs/hubspot/src/hubspot.ts
+++ b/examples/workers/syncs/hubspot/src/hubspot.ts
@@ -7,6 +7,9 @@
 //   3. Wire it into index.ts
 
 const PER_PAGE = 100
+const API_ROOT = "https://api.hubapi.com"
+
+export type BeforeRequest = () => Promise<void>
 
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim()
@@ -24,10 +27,15 @@ function getToken(): string {
   return requireEnv("HUBSPOT_ACCESS_TOKEN")
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+async function fetchJson<T>(
+  url: string,
+  beforeRequest: BeforeRequest
+): Promise<T> {
+  const token = getToken()
+  await beforeRequest()
   const response = await fetch(url, {
     headers: {
-      Authorization: `Bearer ${getToken()}`,
+      Authorization: `Bearer ${token}`,
       Accept: "application/json",
     },
   })
@@ -68,10 +76,11 @@ export type CrmRecord<T> = {
 async function fetchCrmPage<T>(
   objectType: string,
   properties: string[],
+  beforeRequest: BeforeRequest,
   cursor?: string,
   associations?: string[]
 ): Promise<{ records: CrmRecord<T>[]; nextCursor: string | undefined }> {
-  const url = new URL(`https://api.hubapi.com/crm/v3/objects/${objectType}`)
+  const url = new URL(`${API_ROOT}/crm/objects/2026-03/${objectType}`)
   url.searchParams.set("limit", String(PER_PAGE))
   url.searchParams.set("properties", properties.join(","))
   if (associations?.length) {
@@ -81,7 +90,10 @@ async function fetchCrmPage<T>(
     url.searchParams.set("after", cursor)
   }
 
-  const body = await fetchJson<CrmListResponse<T>>(url.toString())
+  const body = await fetchJson<CrmListResponse<T>>(
+    url.toString(),
+    beforeRequest
+  )
   const records = body.results
     .filter((r) => !r.archived)
     .map((r) => {
@@ -112,96 +124,57 @@ async function fetchCrmPage<T>(
 
 export type HubSpotOwner = {
   id: string
-  firstName: string
-  lastName: string
-  email: string
+  firstName?: string | null
+  lastName?: string | null
+  email?: string | null
 }
 
 export type OwnerLookup = Map<string, HubSpotOwner>
 
-export async function fetchAllOwners(): Promise<OwnerLookup> {
+export async function fetchAllOwners(
+  beforeRequest: BeforeRequest
+): Promise<OwnerLookup> {
   const owners: OwnerLookup = new Map()
-  let after: string | undefined
 
-  do {
-    const url = new URL("https://api.hubapi.com/crm/v3/owners")
-    url.searchParams.set("limit", String(PER_PAGE))
-    if (after) url.searchParams.set("after", after)
+  // Records can remain assigned to deactivated owners. HubSpot exposes active
+  // and archived owners as separate result sets, so fetch both.
+  for (const archived of [false, true]) {
+    let after: string | undefined
 
-    const body = await fetchJson<{
-      results: HubSpotOwner[]
-      paging?: { next?: { after: string } }
-    }>(url.toString())
+    do {
+      const url = new URL(`${API_ROOT}/crm/owners/2026-03`)
+      url.searchParams.set("limit", String(PER_PAGE))
+      url.searchParams.set("archived", String(archived))
+      if (after) url.searchParams.set("after", after)
 
-    for (const owner of body.results) {
-      owners.set(owner.id, owner)
-    }
+      const body = await fetchJson<{
+        results: HubSpotOwner[]
+        paging?: { next?: { after: string } }
+      }>(url.toString(), beforeRequest)
 
-    after = body.paging?.next?.after
-  } while (after)
+      for (const owner of body.results) {
+        owners.set(owner.id, owner)
+      }
+
+      after = body.paging?.next?.after
+    } while (after)
+  }
 
   return owners
 }
 
-export function ownerName(owners: OwnerLookup, id: string | null): string | null {
+export function ownerName(
+  owners: OwnerLookup,
+  id: string | null
+): string | null {
   if (!id) return null
   const owner = owners.get(id)
   if (!owner) return null
-  const name = `${owner.firstName} ${owner.lastName}`.trim()
-  return name || owner.email || null
-}
-
-// ---------------------------------------------------------------------------
-// Batch read — resolve a set of record IDs to their properties in one call
-// https://developers.hubspot.com/docs/api/crm/contacts#batch
-// ---------------------------------------------------------------------------
-
-export type NameLookup = Map<string, string>
-
-export async function batchReadNames(
-  objectType: string,
-  ids: string[],
-  nameProperties: string[],
-  formatter?: (props: Record<string, string | null>) => string | null
-): Promise<NameLookup> {
-  const names: NameLookup = new Map()
-  if (ids.length === 0) return names
-
-  const unique = [...new Set(ids)]
-  const url = `https://api.hubapi.com/crm/v3/objects/${objectType}/batch/read`
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${getToken()}`,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      properties: nameProperties,
-      inputs: unique.map((id) => ({ id })),
-    }),
-  })
-
-  const text = await response.text()
-  if (!response.ok) {
-    throw new Error(
-      `HubSpot API error (${response.status}): ${text || "No response body"}`
-    )
-  }
-
-  const body = JSON.parse(text) as {
-    results: { id: string; properties: Record<string, string | null> }[]
-  }
-
-  for (const record of body.results) {
-    const name = formatter
-      ? formatter(record.properties)
-      : record.properties[nameProperties[0]]
-    if (name) names.set(record.id, name)
-  }
-
-  return names
+  const name = [owner.firstName, owner.lastName]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+    .join(" ")
+  return name || owner.email?.trim() || null
 }
 
 // ---------------------------------------------------------------------------
@@ -222,9 +195,12 @@ type PipelineResponse = {
   }[]
 }
 
-export async function fetchDealPipelines(): Promise<PipelineLookup> {
+export async function fetchDealPipelines(
+  beforeRequest: BeforeRequest
+): Promise<PipelineLookup> {
   const body = await fetchJson<PipelineResponse>(
-    "https://api.hubapi.com/crm/v3/pipelines/deals"
+    `${API_ROOT}/crm/pipelines/2026-03/deals`,
+    beforeRequest
   )
 
   const pipelines = new Map<string, string>()
@@ -258,7 +234,7 @@ export type HubSpotContact = {
   lifecyclestage: string | null
   hs_lead_status: string | null
   hubspot_owner_id: string | null
-  hs_last_sales_activity_timestamp: string | null
+  notes_last_updated: string | null
   num_associated_deals: string | null
   recent_deal_amount: string | null
   createdate: string | null
@@ -274,19 +250,23 @@ const CONTACT_PROPERTIES = [
   "lifecyclestage",
   "hs_lead_status",
   "hubspot_owner_id",
-  "hs_last_sales_activity_timestamp",
+  "notes_last_updated",
   "num_associated_deals",
   "recent_deal_amount",
   "createdate",
 ]
 
-export async function fetchContactsPage(cursor?: string): Promise<{
+export async function fetchContactsPage(
+  beforeRequest: BeforeRequest,
+  cursor?: string
+): Promise<{
   contacts: CrmRecord<HubSpotContact>[]
   nextCursor: string | undefined
 }> {
   const { records, nextCursor } = await fetchCrmPage<HubSpotContact>(
     "contacts",
     CONTACT_PROPERTIES,
+    beforeRequest,
     cursor
   )
   return { contacts: records, nextCursor }
@@ -327,13 +307,17 @@ const DEAL_PROPERTIES = [
   "createdate",
 ]
 
-export async function fetchDealsPage(cursor?: string): Promise<{
+export async function fetchDealsPage(
+  beforeRequest: BeforeRequest,
+  cursor?: string
+): Promise<{
   deals: CrmRecord<HubSpotDeal>[]
   nextCursor: string | undefined
 }> {
   const { records, nextCursor } = await fetchCrmPage<HubSpotDeal>(
     "deals",
     DEAL_PROPERTIES,
+    beforeRequest,
     cursor,
     ["companies", "contacts"]
   )
@@ -381,13 +365,17 @@ const COMPANY_PROPERTIES = [
   "createdate",
 ]
 
-export async function fetchCompaniesPage(cursor?: string): Promise<{
+export async function fetchCompaniesPage(
+  beforeRequest: BeforeRequest,
+  cursor?: string
+): Promise<{
   companies: CrmRecord<HubSpotCompany>[]
   nextCursor: string | undefined
 }> {
   const { records, nextCursor } = await fetchCrmPage<HubSpotCompany>(
     "companies",
     COMPANY_PROPERTIES,
+    beforeRequest,
     cursor
   )
   return { companies: records, nextCursor }

--- a/examples/workers/syncs/hubspot/src/hubspot.ts
+++ b/examples/workers/syncs/hubspot/src/hubspot.ts
@@ -7,6 +7,7 @@
 //   3. Wire it into index.ts
 
 const PER_PAGE = 100
+const ASSOCIATION_BATCH_SIZE = 100
 const API_ROOT = "https://api.hubapi.com"
 
 export type BeforeRequest = () => Promise<void>
@@ -29,15 +30,18 @@ function getToken(): string {
 
 async function fetchJson<T>(
   url: string,
-  beforeRequest: BeforeRequest
+  beforeRequest: BeforeRequest,
+  init?: RequestInit
 ): Promise<T> {
   const token = getToken()
+  const headers = new Headers(init?.headers)
+  headers.set("Authorization", `Bearer ${token}`)
+  headers.set("Accept", "application/json")
+
   await beforeRequest()
   const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
+    ...init,
+    headers,
   })
 
   const text = await response.text()
@@ -55,7 +59,6 @@ type CrmListResponse<T> = {
   results: {
     id: string
     properties: T
-    associations?: Record<string, { results: { id: string }[] }>
     createdAt: string
     updatedAt: string
     archived: boolean
@@ -73,19 +76,89 @@ export type CrmRecord<T> = {
   updatedAt: string
 }
 
+type AssociationBatchInput = {
+  id: string
+  after?: string
+}
+
+type AssociationBatchResponse = {
+  results: {
+    from: { id: string }
+    to: { toObjectId: string }[]
+    paging?: { next?: { after: string } }
+  }[]
+}
+
+async function fetchAllAssociations(
+  fromObjectType: string,
+  toObjectType: string,
+  recordIds: string[],
+  beforeRequest: BeforeRequest
+): Promise<Map<string, string[]>> {
+  const uniqueIds = [...new Set(recordIds)]
+  const associations = new Map<string, Set<string>>(
+    uniqueIds.map((id) => [id, new Set<string>()])
+  )
+  const seenCursors = new Set<string>()
+  let pending: AssociationBatchInput[] = uniqueIds.map((id) => ({ id }))
+
+  while (pending.length > 0) {
+    const next: AssociationBatchInput[] = []
+
+    for (
+      let index = 0;
+      index < pending.length;
+      index += ASSOCIATION_BATCH_SIZE
+    ) {
+      const inputs = pending.slice(index, index + ASSOCIATION_BATCH_SIZE)
+      const body = await fetchJson<AssociationBatchResponse>(
+        `${API_ROOT}/crm/associations/2026-03/${fromObjectType}/${toObjectType}/batch/read`,
+        beforeRequest,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ inputs }),
+        }
+      )
+
+      for (const result of body.results) {
+        const ids = associations.get(result.from.id) ?? new Set<string>()
+        for (const association of result.to) {
+          ids.add(association.toObjectId)
+        }
+        associations.set(result.from.id, ids)
+
+        const after = result.paging?.next?.after
+        if (after) {
+          const cursorKey = `${result.from.id}:${after}`
+          if (seenCursors.has(cursorKey)) {
+            throw new Error(
+              `HubSpot repeated association cursor for ${fromObjectType} ${result.from.id}`
+            )
+          }
+          seenCursors.add(cursorKey)
+          next.push({ id: result.from.id, after })
+        }
+      }
+    }
+
+    pending = next
+  }
+
+  return new Map(
+    [...associations].map(([recordId, ids]) => [recordId, [...ids]])
+  )
+}
+
 async function fetchCrmPage<T>(
   objectType: string,
   properties: string[],
   beforeRequest: BeforeRequest,
-  cursor?: string,
-  associations?: string[]
+  cursor?: string
 ): Promise<{ records: CrmRecord<T>[]; nextCursor: string | undefined }> {
   const url = new URL(`${API_ROOT}/crm/objects/2026-03/${objectType}`)
   url.searchParams.set("limit", String(PER_PAGE))
   url.searchParams.set("properties", properties.join(","))
-  if (associations?.length) {
-    url.searchParams.set("associations", associations.join(","))
-  }
   if (cursor) {
     url.searchParams.set("after", cursor)
   }
@@ -96,21 +169,13 @@ async function fetchCrmPage<T>(
   )
   const records = body.results
     .filter((r) => !r.archived)
-    .map((r) => {
-      const assoc: Record<string, string[]> = {}
-      if (r.associations) {
-        for (const [key, val] of Object.entries(r.associations)) {
-          assoc[key] = val.results.map((a) => a.id)
-        }
-      }
-      return {
-        id: r.id,
-        properties: r.properties,
-        associations: assoc,
-        createdAt: r.createdAt,
-        updatedAt: r.updatedAt,
-      }
-    })
+    .map((r) => ({
+      id: r.id,
+      properties: r.properties,
+      associations: {},
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }))
 
   return {
     records,
@@ -318,10 +383,24 @@ export async function fetchDealsPage(
     "deals",
     DEAL_PROPERTIES,
     beforeRequest,
-    cursor,
-    ["companies", "contacts"]
+    cursor
   )
-  return { deals: records, nextCursor }
+
+  const dealIds = records.map((deal) => deal.id)
+  const [companies, contacts] = await Promise.all([
+    fetchAllAssociations("deals", "companies", dealIds, beforeRequest),
+    fetchAllAssociations("deals", "contacts", dealIds, beforeRequest),
+  ])
+  const deals = records.map((deal) => ({
+    ...deal,
+    associations: {
+      ...deal.associations,
+      companies: companies.get(deal.id) ?? [],
+      contacts: contacts.get(deal.id) ?? [],
+    },
+  }))
+
+  return { deals, nextCursor }
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/workers/syncs/hubspot/src/index.ts
+++ b/examples/workers/syncs/hubspot/src/index.ts
@@ -100,7 +100,7 @@ worker.sync("contactsSync", {
 })
 
 // ---------------------------------------------------------------------------
-// Deals — resolves stage/pipeline IDs and association IDs to names
+// Deals — resolves stage/pipeline IDs and maps association IDs to relations
 // ---------------------------------------------------------------------------
 
 const deals = worker.database("deals", {

--- a/examples/workers/syncs/hubspot/src/index.ts
+++ b/examples/workers/syncs/hubspot/src/index.ts
@@ -8,7 +8,7 @@
 //
 // Owner IDs and pipeline/stage IDs are resolved to human-readable names by
 // fetching lookup data once at the start of each sync cycle.
-// Deal associations (company/contact) are resolved per-page using batch reads.
+// Deal associations become relations to the managed company/contact databases.
 
 import { Worker } from "@notionhq/workers"
 
@@ -19,7 +19,6 @@ import {
   fetchContactsPage,
   fetchDealsPage,
   fetchCompaniesPage,
-  batchReadNames,
 } from "./hubspot.js"
 import type { OwnerLookup, PipelineLookup } from "./hubspot.js"
 import {
@@ -53,6 +52,7 @@ const pacer = worker.pacer("hubspot", {
   allowedRequests: 90,
   intervalMs: 10_000,
 })
+const beforeHubSpotRequest = () => pacer.wait()
 
 // Per-cycle caches cleared when the last page completes.
 let contactOwners: OwnerLookup | undefined
@@ -76,16 +76,14 @@ worker.sync("contactsSync", {
   mode: "replace",
   schedule: "5m",
   execute: async (state: SyncState | undefined) => {
-    await pacer.wait()
     const portalId = getPortalId()
 
-    if (!contactOwners) {
-      contactOwners = await fetchAllOwners()
-    }
+    const owners = contactOwners ?? (await fetchAllOwners(beforeHubSpotRequest))
+    contactOwners = owners
 
-    const page = await fetchContactsPage(state?.cursor)
+    const page = await fetchContactsPage(beforeHubSpotRequest, state?.cursor)
     const changes = page.contacts.map((c) =>
-      contactToChange(c.id, c.properties, c.updatedAt, portalId, contactOwners!)
+      contactToChange(c.id, c.properties, c.updatedAt, portalId, owners)
     )
 
     if (page.nextCursor) {
@@ -96,7 +94,7 @@ worker.sync("contactsSync", {
       }
     }
 
-    contactOwners = undefined
+    if (contactOwners === owners) contactOwners = undefined
     return { changes, hasMore: false }
   },
 })
@@ -115,46 +113,29 @@ const deals = worker.database("deals", {
 worker.sync("dealsSync", {
   database: deals,
   mode: "replace",
-  schedule: "2m",
+  schedule: "5m",
   execute: async (state: SyncState | undefined) => {
-    await pacer.wait()
     const portalId = getPortalId()
 
-    if (!dealOwners) {
-      const [owners, pipelines] = await Promise.all([
-        fetchAllOwners(),
-        fetchDealPipelines(),
+    let owners = dealOwners
+    let pipelines = dealPipelines
+    if (!owners || !pipelines) {
+      const lookups = await Promise.all([
+        fetchAllOwners(beforeHubSpotRequest),
+        fetchDealPipelines(beforeHubSpotRequest),
       ])
+      owners = lookups[0]
+      pipelines = lookups[1]
       dealOwners = owners
       dealPipelines = pipelines
     }
 
-    const page = await fetchDealsPage(state?.cursor)
-
-    const companyIds: string[] = []
-    const contactIds: string[] = []
-    for (const d of page.deals) {
-      const cid = d.associations["companies"]?.[0]
-      const tid = d.associations["contacts"]?.[0]
-      if (cid) companyIds.push(cid)
-      if (tid) contactIds.push(tid)
-    }
-
-    await pacer.wait()
-    const [companyNames, contactNames] = await Promise.all([
-      batchReadNames("companies", companyIds, ["name"]),
-      batchReadNames("contacts", contactIds, ["firstname", "lastname"], (props) => {
-        const name = `${props.firstname ?? ""} ${props.lastname ?? ""}`.trim()
-        return name || null
-      }),
-    ])
+    const page = await fetchDealsPage(beforeHubSpotRequest, state?.cursor)
 
     const ctx: DealContext = {
       portalId,
-      owners: dealOwners!,
-      pipelines: dealPipelines!,
-      companyNames,
-      contactNames,
+      owners,
+      pipelines,
     }
 
     const changes = page.deals.map((d) =>
@@ -169,8 +150,8 @@ worker.sync("dealsSync", {
       }
     }
 
-    dealOwners = undefined
-    dealPipelines = undefined
+    if (dealOwners === owners) dealOwners = undefined
+    if (dealPipelines === pipelines) dealPipelines = undefined
     return { changes, hasMore: false }
   },
 })
@@ -191,16 +172,14 @@ worker.sync("companiesSync", {
   mode: "replace",
   schedule: "5m",
   execute: async (state: SyncState | undefined) => {
-    await pacer.wait()
     const portalId = getPortalId()
 
-    if (!companyOwners) {
-      companyOwners = await fetchAllOwners()
-    }
+    const owners = companyOwners ?? (await fetchAllOwners(beforeHubSpotRequest))
+    companyOwners = owners
 
-    const page = await fetchCompaniesPage(state?.cursor)
+    const page = await fetchCompaniesPage(beforeHubSpotRequest, state?.cursor)
     const changes = page.companies.map((c) =>
-      companyToChange(c.id, c.properties, c.updatedAt, portalId, companyOwners!)
+      companyToChange(c.id, c.properties, c.updatedAt, portalId, owners)
     )
 
     if (page.nextCursor) {
@@ -211,7 +190,7 @@ worker.sync("companiesSync", {
       }
     }
 
-    companyOwners = undefined
+    if (companyOwners === owners) companyOwners = undefined
     return { changes, hasMore: false }
   },
 })

--- a/examples/workers/syncs/hubspot/test.ts
+++ b/examples/workers/syncs/hubspot/test.ts
@@ -6,7 +6,12 @@ import { contactSchema, contactToChange } from "./src/contacts.js"
 import { dealToChange } from "./src/deals.js"
 import type { DealContext } from "./src/deals.js"
 import { companySchema, companyToChange } from "./src/companies.js"
-import { fetchAllOwners, fetchContactsPage, ownerName } from "./src/hubspot.js"
+import {
+  fetchAllOwners,
+  fetchContactsPage,
+  fetchDealsPage,
+  ownerName,
+} from "./src/hubspot.js"
 import { dateOnly } from "./src/helpers.js"
 import type {
   HubSpotContact,
@@ -769,7 +774,7 @@ ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
 ok("empty string returns empty", dateOnly("") === "")
 
 // ---------------------------------------------------------------------------
-// HubSpot client — request pacing, owner pagination, and API version
+// HubSpot client — request pacing, owner and association pagination, API version
 // ---------------------------------------------------------------------------
 
 async function testHubSpotClient() {
@@ -778,10 +783,15 @@ async function testHubSpotClient() {
   const originalFetch = globalThis.fetch
   const originalToken = process.env.HUBSPOT_ACCESS_TOKEN
   const requestedUrls: string[] = []
+  const associationRequests: {
+    objectType: string
+    method: string | undefined
+    inputs: { id: string; after?: string }[]
+  }[] = []
   let waits = 0
 
   process.env.HUBSPOT_ACCESS_TOKEN = "test-token"
-  globalThis.fetch = async (input) => {
+  globalThis.fetch = async (input, init) => {
     const rawUrl =
       typeof input === "string"
         ? input
@@ -815,6 +825,99 @@ async function testHubSpotClient() {
       return Response.json({ results: [] })
     }
 
+    if (url.pathname === "/crm/objects/2026-03/deals") {
+      return Response.json({
+        results: [
+          {
+            id: "deal-1",
+            properties: minimalDeal,
+            createdAt: "2026-06-01T00:00:00.000Z",
+            updatedAt: "2026-06-02T00:00:00.000Z",
+            archived: false,
+          },
+          {
+            id: "deal-2",
+            properties: minimalDeal,
+            createdAt: "2026-06-03T00:00:00.000Z",
+            updatedAt: "2026-06-04T00:00:00.000Z",
+            archived: false,
+          },
+        ],
+        paging: { next: { after: "next-deal-page" } },
+      })
+    }
+
+    if (
+      url.pathname === "/crm/associations/2026-03/deals/companies/batch/read" ||
+      url.pathname === "/crm/associations/2026-03/deals/contacts/batch/read"
+    ) {
+      const objectType = url.pathname.includes("/companies/")
+        ? "companies"
+        : "contacts"
+      const body = JSON.parse(String(init?.body)) as {
+        inputs: { id: string; after?: string }[]
+      }
+      associationRequests.push({
+        objectType,
+        method: init?.method,
+        inputs: body.inputs,
+      })
+
+      if (objectType === "contacts") {
+        const after = body.inputs[0]?.after
+        if (after === "contact-page-2") {
+          return Response.json({
+            results: [
+              {
+                from: { id: "deal-2" },
+                to: [{ toObjectId: "610" }, { toObjectId: "611" }],
+              },
+            ],
+          })
+        }
+        return Response.json({
+          results: [
+            {
+              from: { id: "deal-1" },
+              to: [{ toObjectId: "600" }],
+            },
+            {
+              from: { id: "deal-2" },
+              to: [{ toObjectId: "610" }],
+              paging: { next: { after: "contact-page-2" } },
+            },
+          ],
+        })
+      }
+
+      const after = body.inputs[0]?.after
+      if (!after) {
+        return Response.json({
+          results: [
+            {
+              from: { id: "deal-1" },
+              to: [{ toObjectId: "500" }, { toObjectId: "501" }],
+              paging: { next: { after: "company-page-2" } },
+            },
+            {
+              from: { id: "deal-2" },
+              to: [{ toObjectId: "510" }],
+            },
+          ],
+        })
+      }
+      if (after === "company-page-2") {
+        return Response.json({
+          results: [
+            {
+              from: { id: "deal-1" },
+              to: [{ toObjectId: "501" }, { toObjectId: "502" }],
+            },
+          ],
+        })
+      }
+    }
+
     return new Response("Unexpected test URL", { status: 500 })
   }
 
@@ -824,6 +927,7 @@ async function testHubSpotClient() {
     }
     const fetchedOwners = await fetchAllOwners(beforeRequest)
     await fetchContactsPage(beforeRequest)
+    const dealsPage = await fetchDealsPage(beforeRequest, "deal-page")
 
     ok(
       "every HTTP request consumes a pacer slot",
@@ -834,6 +938,56 @@ async function testHubSpotClient() {
     ok(
       "client uses HubSpot's current date-versioned API",
       requestedUrls.every((url) => url.includes("/2026-03"))
+    )
+    ok(
+      "deal object pages propagate both cursors",
+      new URL(
+        requestedUrls.find((url) => url.includes("/objects/2026-03/deals")) ??
+          "https://invalid"
+      ).searchParams.get("after") === "deal-page" &&
+        dealsPage.nextCursor === "next-deal-page"
+    )
+    ok(
+      "deal company associations are fully paginated and deduplicated",
+      dealsPage.deals[0]?.associations.companies?.join(",") === "500,501,502" &&
+        dealsPage.deals[1]?.associations.companies?.join(",") === "510"
+    )
+    ok(
+      "association cursors are independent by type and deal",
+      dealsPage.deals[0]?.associations.contacts?.join(",") === "600" &&
+        dealsPage.deals[1]?.associations.contacts?.join(",") === "610,611"
+    )
+    ok(
+      "association IDs and page cursors are sent in batch request bodies",
+      associationRequests.every((request) => request.method === "POST") &&
+        associationRequests.some(
+          (request) =>
+            request.objectType === "companies" &&
+            request.inputs.map((input) => input.id).join(",") ===
+              "deal-1,deal-2" &&
+            request.inputs.every((input) => input.after === undefined)
+        ) &&
+        associationRequests.some(
+          (request) =>
+            request.objectType === "contacts" &&
+            request.inputs.map((input) => input.id).join(",") ===
+              "deal-1,deal-2" &&
+            request.inputs.every((input) => input.after === undefined)
+        ) &&
+        associationRequests.some(
+          (request) =>
+            request.objectType === "companies" &&
+            request.inputs.length === 1 &&
+            request.inputs[0]?.id === "deal-1" &&
+            request.inputs[0]?.after === "company-page-2"
+        ) &&
+        associationRequests.some(
+          (request) =>
+            request.objectType === "contacts" &&
+            request.inputs.length === 1 &&
+            request.inputs[0]?.id === "deal-2" &&
+            request.inputs[0]?.after === "contact-page-2"
+        )
     )
 
     const contactsUrl = new URL(

--- a/examples/workers/syncs/hubspot/test.ts
+++ b/examples/workers/syncs/hubspot/test.ts
@@ -1,12 +1,12 @@
 // Offline tests for the hubspot sync worker.
-// No HubSpot connection is made — all assertions run against pure functions.
+// No HubSpot connection is made — API assertions use a mocked fetch.
 // Run: npm test  (or: npx tsx test.ts)
 
-import { contactToChange } from "./src/contacts.js"
+import { contactSchema, contactToChange } from "./src/contacts.js"
 import { dealToChange } from "./src/deals.js"
 import type { DealContext } from "./src/deals.js"
-import { companyToChange } from "./src/companies.js"
-import { ownerName } from "./src/hubspot.js"
+import { companySchema, companyToChange } from "./src/companies.js"
+import { fetchAllOwners, fetchContactsPage, ownerName } from "./src/hubspot.js"
 import { dateOnly } from "./src/helpers.js"
 import type {
   HubSpotContact,
@@ -32,12 +32,18 @@ function ok(name: string, cond: boolean) {
 const PORTAL_ID = "12345"
 
 const owners: OwnerLookup = new Map([
-  ["101", { id: "101", firstName: "Jane", lastName: "Smith", email: "jane@acme.com" }],
+  [
+    "101",
+    { id: "101", firstName: "Jane", lastName: "Smith", email: "jane@acme.com" },
+  ],
   ["202", { id: "202", firstName: "", lastName: "", email: "sales@acme.com" }],
+  ["303", { id: "303", email: "queue@acme.com" }],
+  ["404", { id: "404" }],
 ])
 
 const pipelines: PipelineLookup = {
-  pipelineName: (id) => ({ default: "Sales Pipeline", enterprise: "Enterprise" })[id] ?? null,
+  pipelineName: (id) =>
+    ({ default: "Sales Pipeline", enterprise: "Enterprise" })[id] ?? null,
   stageName: (id) =>
     ({
       appointmentscheduled: "Appointment Scheduled",
@@ -52,8 +58,6 @@ const dealCtx: DealContext = {
   portalId: PORTAL_ID,
   owners,
   pipelines,
-  companyNames: new Map([["500", "Acme Corp"]]),
-  contactNames: new Map([["600", "Alice Johnson"]]),
 }
 
 // ---------------------------------------------------------------------------
@@ -72,13 +76,19 @@ const standardContact: HubSpotContact = {
   lifecyclestage: "salesqualifiedlead",
   hs_lead_status: "OPEN",
   hubspot_owner_id: "101",
-  hs_last_sales_activity_timestamp: "2024-06-16T14:00:00Z",
+  notes_last_updated: "2024-06-16T14:00:00Z",
   num_associated_deals: "3",
   recent_deal_amount: "50000",
   createdate: "2024-06-01T10:00:00Z",
 }
 
-const contactChange = contactToChange("42", standardContact, "2024-06-16T14:00:00Z", PORTAL_ID, owners)
+const contactChange = contactToChange(
+  "42",
+  standardContact,
+  "2024-06-16T14:00:00Z",
+  PORTAL_ID,
+  owners
+)
 
 ok("type is upsert", contactChange.type === "upsert")
 ok("key is contact id", contactChange.key === "42")
@@ -88,7 +98,9 @@ ok(
 )
 ok(
   "Lifecycle Stage maps to label",
-  JSON.stringify(contactChange.properties["Lifecycle Stage"]).includes("Sales Qualified Lead")
+  JSON.stringify(contactChange.properties["Lifecycle Stage"]).includes(
+    "Sales Qualified Lead"
+  )
 )
 ok(
   "Lead Status maps to label",
@@ -103,12 +115,16 @@ ok(
   JSON.stringify(contactChange.properties.Company).includes("Acme Corp")
 )
 ok(
-  "Last Activity from sales activity timestamp",
-  JSON.stringify(contactChange.properties["Last Activity"]).includes("2024-06-16")
+  "Last Activity uses HubSpot's Last Activity Date",
+  JSON.stringify(contactChange.properties["Last Activity"]).includes(
+    "2024-06-16"
+  )
 )
 ok(
   "Job Title is set",
-  JSON.stringify(contactChange.properties["Job Title"]).includes("VP of Engineering")
+  JSON.stringify(contactChange.properties["Job Title"]).includes(
+    "VP of Engineering"
+  )
 )
 ok(
   "Owner resolved to name",
@@ -120,7 +136,9 @@ ok(
 )
 ok(
   "Recent Deal Amount is 50000",
-  JSON.stringify(contactChange.properties["Recent Deal Amount"]).includes("50000")
+  JSON.stringify(contactChange.properties["Recent Deal Amount"]).includes(
+    "50000"
+  )
 )
 ok(
   "Updated is set from updatedAt",
@@ -128,7 +146,9 @@ ok(
 )
 ok(
   "Contact Link contains portal ID and contact ID",
-  JSON.stringify(contactChange.properties["Contact Link"]).includes("12345/contact/42")
+  JSON.stringify(contactChange.properties["Contact Link"]).includes(
+    "12345/contact/42"
+  )
 )
 ok(
   "Contact ID is last",
@@ -151,27 +171,115 @@ const minimalContact: HubSpotContact = {
   lifecyclestage: null,
   hs_lead_status: null,
   hubspot_owner_id: null,
-  hs_last_sales_activity_timestamp: null,
+  notes_last_updated: null,
   num_associated_deals: null,
   recent_deal_amount: null,
   createdate: null,
 }
 
-const minimalContactChange = contactToChange("1", minimalContact, "2024-01-01", PORTAL_ID, owners)
+const minimalContactChange = contactToChange(
+  "1",
+  minimalContact,
+  "2024-01-01",
+  PORTAL_ID,
+  owners
+)
 
 ok(
   "null names gives (no name)",
   JSON.stringify(minimalContactChange.properties.Name).includes("(no name)")
 )
-ok("null lifecycle omits Lifecycle Stage", minimalContactChange.properties["Lifecycle Stage"] === undefined)
-ok("null lead status omits Lead Status", minimalContactChange.properties["Lead Status"] === undefined)
-ok("null email omits Email", minimalContactChange.properties.Email === undefined)
-ok("null company omits Company", minimalContactChange.properties.Company === undefined)
-ok("null owner omits Owner", minimalContactChange.properties.Owner === undefined)
-ok("null jobtitle omits Job Title", minimalContactChange.properties["Job Title"] === undefined)
-ok("null phone omits Phone", minimalContactChange.properties.Phone === undefined)
-ok("null deals omits Associated Deals", minimalContactChange.properties["Associated Deals"] === undefined)
-ok("null deal amount omits Recent Deal Amount", minimalContactChange.properties["Recent Deal Amount"] === undefined)
+ok(
+  "null lifecycle omits Lifecycle Stage",
+  minimalContactChange.properties["Lifecycle Stage"] === undefined
+)
+ok(
+  "null lead status omits Lead Status",
+  minimalContactChange.properties["Lead Status"] === undefined
+)
+ok(
+  "null email omits Email",
+  minimalContactChange.properties.Email === undefined
+)
+ok(
+  "null company omits Company",
+  minimalContactChange.properties.Company === undefined
+)
+ok(
+  "null owner omits Owner",
+  minimalContactChange.properties.Owner === undefined
+)
+ok(
+  "null jobtitle omits Job Title",
+  minimalContactChange.properties["Job Title"] === undefined
+)
+ok(
+  "null phone omits Phone",
+  minimalContactChange.properties.Phone === undefined
+)
+ok(
+  "null deals omits Associated Deals",
+  minimalContactChange.properties["Associated Deals"] === undefined
+)
+ok(
+  "null deal amount omits Recent Deal Amount",
+  minimalContactChange.properties["Recent Deal Amount"] === undefined
+)
+
+// ---------------------------------------------------------------------------
+// contactToChange — complete and custom enumerations
+// ---------------------------------------------------------------------------
+
+console.log("contactToChange — enumeration coverage:")
+
+const leadStatuses: Record<string, string> = {
+  OPEN_DEAL: "Open Deal",
+  ATTEMPTED_TO_CONTACT: "Attempted to Contact",
+  CONNECTED: "Connected",
+  BAD_TIMING: "Bad Timing",
+}
+
+for (const [value, label] of Object.entries(leadStatuses)) {
+  const change = contactToChange(
+    value,
+    { ...minimalContact, hs_lead_status: value },
+    "2024-01-01",
+    PORTAL_ID,
+    owners
+  )
+  ok(
+    `${value} maps to ${label}`,
+    JSON.stringify(change.properties["Lead Status"]).includes(label)
+  )
+}
+
+const customContactChange = contactToChange(
+  "custom",
+  {
+    ...minimalContact,
+    lifecyclestage: "productqualifiedlead",
+    hs_lead_status: "NURTURING",
+  },
+  "2024-01-01",
+  PORTAL_ID,
+  owners
+)
+ok(
+  "custom lifecycle stage is preserved",
+  JSON.stringify(customContactChange.properties["Lifecycle Stage"]).includes(
+    "productqualifiedlead"
+  )
+)
+ok(
+  "custom lead status is preserved",
+  JSON.stringify(customContactChange.properties["Lead Status"]).includes(
+    "NURTURING"
+  )
+)
+ok(
+  "contact phone uses the phone number schema",
+  contactSchema.properties.Phone.type === "phone_number"
+)
 
 // ---------------------------------------------------------------------------
 // dealToChange — standard deal
@@ -190,20 +298,29 @@ const standardDeal: HubSpotDeal = {
   hs_forecast_amount: "40000",
   hs_forecast_category: "commit",
   hs_is_closed_won: "false",
+  description: "Enterprise license renewal details.",
   createdate: "2024-06-01T10:00:00Z",
 }
 
 const dealAssociations = {
-  companies: ["500"],
-  contacts: ["600"],
+  companies: ["500", "501"],
+  contacts: ["600", "601"],
 }
 
-const dealChange = dealToChange("99", standardDeal, "2024-06-16T14:00:00Z", dealAssociations, dealCtx)
+const dealChange = dealToChange(
+  "99",
+  standardDeal,
+  "2024-06-16T14:00:00Z",
+  dealAssociations,
+  dealCtx
+)
 
 ok("key is deal id", dealChange.key === "99")
 ok(
   "Deal Name is set",
-  JSON.stringify(dealChange.properties["Deal Name"]).includes("Enterprise License")
+  JSON.stringify(dealChange.properties["Deal Name"]).includes(
+    "Enterprise License"
+  )
 )
 ok(
   "Stage resolved to label",
@@ -226,12 +343,20 @@ ok(
   JSON.stringify(dealChange.properties.Owner).includes("Jane Smith")
 )
 ok(
-  "Company resolved from association",
-  JSON.stringify(dealChange.properties.Company).includes("Acme Corp")
+  "all companies become relations",
+  dealChange.properties.Company.length === 2 &&
+    dealChange.properties.Company[0]?.value === "500" &&
+    dealChange.properties.Company[1]?.value === "501"
 )
 ok(
-  "Contact resolved from association",
-  JSON.stringify(dealChange.properties.Contact).includes("Alice Johnson")
+  "all contacts become relations",
+  dealChange.properties.Contact.length === 2 &&
+    dealChange.properties.Contact[0]?.value === "600" &&
+    dealChange.properties.Contact[1]?.value === "601"
+)
+ok(
+  "pageContentMarkdown contains description",
+  dealChange.pageContentMarkdown.includes("renewal details")
 )
 ok(
   "Forecast Amount is 40000",
@@ -280,9 +405,16 @@ const unknownStageDeal: HubSpotDeal = {
   ...standardDeal,
   dealstage: "custom_stage_123",
   pipeline: "custom_pipeline_456",
+  dealtype: "partner_sale",
 }
 
-const unknownChange = dealToChange("100", unknownStageDeal, "2024-06-16T14:00:00Z", {}, dealCtx)
+const unknownChange = dealToChange(
+  "100",
+  unknownStageDeal,
+  "2024-06-16T14:00:00Z",
+  {},
+  dealCtx
+)
 
 ok(
   "unknown stage falls back to raw ID",
@@ -290,7 +422,13 @@ ok(
 )
 ok(
   "unknown pipeline falls back to raw ID",
-  JSON.stringify(unknownChange.properties.Pipeline).includes("custom_pipeline_456")
+  JSON.stringify(unknownChange.properties.Pipeline).includes(
+    "custom_pipeline_456"
+  )
+)
+ok(
+  "custom deal type is preserved",
+  JSON.stringify(unknownChange.properties["Deal Type"]).includes("partner_sale")
 )
 
 // ---------------------------------------------------------------------------
@@ -310,23 +448,60 @@ const minimalDeal: HubSpotDeal = {
   hs_forecast_amount: null,
   hs_forecast_category: null,
   hs_is_closed_won: null,
+  description: null,
   createdate: null,
 }
 
-const minimalDealChange = dealToChange("1", minimalDeal, "2024-01-01", {}, dealCtx)
+const minimalDealChange = dealToChange(
+  "1",
+  minimalDeal,
+  "2024-01-01",
+  {},
+  dealCtx
+)
 
 ok("null stage omits Stage", minimalDealChange.properties.Stage === undefined)
-ok("null amount omits Amount", minimalDealChange.properties.Amount === undefined)
-ok("null closedate omits Close Date", minimalDealChange.properties["Close Date"] === undefined)
-ok("null pipeline omits Pipeline", minimalDealChange.properties.Pipeline === undefined)
+ok(
+  "null amount omits Amount",
+  minimalDealChange.properties.Amount === undefined
+)
+ok(
+  "null closedate omits Close Date",
+  minimalDealChange.properties["Close Date"] === undefined
+)
+ok(
+  "null pipeline omits Pipeline",
+  minimalDealChange.properties.Pipeline === undefined
+)
 ok("null owner omits Owner", minimalDealChange.properties.Owner === undefined)
-ok("no associations omits Company", minimalDealChange.properties.Company === undefined)
-ok("no associations omits Contact", minimalDealChange.properties.Contact === undefined)
-ok("null forecast omits Forecast Amount", minimalDealChange.properties["Forecast Amount"] === undefined)
-ok("null forecast category omits Forecast Category", minimalDealChange.properties["Forecast Category"] === undefined)
-ok("null dealtype omits Deal Type", minimalDealChange.properties["Deal Type"] === undefined)
-ok("null stage omits Stage ID", minimalDealChange.properties["Stage ID"] === undefined)
-ok("null pipeline omits Pipeline ID", minimalDealChange.properties["Pipeline ID"] === undefined)
+ok(
+  "no associations clears Company",
+  minimalDealChange.properties.Company.length === 0
+)
+ok(
+  "no associations clears Contact",
+  minimalDealChange.properties.Contact.length === 0
+)
+ok(
+  "null forecast omits Forecast Amount",
+  minimalDealChange.properties["Forecast Amount"] === undefined
+)
+ok(
+  "null forecast category omits Forecast Category",
+  minimalDealChange.properties["Forecast Category"] === undefined
+)
+ok(
+  "null dealtype omits Deal Type",
+  minimalDealChange.properties["Deal Type"] === undefined
+)
+ok(
+  "null stage omits Stage ID",
+  minimalDealChange.properties["Stage ID"] === undefined
+)
+ok(
+  "null pipeline omits Pipeline ID",
+  minimalDealChange.properties["Pipeline ID"] === undefined
+)
 
 // ---------------------------------------------------------------------------
 // dealToChange — closed won deal
@@ -340,7 +515,13 @@ const closedWonDeal: HubSpotDeal = {
   hs_is_closed_won: "true",
 }
 
-const closedWonChange = dealToChange("200", closedWonDeal, "2024-07-15", dealAssociations, dealCtx)
+const closedWonChange = dealToChange(
+  "200",
+  closedWonDeal,
+  "2024-07-15",
+  dealAssociations,
+  dealCtx
+)
 
 ok(
   "Stage is Closed Won",
@@ -375,7 +556,13 @@ const standardCompany: HubSpotCompany = {
   createdate: "2024-01-15T10:00:00Z",
 }
 
-const companyChange = companyToChange("77", standardCompany, "2024-06-16T14:00:00Z", PORTAL_ID, owners)
+const companyChange = companyToChange(
+  "77",
+  standardCompany,
+  "2024-06-16T14:00:00Z",
+  PORTAL_ID,
+  owners
+)
 
 ok("key is company id", companyChange.key === "77")
 ok(
@@ -392,11 +579,15 @@ ok(
 )
 ok(
   "Annual Revenue is numeric",
-  JSON.stringify(companyChange.properties["Annual Revenue"]).includes("10000000")
+  JSON.stringify(companyChange.properties["Annual Revenue"]).includes(
+    "10000000"
+  )
 )
 ok(
   "Number of Employees is numeric",
-  JSON.stringify(companyChange.properties["Number of Employees"]).includes("250")
+  JSON.stringify(companyChange.properties["Number of Employees"]).includes(
+    "250"
+  )
 )
 ok(
   "Owner resolved to name",
@@ -412,7 +603,9 @@ ok(
 )
 ok(
   "Lifecycle Stage maps to label",
-  JSON.stringify(companyChange.properties["Lifecycle Stage"]).includes("Customer")
+  JSON.stringify(companyChange.properties["Lifecycle Stage"]).includes(
+    "Customer"
+  )
 )
 ok(
   "Type maps to label",
@@ -432,7 +625,9 @@ ok(
 )
 ok(
   "Company Link contains portal ID",
-  JSON.stringify(companyChange.properties["Company Link"]).includes("12345/company/77")
+  JSON.stringify(companyChange.properties["Company Link"]).includes(
+    "12345/company/77"
+  )
 )
 ok(
   "Company ID is set",
@@ -463,19 +658,80 @@ const minimalCompany: HubSpotCompany = {
   createdate: null,
 }
 
-const minimalCompanyChange = companyToChange("1", minimalCompany, "2024-01-01", PORTAL_ID, owners)
+const minimalCompanyChange = companyToChange(
+  "1",
+  minimalCompany,
+  "2024-01-01",
+  PORTAL_ID,
+  owners
+)
 
-ok("null industry omits Industry", minimalCompanyChange.properties.Industry === undefined)
-ok("null domain omits Domain", minimalCompanyChange.properties.Domain === undefined)
-ok("null revenue omits Annual Revenue", minimalCompanyChange.properties["Annual Revenue"] === undefined)
-ok("null employees omits Number of Employees", minimalCompanyChange.properties["Number of Employees"] === undefined)
-ok("null owner omits Owner", minimalCompanyChange.properties.Owner === undefined)
-ok("null open deals omits Open Deals", minimalCompanyChange.properties["Open Deals"] === undefined)
-ok("null total revenue omits Total Revenue", minimalCompanyChange.properties["Total Revenue"] === undefined)
-ok("null lifecycle omits Lifecycle Stage", minimalCompanyChange.properties["Lifecycle Stage"] === undefined)
+ok(
+  "null industry omits Industry",
+  minimalCompanyChange.properties.Industry === undefined
+)
+ok(
+  "null domain omits Domain",
+  minimalCompanyChange.properties.Domain === undefined
+)
+ok(
+  "null revenue omits Annual Revenue",
+  minimalCompanyChange.properties["Annual Revenue"] === undefined
+)
+ok(
+  "null employees omits Number of Employees",
+  minimalCompanyChange.properties["Number of Employees"] === undefined
+)
+ok(
+  "null owner omits Owner",
+  minimalCompanyChange.properties.Owner === undefined
+)
+ok(
+  "null open deals omits Open Deals",
+  minimalCompanyChange.properties["Open Deals"] === undefined
+)
+ok(
+  "null total revenue omits Total Revenue",
+  minimalCompanyChange.properties["Total Revenue"] === undefined
+)
+ok(
+  "null lifecycle omits Lifecycle Stage",
+  minimalCompanyChange.properties["Lifecycle Stage"] === undefined
+)
 ok("null type omits Type", minimalCompanyChange.properties.Type === undefined)
 ok("null city omits City", minimalCompanyChange.properties.City === undefined)
-ok("null description gives empty pageContentMarkdown", minimalCompanyChange.pageContentMarkdown === "")
+ok(
+  "null description gives empty pageContentMarkdown",
+  minimalCompanyChange.pageContentMarkdown === ""
+)
+
+const customCompanyChange = companyToChange(
+  "custom",
+  {
+    ...minimalCompany,
+    lifecyclestage: "productqualifiedlead",
+    type: "STRATEGIC_PARTNER",
+  },
+  "2024-01-01",
+  PORTAL_ID,
+  owners
+)
+ok(
+  "custom company lifecycle stage is preserved",
+  JSON.stringify(customCompanyChange.properties["Lifecycle Stage"]).includes(
+    "productqualifiedlead"
+  )
+)
+ok(
+  "custom company type is preserved",
+  JSON.stringify(customCompanyChange.properties.Type).includes(
+    "STRATEGIC_PARTNER"
+  )
+)
+ok(
+  "company phone uses the phone number schema",
+  companySchema.properties.Phone.type === "phone_number"
+)
 
 // ---------------------------------------------------------------------------
 // ownerName — resolves owner IDs
@@ -484,7 +740,18 @@ ok("null description gives empty pageContentMarkdown", minimalCompanyChange.page
 console.log("ownerName:")
 
 ok("resolves known owner", ownerName(owners, "101") === "Jane Smith")
-ok("falls back to email when no name", ownerName(owners, "202") === "sales@acme.com")
+ok(
+  "falls back to email when no name",
+  ownerName(owners, "202") === "sales@acme.com"
+)
+ok(
+  "handles an owner with omitted name fields",
+  ownerName(owners, "303") === "queue@acme.com"
+)
+ok(
+  "does not render missing fields as undefined",
+  ownerName(owners, "404") === null
+)
 ok("null id returns null", ownerName(owners, null) === null)
 ok("unknown id returns null", ownerName(owners, "999") === null)
 
@@ -494,9 +761,107 @@ ok("unknown id returns null", ownerName(owners, "999") === null)
 
 console.log("dateOnly:")
 
-ok("ISO timestamp returns date part", dateOnly("2024-03-15T12:00:00Z") === "2024-03-15")
+ok(
+  "ISO timestamp returns date part",
+  dateOnly("2024-03-15T12:00:00Z") === "2024-03-15"
+)
 ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
 ok("empty string returns empty", dateOnly("") === "")
 
-console.log(`\n${passed} passed, ${failed} failed`)
-if (failed > 0) process.exit(1)
+// ---------------------------------------------------------------------------
+// HubSpot client — request pacing, owner pagination, and API version
+// ---------------------------------------------------------------------------
+
+async function testHubSpotClient() {
+  console.log("HubSpot client:")
+
+  const originalFetch = globalThis.fetch
+  const originalToken = process.env.HUBSPOT_ACCESS_TOKEN
+  const requestedUrls: string[] = []
+  let waits = 0
+
+  process.env.HUBSPOT_ACCESS_TOKEN = "test-token"
+  globalThis.fetch = async (input) => {
+    const rawUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    const url = new URL(rawUrl)
+    requestedUrls.push(url.toString())
+
+    if (url.pathname === "/crm/owners/2026-03") {
+      const archived = url.searchParams.get("archived") === "true"
+      const after = url.searchParams.get("after")
+
+      if (!archived && !after) {
+        return Response.json({
+          results: [{ id: "active", firstName: "Active", lastName: "Owner" }],
+          paging: { next: { after: "next-owner" } },
+        })
+      }
+      if (!archived) {
+        return Response.json({
+          results: [{ id: "active-2", email: "two@example.com" }],
+        })
+      }
+      return Response.json({
+        results: [{ id: "archived", email: "former@example.com" }],
+      })
+    }
+
+    if (url.pathname === "/crm/objects/2026-03/contacts") {
+      return Response.json({ results: [] })
+    }
+
+    return new Response("Unexpected test URL", { status: 500 })
+  }
+
+  try {
+    const beforeRequest = async () => {
+      waits++
+    }
+    const fetchedOwners = await fetchAllOwners(beforeRequest)
+    await fetchContactsPage(beforeRequest)
+
+    ok(
+      "every HTTP request consumes a pacer slot",
+      waits === requestedUrls.length
+    )
+    ok("active owner pages are fully paginated", fetchedOwners.has("active-2"))
+    ok("archived owners are included", fetchedOwners.has("archived"))
+    ok(
+      "client uses HubSpot's current date-versioned API",
+      requestedUrls.every((url) => url.includes("/2026-03"))
+    )
+
+    const contactsUrl = new URL(
+      requestedUrls.find((url) => url.includes("/contacts")) ??
+        "https://invalid"
+    )
+    const requestedProperties = contactsUrl.searchParams.get("properties") ?? ""
+    ok(
+      "contacts request HubSpot's Last Activity Date",
+      requestedProperties.includes("notes_last_updated") &&
+        !requestedProperties.includes("hs_last_sales_activity_timestamp")
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalToken === undefined) {
+      delete process.env.HUBSPOT_ACCESS_TOKEN
+    } else {
+      process.env.HUBSPOT_ACCESS_TOKEN = originalToken
+    }
+  }
+}
+
+testHubSpotClient()
+  .catch((error: unknown) => {
+    failed++
+    console.error("  FAIL HubSpot client tests", error)
+  })
+  .finally(() => {
+    console.log(`\n${passed} passed, ${failed} failed`)
+    if (failed > 0) process.exitCode = 1
+  })

--- a/examples/workers/syncs/hubspot/tsconfig.test.json
+++ b/examples/workers/syncs/hubspot/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- pace every HubSpot HTTP request and move the client to the current 2026-03 API paths
- read HubSpot's actual Last Activity Date and resolve both active and deactivated owners safely
- replace lossy single-name deal associations with native Notion relations for all returned contacts and companies
- preserve standard and custom enum values, use phone-number properties, and restore the supported five-minute schedule
- update setup/schema documentation and typecheck the expanded offline API tests

Follow-up to #35.

## Test plan

- [x] `npm run check`
- [x] `npm run build`
- [x] `npm test` (112 assertions)
- [x] validate the generated worker manifest and relation schemas
- [x] Prettier check
- [x] Markdown lint
