### PR TITLE
feat(workers): add jira sync example

### DIFF
--- a/examples/workers/syncs/jira/.env.example
+++ b/examples/workers/syncs/jira/.env.example
@@ -1,0 +1,24 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+
+# Required
+# Your Jira Cloud domain (e.g. "acme" for acme.atlassian.net).
+JIRA_DOMAIN=
+
+# The email address of the Jira user whose API token you're using.
+JIRA_EMAIL=
+
+# A Jira API token. Create one at https://id.atlassian.com/manage/api-tokens
+JIRA_API_TOKEN=
+
+# Optional — comma-separated list of project keys to sync (e.g. "PROJ,TEAM").
+# If not set, all projects are synced — this can be slow on large instances.
+# JIRA_PROJECTS=PROJ,TEAM
+
+# Optional — custom field IDs for Story Points and Epic Link.
+# These vary by Jira instance. To find yours, open an issue in the browser,
+# inspect the fields via GET /rest/api/3/issue/{key}, and look for the
+# customfield_XXXXX entries.
+# JIRA_STORY_POINTS_FIELD=customfield_10016
+# JIRA_EPIC_FIELD=customfield_10014

--- a/examples/workers/syncs/jira/.env.example
+++ b/examples/workers/syncs/jira/.env.example
@@ -12,13 +12,16 @@ JIRA_EMAIL=
 # A Jira API token. Create one at https://id.atlassian.com/manage/api-tokens
 JIRA_API_TOKEN=
 
-# Optional — comma-separated list of project keys to sync (e.g. "PROJ,TEAM").
-# If not set, all projects are synced — this can be slow on large instances.
+# Optional — comma-separated project keys whose issues should be synced.
+# Sprints and the Projects database still include all visible Jira projects.
+# If not set, issues from all projects are synced, which can be slow.
 # JIRA_PROJECTS=PROJ,TEAM
 
-# Optional — custom field IDs for Story Points and Epic Link.
-# These vary by Jira instance. To find yours, open an issue in the browser,
-# inspect the fields via GET /rest/api/3/issue/{key}, and look for the
-# customfield_XXXXX entries.
+# Optional — custom field ID overrides for Sprint, Story Points, and Epic Link.
+# The worker discovers these automatically from Jira's field metadata. Set an
+# override only if a field is renamed or discovery is ambiguous. Story Points
+# accepts comma-separated IDs when both Jira estimation fields are in use. To
+# find IDs, inspect GET /rest/api/3/field for customfield_XXXXX entries.
+# JIRA_SPRINT_FIELD=customfield_10020
 # JIRA_STORY_POINTS_FIELD=customfield_10016
 # JIRA_EPIC_FIELD=customfield_10014

--- a/examples/workers/syncs/jira/.gitignore
+++ b/examples/workers/syncs/jira/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/jira/README.md
+++ b/examples/workers/syncs/jira/README.md
@@ -10,58 +10,74 @@ schemas and Notion creates and manages each database for you (these are called
 
 ## What you get
 
-| Database | Jira resource | Schedule |
-| --- | --- | --- |
-| **Jira Issues** | Issues (via JQL search) | Every 2 min |
-| **Jira Sprints** | Sprints (across Scrum boards) | Every 5 min |
-| **Jira Projects** | Projects | Every 5 min |
+| Database          | Jira resource                 | Schedule    |
+| ----------------- | ----------------------------- | ----------- |
+| **Jira Issues**   | Issues (via JQL search)       | Every 2 min |
+| **Jira Sprints**  | Sprints (across Scrum boards) | Every 5 min |
+| **Jira Projects** | Projects                      | Every 5 min |
 
 ### Jira Issues
 
-| Notion property | Jira field | Type |
-| --- | --- | --- |
-| Summary | `summary` | title |
-| Status | `status.name` | select |
-| Issue Type | `issuetype.name` | select |
-| Assignee | `assignee.displayName` | richText |
-| Sprint | `sprint.name` | richText |
-| Updated | `updated` | date |
-| Status Category | `status.statusCategory.name` | select |
-| Priority | `priority.name` | select |
-| Reporter | `reporter.displayName` | richText |
-| Project | `project.name` | richText |
-| Issue Link | link to Jira issue | url |
-| Labels | `labels` | multiSelect |
-| Components | `components[].name` | multiSelect |
-| Fix Versions | `fixVersions[].name` | multiSelect |
-| Resolution | `resolution.name` | select |
-| Due Date | `duedate` | date |
-| Epic | `parent.fields.summary` or custom field | richText |
-| Story Points | custom field (configurable) | number |
-| Created | `created` | date |
-| Issue Key | `key` (e.g. PROJ-123) | richText |
+| Notion property | Jira field                                           | Type        |
+| --------------- | ---------------------------------------------------- | ----------- |
+| Summary         | `summary`                                            | title       |
+| Status          | `status.name`                                        | select      |
+| Issue Type      | `issuetype.name`                                     | select      |
+| Assignee        | `assignee.displayName`                               | richText    |
+| Sprint          | discovered Sprint custom field                       | richText    |
+| Updated         | `updated`                                            | date        |
+| Status Category | `status.statusCategory.name`                         | select      |
+| Priority        | `priority.name`                                      | select      |
+| Reporter        | `reporter.displayName`                               | richText    |
+| Project         | `project.name`                                       | richText    |
+| Issue Link      | link to Jira issue                                   | url         |
+| Labels          | `labels`                                             | multiSelect |
+| Components      | `components[].name`                                  | multiSelect |
+| Fix Versions    | `fixVersions[].name`                                 | multiSelect |
+| Resolution      | `resolution.name`                                    | select      |
+| Due Date        | `duedate`                                            | date        |
+| Epic            | issue hierarchy or discovered Epic Link custom field | richText    |
+| Story Points    | discovered Story Points custom field                 | number      |
+| Created         | `created`                                            | date        |
+| Issue Key       | `key` (e.g. PROJ-123)                                | richText    |
+| Jira Issue ID   | `id` (immutable primary key)                         | richText    |
 
 **Status Category** groups custom statuses (like "Waiting for Customer" or
 "Code Review") into three categories: To Do, In Progress, Done. More useful
 for high-level views than individual status names.
 
-**Epic** is resolved from the issue's parent summary (next-gen/team-managed
-projects) or from a custom field (classic projects — see optional env vars).
+**Sprint**, **Story Points**, and **Epic Link** custom fields are discovered
+automatically from Jira's field metadata. If your Jira instance has ambiguous
+or renamed fields, use the optional environment variables below to specify the
+field IDs explicitly.
 
-**Story Points** requires setting the `JIRA_STORY_POINTS_FIELD` env var.
+Story Points discovery requests both Jira's company-managed **Story Points**
+field and team-managed **Story point estimate** field when both exist, then
+uses whichever is populated on each issue. Because this discovery is based on
+the standard English field names, renamed or localized fields need an explicit
+override.
+
+**Epic** uses a standard issue's direct hierarchy parent, then falls back to
+the discovered Epic Link field. A subtask's direct parent is a task or story,
+so it is deliberately left blank rather than mislabeled when Jira doesn't
+expose an explicit Epic Link for the subtask.
+
+The immutable **Jira Issue ID** is the database primary key. **Issue Key**
+remains a display property and is used in links, but it can change when an issue
+moves to another project.
 
 ### Jira Sprints
 
-| Notion property | Jira field | Type |
-| --- | --- | --- |
-| Name | `name` | title |
-| State | `state` | select |
-| Board | board name (resolved) | richText |
-| Start Date | `startDate` | date |
-| End Date | `endDate` | date |
-| Goal | `goal` | richText |
-| Complete Date | `completeDate` | date |
-| Sprint ID | `id` | richText |
+| Notion property | Jira field            | Type     |
+| --------------- | --------------------- | -------- |
+| Name            | `name`                | title    |
+| State           | `state`               | select   |
+| Board           | board name (resolved) | richText |
+| Start Date      | `startDate`           | date     |
+| End Date        | `endDate`             | date     |
+| Goal            | `goal`                | richText |
+| Complete Date   | `completeDate`        | date     |
+| Sprint ID       | `id`                  | richText |
 
 Board IDs are resolved to names by fetching all Scrum boards once per sync
 cycle. Only Scrum boards are fetched (Kanban boards don't have sprints).
@@ -69,16 +85,20 @@ Page body contains the sprint goal.
 
 ### Jira Projects
 
-| Notion property | Jira field | Type |
-| --- | --- | --- |
-| Name | `name` | title |
-| Project Key | `key` (e.g. PROJ) | richText |
-| Lead | `lead.displayName` | richText |
-| Category | `projectCategory.name` | select |
-| Project Type | `projectTypeKey` | select |
-| Project Link | link to Jira project | url |
+| Notion property | Jira field                   | Type     |
+| --------------- | ---------------------------- | -------- |
+| Name            | `name`                       | title    |
+| Project Key     | `key` (e.g. PROJ)            | richText |
+| Lead            | `lead.displayName`           | richText |
+| Category        | `projectCategory.name`       | select   |
+| Project Type    | `projectTypeKey`             | select   |
+| Project Link    | link to Jira project         | url      |
+| Jira Project ID | `id` (immutable primary key) | richText |
 
 Page body contains the project description.
+The immutable **Jira Project ID** is the database primary key; **Project Key**
+stays available as a display property because Jira administrators can change
+it.
 
 ## Project structure
 
@@ -95,14 +115,16 @@ src/
 ## How it works
 
 1. **Issues** are fetched every 2 minutes via JQL search, scoped to
-   specific projects if `JIRA_PROJECTS` is set. Uses `startAt`/`total`
-   pagination (100 issues per page).
+   specific projects if `JIRA_PROJECTS` is set. Uses `nextPageToken`
+   pagination (100 issues per page). Jira truncation warnings abort the sync so
+   a partial result can't be committed as a complete replacement snapshot.
 2. **Sprints** are fetched every 5 minutes by listing all Scrum boards,
    then fetching sprints for each. Board names are resolved once per cycle.
    Deleted boards are skipped gracefully.
 3. **Projects** are fetched every 5 minutes via the project search endpoint.
-4. All syncs share a single rate-limit pacer (9 requests per second) to stay
-   within Jira Cloud's 10/second limit on Standard plans.
+4. All syncs share a single rate-limit pacer (9 requests per second). If Jira
+   responds with HTTP 429, the worker passes Jira's `Retry-After` interval to
+   the runtime so the request can be retried after the requested delay.
 5. Because all syncs use `mode: "replace"`, records deleted from Jira are
    automatically removed from the Notion database on the next full sync.
 
@@ -110,7 +132,7 @@ src/
 
 - Node >= 22, npm >= 10.9.2
 - A Jira Cloud instance
-- The `ntn` CLI installed and authenticated (`ntn auth login`)
+- The `ntn` CLI installed and authenticated (`ntn login`)
 
 ### Getting a Jira API token
 
@@ -122,23 +144,25 @@ src/
 
 ### Required
 
-| Variable | Description |
-| --- | --- |
-| `JIRA_DOMAIN` | Your Jira Cloud domain (e.g. `acme` for acme.atlassian.net) |
-| `JIRA_EMAIL` | Email of the Atlassian account for API access |
-| `JIRA_API_TOKEN` | API token from id.atlassian.com |
+| Variable         | Description                                                 |
+| ---------------- | ----------------------------------------------------------- |
+| `JIRA_DOMAIN`    | Your Jira Cloud domain (e.g. `acme` for acme.atlassian.net) |
+| `JIRA_EMAIL`     | Email of the Atlassian account for API access               |
+| `JIRA_API_TOKEN` | API token from id.atlassian.com                             |
 
 ### Optional
 
-| Variable | Description |
-| --- | --- |
-| `JIRA_PROJECTS` | Comma-separated project keys to sync (e.g. `PROJ,TEAM`). If not set, all projects are synced. |
-| `JIRA_STORY_POINTS_FIELD` | Custom field ID for story points (e.g. `customfield_10016`) |
-| `JIRA_EPIC_FIELD` | Custom field ID for epic link (e.g. `customfield_10014`) |
+| Variable                  | Description                                                                                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JIRA_PROJECTS`           | Comma-separated project keys whose issues should be synced (e.g. `PROJ,TEAM`). Sprints and the Projects database still include all visible projects. |
+| `JIRA_SPRINT_FIELD`       | Override the automatically discovered Sprint field ID (e.g. `customfield_10020`)                                                                     |
+| `JIRA_STORY_POINTS_FIELD` | Override the automatically discovered Story Points field ID, or comma-separated IDs (e.g. `customfield_10016,customfield_10026`)                     |
+| `JIRA_EPIC_FIELD`         | Override the automatically discovered Epic Link field ID (e.g. `customfield_10014`)                                                                  |
 
-To find your custom field IDs, fetch any issue with all fields:
-`GET https://{domain}.atlassian.net/rest/api/3/issue/{key}` and look for the
-`customfield_XXXXX` entries containing story point values or epic references.
+The worker normally discovers these custom fields from Jira's field metadata,
+so no overrides are needed. To find an ID for an override, request
+`GET https://{domain}.atlassian.net/rest/api/3/field` and find the relevant
+`customfield_XXXXX` entry.
 
 No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
 automatically.
@@ -148,7 +172,7 @@ automatically.
 1. Install the Notion Workers CLI:
 
    ```sh
-   npm install -g @notionhq/ntn
+   npm install --global ntn
    ```
 
 2. Clone and install:
@@ -168,7 +192,7 @@ automatically.
 4. Log in to Notion:
 
    ```sh
-   ntn auth login
+   ntn login
    ```
 
 5. Deploy the worker:
@@ -185,10 +209,12 @@ automatically.
    ntn workers env set JIRA_API_TOKEN=your-api-token
    ```
 
-7. Optionally scope to specific projects and set custom fields:
+7. Optionally scope the issue sync to specific projects and override custom
+   fields:
 
    ```sh
    ntn workers env set JIRA_PROJECTS=PROJ,TEAM
+   ntn workers env set JIRA_SPRINT_FIELD=customfield_10020
    ntn workers env set JIRA_STORY_POINTS_FIELD=customfield_10016
    ntn workers env set JIRA_EPIC_FIELD=customfield_10014
    ```
@@ -216,10 +242,10 @@ in your Notion workspace after the first run.
 
 Each resource has its own file with a schema and transform function:
 
-| Resource | File |
-| --- | --- |
-| Issues | `src/issues.ts` |
-| Sprints | `src/sprints.ts` |
+| Resource | File              |
+| -------- | ----------------- |
+| Issues   | `src/issues.ts`   |
+| Sprints  | `src/sprints.ts`  |
 | Projects | `src/projects.ts` |
 
 To add a new Jira field:

--- a/examples/workers/syncs/jira/README.md
+++ b/examples/workers/syncs/jira/README.md
@@ -1,0 +1,254 @@
+# Worker sync: Jira Cloud
+
+Syncs Jira Cloud issues, sprints, and projects into Notion databases that
+stay up to date automatically. Once deployed, the worker checks Jira every
+few minutes and creates or updates a Notion page for each record.
+
+You don't need to create the Notion databases yourself. The worker declares the
+schemas and Notion creates and manages each database for you (these are called
+"managed databases").
+
+## What you get
+
+| Database | Jira resource | Schedule |
+| --- | --- | --- |
+| **Jira Issues** | Issues (via JQL search) | Every 2 min |
+| **Jira Sprints** | Sprints (across Scrum boards) | Every 5 min |
+| **Jira Projects** | Projects | Every 5 min |
+
+### Jira Issues
+
+| Notion property | Jira field | Type |
+| --- | --- | --- |
+| Summary | `summary` | title |
+| Status | `status.name` | select |
+| Issue Type | `issuetype.name` | select |
+| Assignee | `assignee.displayName` | richText |
+| Sprint | `sprint.name` | richText |
+| Updated | `updated` | date |
+| Status Category | `status.statusCategory.name` | select |
+| Priority | `priority.name` | select |
+| Reporter | `reporter.displayName` | richText |
+| Project | `project.name` | richText |
+| Issue Link | link to Jira issue | url |
+| Labels | `labels` | multiSelect |
+| Components | `components[].name` | multiSelect |
+| Fix Versions | `fixVersions[].name` | multiSelect |
+| Resolution | `resolution.name` | select |
+| Due Date | `duedate` | date |
+| Epic | `parent.fields.summary` or custom field | richText |
+| Story Points | custom field (configurable) | number |
+| Created | `created` | date |
+| Issue Key | `key` (e.g. PROJ-123) | richText |
+
+**Status Category** groups custom statuses (like "Waiting for Customer" or
+"Code Review") into three categories: To Do, In Progress, Done. More useful
+for high-level views than individual status names.
+
+**Epic** is resolved from the issue's parent summary (next-gen/team-managed
+projects) or from a custom field (classic projects — see optional env vars).
+
+**Story Points** requires setting the `JIRA_STORY_POINTS_FIELD` env var.
+
+### Jira Sprints
+
+| Notion property | Jira field | Type |
+| --- | --- | --- |
+| Name | `name` | title |
+| State | `state` | select |
+| Board | board name (resolved) | richText |
+| Start Date | `startDate` | date |
+| End Date | `endDate` | date |
+| Goal | `goal` | richText |
+| Complete Date | `completeDate` | date |
+| Sprint ID | `id` | richText |
+
+Board IDs are resolved to names by fetching all Scrum boards once per sync
+cycle. Only Scrum boards are fetched (Kanban boards don't have sprints).
+Page body contains the sprint goal.
+
+### Jira Projects
+
+| Notion property | Jira field | Type |
+| --- | --- | --- |
+| Name | `name` | title |
+| Project Key | `key` (e.g. PROJ) | richText |
+| Lead | `lead.displayName` | richText |
+| Category | `projectCategory.name` | select |
+| Project Type | `projectTypeKey` | select |
+| Project Link | link to Jira project | url |
+
+Page body contains the project description.
+
+## Project structure
+
+```text
+src/
+├── index.ts      — registers all databases and syncs
+├── jira.ts       — API client (auth, pagination, types, lookups)
+├── issues.ts     — issue schema + transform
+├── sprints.ts    — sprint schema + transform
+├── projects.ts   — project schema + transform
+└── helpers.ts    — shared utilities (dateOnly)
+```
+
+## How it works
+
+1. **Issues** are fetched every 2 minutes via JQL search, scoped to
+   specific projects if `JIRA_PROJECTS` is set. Uses `startAt`/`total`
+   pagination (100 issues per page).
+2. **Sprints** are fetched every 5 minutes by listing all Scrum boards,
+   then fetching sprints for each. Board names are resolved once per cycle.
+   Deleted boards are skipped gracefully.
+3. **Projects** are fetched every 5 minutes via the project search endpoint.
+4. All syncs share a single rate-limit pacer (9 requests per second) to stay
+   within Jira Cloud's 10/second limit on Standard plans.
+5. Because all syncs use `mode: "replace"`, records deleted from Jira are
+   automatically removed from the Notion database on the next full sync.
+
+## Prerequisites
+
+- Node >= 22, npm >= 10.9.2
+- A Jira Cloud instance
+- The `ntn` CLI installed and authenticated (`ntn auth login`)
+
+### Getting a Jira API token
+
+1. Go to [https://id.atlassian.com/manage/api-tokens](https://id.atlassian.com/manage/api-tokens)
+2. Click **Create API token**, give it a name, and copy the token
+3. Note the email address associated with your Atlassian account
+
+## Environment variables
+
+### Required
+
+| Variable | Description |
+| --- | --- |
+| `JIRA_DOMAIN` | Your Jira Cloud domain (e.g. `acme` for acme.atlassian.net) |
+| `JIRA_EMAIL` | Email of the Atlassian account for API access |
+| `JIRA_API_TOKEN` | API token from id.atlassian.com |
+
+### Optional
+
+| Variable | Description |
+| --- | --- |
+| `JIRA_PROJECTS` | Comma-separated project keys to sync (e.g. `PROJ,TEAM`). If not set, all projects are synced. |
+| `JIRA_STORY_POINTS_FIELD` | Custom field ID for story points (e.g. `customfield_10016`) |
+| `JIRA_EPIC_FIELD` | Custom field ID for epic link (e.g. `customfield_10014`) |
+
+To find your custom field IDs, fetch any issue with all fields:
+`GET https://{domain}.atlassian.net/rest/api/3/issue/{key}` and look for the
+`customfield_XXXXX` entries containing story point values or epic references.
+
+No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
+automatically.
+
+## Setup and deploy
+
+1. Install the Notion Workers CLI:
+
+   ```sh
+   npm install -g @notionhq/ntn
+   ```
+
+2. Clone and install:
+
+   ```sh
+   cd examples/workers/syncs/jira
+   npm install
+   ```
+
+3. Typecheck and test:
+
+   ```sh
+   npm run check
+   npm test
+   ```
+
+4. Log in to Notion:
+
+   ```sh
+   ntn auth login
+   ```
+
+5. Deploy the worker:
+
+   ```sh
+   ntn workers deploy
+   ```
+
+6. Set environment variables on the deployed worker:
+
+   ```sh
+   ntn workers env set JIRA_DOMAIN=acme
+   ntn workers env set JIRA_EMAIL=you@example.com
+   ntn workers env set JIRA_API_TOKEN=your-api-token
+   ```
+
+7. Optionally scope to specific projects and set custom fields:
+
+   ```sh
+   ntn workers env set JIRA_PROJECTS=PROJ,TEAM
+   ntn workers env set JIRA_STORY_POINTS_FIELD=customfield_10016
+   ntn workers env set JIRA_EPIC_FIELD=customfield_10014
+   ```
+
+8. Preview a sync without writing to Notion:
+
+   ```sh
+   ntn workers sync trigger issuesSync --preview
+   ntn workers sync trigger sprintsSync --preview
+   ntn workers sync trigger projectsSync --preview
+   ```
+
+9. Run a real sync:
+
+   ```sh
+   ntn workers sync trigger issuesSync
+   ntn workers sync trigger sprintsSync
+   ntn workers sync trigger projectsSync
+   ```
+
+Once deployed, all three syncs run automatically. Three databases will appear
+in your Notion workspace after the first run.
+
+## Adapting the schema
+
+Each resource has its own file with a schema and transform function:
+
+| Resource | File |
+| --- | --- |
+| Issues | `src/issues.ts` |
+| Sprints | `src/sprints.ts` |
+| Projects | `src/projects.ts` |
+
+To add a new Jira field:
+
+1. Add the field name to the `ISSUE_FIELDS` array in `src/jira.ts` (Jira only
+   returns fields you request)
+2. Add the field to the `JiraIssue` type in `src/jira.ts`
+3. Add a property to the schema with the appropriate `Schema.*` type
+4. Add a `Builder.*` call in the transform function
+
+## Local testing
+
+Run offline tests (no Jira connection needed):
+
+```sh
+npm test
+```
+
+Test a sync locally against a real Jira instance:
+
+```sh
+ntn workers exec issuesSync --local
+```
+
+## Learn more
+
+- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [Jira Cloud REST API — Issue Search](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/)
+- [Jira Software REST API — Sprints](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/)
+- [Jira Cloud REST API — Projects](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/)
+- [Jira API Tokens](https://id.atlassian.com/manage/api-tokens)
+- [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/jira/README.md
+++ b/examples/workers/syncs/jira/README.md
@@ -1,8 +1,9 @@
 # Worker sync: Jira Cloud
 
-Syncs Jira Cloud issues, sprints, and projects into Notion databases that
-stay up to date automatically. Once deployed, the worker checks Jira every
-few minutes and creates or updates a Notion page for each record.
+Syncs Jira Cloud issues, current sprints, sprint performance, and projects
+into Notion databases that stay up to date automatically. Each database uses
+a schedule suited to its job, from a five-minute operational issue mirror to
+daily sprint analytics and project reference data.
 
 You don't need to create the Notion databases yourself. The worker declares the
 schemas and Notion creates and manages each database for you (these are called
@@ -10,11 +11,16 @@ schemas and Notion creates and manages each database for you (these are called
 
 ## What you get
 
-| Database          | Jira resource                 | Schedule    |
-| ----------------- | ----------------------------- | ----------- |
-| **Jira Issues**   | Issues (via JQL search)       | Every 2 min |
-| **Jira Sprints**  | Sprints (across Scrum boards) | Every 5 min |
-| **Jira Projects** | Projects                      | Every 5 min |
+| Database                    | Purpose                                 | Schedule     |
+| --------------------------- | --------------------------------------- | ------------ |
+| **Jira Issues**             | Operational issue mirror                | Every 5 min  |
+| **Jira Current Sprints**    | Active and future sprint mirror         | Every 15 min |
+| **Jira Sprint Performance** | Cross-board sprint analytics and roster | Daily        |
+| **Jira Projects**           | Project reference data                  | Daily        |
+
+The four databases are intentionally independent. This example stores stable
+Jira IDs but does not create Notion relations, avoiding sync-order and scope
+dependencies that can make a ready-to-deploy mirror brittle.
 
 ### Jira Issues
 
@@ -66,7 +72,7 @@ The immutable **Jira Issue ID** is the database primary key. **Issue Key**
 remains a display property and is used in links, but it can change when an issue
 moves to another project.
 
-### Jira Sprints
+### Jira Current Sprints
 
 | Notion property | Jira field            | Type     |
 | --------------- | --------------------- | -------- |
@@ -79,9 +85,53 @@ moves to another project.
 | Complete Date   | `completeDate`        | date     |
 | Sprint ID       | `id`                  | richText |
 
+This lightweight mirror includes only active and future sprints, making it
+useful for current planning without mixing in years of closed sprint history.
 Board IDs are resolved to names by fetching all Scrum boards once per sync
-cycle. Only Scrum boards are fetched (Kanban boards don't have sprints).
-Page body contains the sprint goal.
+cycle. Only Scrum boards are fetched (Kanban boards don't have sprints). Page
+body contains the sprint goal.
+
+### Jira Sprint Performance
+
+This daily analytical sync creates one scorecard per active or closed sprint
+with configured start and end dates across the visible Scrum boards. It uses
+each board's configured Story Points field and rightmost Done column, rather
+than assuming one global field or completion status. Boards configured with a
+different estimate field use issue counts so the example never labels time or
+another unit as story points.
+
+| PM question                              | Sprint scorecard output                                                                            |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Are we likely to complete the scope?     | Delivery Forecast, Forecast Completion %, Days Remaining                                           |
+| What was committed versus completed?     | Committed and Completed Issues/Points, Predictability %, Completion %                              |
+| How much scope changed after the start?  | Added and Removed Issues/Points, Estimate Change, Net Scope Change, Scope Change %                 |
+| What rolled over?                        | Rolled Over Issues/Points and destination sprint names in the page body                            |
+| What is the team's velocity?             | Velocity plus 3-Sprint and 5-Sprint rolling velocity for the same board                            |
+| Which issues participated in the sprint? | A linked issue roster grouped by committed, added, completed, incomplete, removed, and rolled over |
+
+The scorecard also records current scope, estimation basis, unestimated issue
+count, metrics timestamp, and a **Data Quality** rating. Subtasks are excluded
+from the numerical analytics to avoid double counting parent estimates, but
+remain visible in a separate roster section.
+
+For boards configured to estimate by issue count, velocity and percentages use
+issue counts and the point-specific properties are left blank rather than
+presenting counts as story points.
+
+**Delivery Forecast** predicts delivery of the current sprint scope; it does
+not claim to interpret whether Jira's free-text sprint goal will be achieved.
+For closed sprints, the forecast becomes a delivered, partially delivered, or
+missed outcome. Active forecasts require three comparable completed sprints
+from the same board; until then they report **Insufficient Data** instead of
+extrapolating from a small or early sample.
+
+Historical analytics are best effort. Jira's sprint issue endpoint returns
+issues that remain associated with a sprint, so an issue removed before this
+worker first observes the sprint may be absent even when its changelog still
+exists. Missing membership, estimate, completion, and rollover evidence is
+surfaced in the **Data Quality** property and in a data-quality section on the
+sprint page. Treat older Limited or Partial scorecards as directional rather
+than exact Jira sprint reports.
 
 ### Jira Projects
 
@@ -104,28 +154,33 @@ it.
 
 ```text
 src/
-├── index.ts      — registers all databases and syncs
-├── jira.ts       — API client (auth, pagination, types, lookups)
-├── issues.ts     — issue schema + transform
-├── sprints.ts    — sprint schema + transform
-├── projects.ts   — project schema + transform
-└── helpers.ts    — shared utilities (dateOnly)
+├── index.ts              — registers all databases and syncs
+├── jira.ts               — API client (auth, pagination, types, lookups)
+├── issues.ts             — issue schema + transform
+├── sprints.ts            — current sprint schema + transform
+├── all-sprints.ts        — fetches and normalizes sprint history
+├── sprint-analytics.ts   — scorecard calculations, schema, and issue roster
+├── projects.ts           — project schema + transform
+└── helpers.ts            — shared utilities (dateOnly)
 ```
 
 ## How it works
 
-1. **Issues** are fetched every 2 minutes via JQL search, scoped to
+1. **Issues** are fetched every 5 minutes via JQL search, scoped to
    specific projects if `JIRA_PROJECTS` is set. Uses `nextPageToken`
    pagination (100 issues per page). Jira truncation warnings abort the sync so
    a partial result can't be committed as a complete replacement snapshot.
-2. **Sprints** are fetched every 5 minutes by listing all Scrum boards,
-   then fetching sprints for each. Board names are resolved once per cycle.
-   Deleted boards are skipped gracefully.
-3. **Projects** are fetched every 5 minutes via the project search endpoint.
-4. All syncs share a single rate-limit pacer (9 requests per second). If Jira
+2. **Current Sprints** are fetched every 15 minutes by listing all Scrum boards,
+   then fetching only active and future sprints for each. Board names are
+   resolved once per cycle and deleted boards are skipped gracefully.
+3. **Sprint Performance** runs daily across all sprints. It combines board
+   configuration, enhanced sprint issue pages, and bulk issue changelogs to
+   reconstruct commitment, scope changes, completion, rollover, and velocity.
+4. **Projects** are fetched daily via the project search endpoint.
+5. All syncs share a single rate-limit pacer (9 requests per second). If Jira
    responds with HTTP 429, the worker passes Jira's `Retry-After` interval to
    the runtime so the request can be retried after the requested delay.
-5. Because all syncs use `mode: "replace"`, records deleted from Jira are
+6. Because all syncs use `mode: "replace"`, records deleted from Jira are
    automatically removed from the Notion database on the next full sync.
 
 ## Prerequisites
@@ -152,12 +207,12 @@ src/
 
 ### Optional
 
-| Variable                  | Description                                                                                                                                          |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `JIRA_PROJECTS`           | Comma-separated project keys whose issues should be synced (e.g. `PROJ,TEAM`). Sprints and the Projects database still include all visible projects. |
-| `JIRA_SPRINT_FIELD`       | Override the automatically discovered Sprint field ID (e.g. `customfield_10020`)                                                                     |
-| `JIRA_STORY_POINTS_FIELD` | Override the automatically discovered Story Points field ID, or comma-separated IDs (e.g. `customfield_10016,customfield_10026`)                     |
-| `JIRA_EPIC_FIELD`         | Override the automatically discovered Epic Link field ID (e.g. `customfield_10014`)                                                                  |
+| Variable                  | Description                                                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JIRA_PROJECTS`           | Comma-separated project keys whose issues should be synced (e.g. `PROJ,TEAM`). Both sprint databases and the Projects database still include all visible data. |
+| `JIRA_SPRINT_FIELD`       | Override the automatically discovered Sprint field ID (e.g. `customfield_10020`)                                                                               |
+| `JIRA_STORY_POINTS_FIELD` | Override the automatically discovered Story Points field ID, or comma-separated IDs (e.g. `customfield_10016,customfield_10026`)                               |
+| `JIRA_EPIC_FIELD`         | Override the automatically discovered Epic Link field ID (e.g. `customfield_10014`)                                                                            |
 
 The worker normally discovers these custom fields from Jira's field metadata,
 so no overrides are needed. To find an ID for an override, request
@@ -223,7 +278,8 @@ automatically.
 
    ```sh
    ntn workers sync trigger issuesSync --preview
-   ntn workers sync trigger sprintsSync --preview
+   ntn workers sync trigger currentSprintsSync --preview
+   ntn workers sync trigger allSprintsSync --preview
    ntn workers sync trigger projectsSync --preview
    ```
 
@@ -231,22 +287,24 @@ automatically.
 
    ```sh
    ntn workers sync trigger issuesSync
-   ntn workers sync trigger sprintsSync
+   ntn workers sync trigger currentSprintsSync
+   ntn workers sync trigger allSprintsSync
    ntn workers sync trigger projectsSync
    ```
 
-Once deployed, all three syncs run automatically. Three databases will appear
-in your Notion workspace after the first run.
+Once deployed, all four syncs run automatically. Four databases will appear in
+your Notion workspace after their first runs.
 
 ## Adapting the schema
 
 Each resource has its own file with a schema and transform function:
 
-| Resource | File              |
-| -------- | ----------------- |
-| Issues   | `src/issues.ts`   |
-| Sprints  | `src/sprints.ts`  |
-| Projects | `src/projects.ts` |
+| Resource           | File                      |
+| ------------------ | ------------------------- |
+| Issues             | `src/issues.ts`           |
+| Current Sprints    | `src/sprints.ts`          |
+| Sprint Performance | `src/sprint-analytics.ts` |
+| Projects           | `src/projects.ts`         |
 
 To add a new Jira field:
 

--- a/examples/workers/syncs/jira/package.json
+++ b/examples/workers/syncs/jira/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "check": "tsc --noEmit",
-    "test": "tsx test.ts"
+    "test": "node --import tsx --test test.ts sprint-analytics.test.ts"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/examples/workers/syncs/jira/package.json
+++ b/examples/workers/syncs/jira/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jira",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/jira/sprint-analytics.test.ts
+++ b/examples/workers/syncs/jira/sprint-analytics.test.ts
@@ -1,0 +1,383 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import type { JiraChangeHistory, JiraIssue, JiraSprint } from "./src/jira.js"
+import { normalizeSprintIssueTimeline } from "./src/all-sprints.js"
+import {
+  calculateSprintAnalytics,
+  renderSprintIssueRoster,
+  sprintAnalyticsToChange,
+} from "./src/sprint-analytics.js"
+import type {
+  NormalizedSprintIssueTimeline,
+  SprintAnalyticsInput,
+} from "./src/sprint-analytics.js"
+
+const START = "2026-06-01T00:00:00.000Z"
+const END = "2026-06-14T00:00:00.000Z"
+
+function timeline(
+  id: string,
+  key: string,
+  summary: string,
+  options: {
+    enteredAt?: string | null
+    exitedAt?: string | null
+    estimate: number | null
+    estimateChanges?: { at: string; value: number | null }[]
+    completed?: boolean
+    completedAt?: string
+    isSubtask?: boolean
+    rollover?: { sprintId: string; sprintName: string }
+  }
+): NormalizedSprintIssueTimeline {
+  return {
+    id,
+    key,
+    summary,
+    url: `https://acme.atlassian.net/browse/${key}`,
+    isSubtask: options.isSubtask,
+    memberships: [
+      {
+        enteredAt: options.enteredAt ?? null,
+        exitedAt: options.exitedAt ?? null,
+      },
+    ],
+    estimates: [
+      { at: null, value: options.estimate },
+      ...(options.estimateChanges ?? []),
+    ],
+    completion: options.completedAt
+      ? [
+          { at: null, completed: false },
+          { at: options.completedAt, completed: true },
+        ]
+      : [{ at: null, completed: options.completed ?? false }],
+    rollover: options.rollover,
+  }
+}
+
+function closedSprintInput(): SprintAnalyticsInput {
+  return {
+    id: "sprint-1",
+    name: "Sprint 1",
+    state: "closed",
+    boardId: "10",
+    boardName: "Payments",
+    goal: "Ship checkout recovery",
+    startAt: START,
+    endAt: END,
+    completeAt: END,
+    evaluatedAt: "2026-06-15T12:00:00.000Z",
+    estimationBasis: "Story Points",
+    priorSprintVelocities: [9, 7, 6, 8],
+    issues: [
+      timeline("1", "PAY-1", "Completed commitment", {
+        estimate: 5,
+        completedAt: "2026-06-10T12:00:00.000Z",
+      }),
+      timeline("2", "PAY-2", "Removed after estimate grew", {
+        estimate: 3,
+        estimateChanges: [{ at: "2026-06-05T12:00:00.000Z", value: 5 }],
+        exitedAt: "2026-06-09T12:00:00.000Z",
+      }),
+      timeline("3", "PAY-3", "Added then rolled over", {
+        enteredAt: "2026-06-04T12:00:00.000Z",
+        estimate: 2,
+        rollover: { sprintId: "sprint-2", sprintName: "Sprint 2" },
+      }),
+      timeline("4", "PAY-4", "Excluded subtask", {
+        estimate: 13,
+        completed: true,
+        isSubtask: true,
+      }),
+    ],
+  }
+}
+
+test("calculates closed-sprint scope, delivery, rollover, and velocity", () => {
+  const metrics = calculateSprintAnalytics(closedSprintInput())
+
+  assert.equal(metrics.committedIssueCount, 2)
+  assert.equal(metrics.committedPoints, 8)
+  assert.equal(metrics.currentIssueCount, 2)
+  assert.equal(metrics.currentPoints, 7)
+  assert.equal(metrics.completedIssueCount, 1)
+  assert.equal(metrics.completedPoints, 5)
+  assert.equal(metrics.addedIssueCount, 1)
+  assert.equal(metrics.addedPoints, 2)
+  assert.equal(metrics.removedIssueCount, 1)
+  assert.equal(metrics.removedPoints, 5)
+  assert.equal(metrics.estimateChange, 2)
+  assert.equal(metrics.reconstructedScopePoints, 7)
+  assert.equal(metrics.netScopeChangePoints, -1)
+  assert.equal(metrics.rolledOverIssueCount, 1)
+  assert.equal(metrics.rolledOverPoints, 2)
+  assert.equal(metrics.completionPercent, 5 / 7)
+  assert.equal(metrics.predictabilityPercent, 5 / 8)
+  assert.equal(metrics.velocity, 5)
+  assert.equal(metrics.rollingVelocity3, 7)
+  assert.equal(metrics.rollingVelocity5, 7)
+  assert.equal(metrics.deliveryForecast, "Missed")
+  assert.equal(metrics.forecastCompletionPercent, 5 / 7)
+  assert.equal(metrics.daysRemaining, 0)
+  assert.equal(metrics.dataQuality, "Complete")
+})
+
+test("uses rolling velocity and remaining time for an active forecast", () => {
+  const input: SprintAnalyticsInput = {
+    id: "sprint-active",
+    name: "Active Sprint",
+    state: "active",
+    startAt: "2026-07-01T00:00:00.000Z",
+    endAt: "2026-07-11T00:00:00.000Z",
+    evaluatedAt: "2026-07-06T00:00:00.000Z",
+    estimationBasis: "Story Points",
+    priorSprintVelocities: [22, 22, 22],
+    issues: [
+      timeline("10", "PAY-10", "Done", { estimate: 5, completed: true }),
+      timeline("11", "PAY-11", "Still in progress", {
+        estimate: 15,
+      }),
+    ],
+  }
+
+  const metrics = calculateSprintAnalytics(input)
+
+  assert.equal(metrics.velocity, 5)
+  assert.equal(metrics.rollingVelocity3, 22)
+  assert.equal(metrics.daysRemaining, 5)
+  assert.equal(metrics.deliveryForecast, "At Risk")
+  assert.equal(metrics.forecastCompletionPercent, 0.8)
+})
+
+test("does not overstate an active forecast without three prior sprints", () => {
+  const input: SprintAnalyticsInput = {
+    id: "sprint-new-team",
+    name: "New Team Sprint",
+    state: "active",
+    startAt: "2026-07-01T00:00:00.000Z",
+    endAt: "2026-07-11T00:00:00.000Z",
+    evaluatedAt: "2026-07-06T00:00:00.000Z",
+    estimationBasis: "Story Points",
+    priorSprintVelocities: [8, 5],
+    issues: [timeline("12", "PAY-12", "In progress", { estimate: 8 })],
+  }
+
+  const metrics = calculateSprintAnalytics(input)
+
+  assert.equal(metrics.rollingVelocity3, null)
+  assert.equal(metrics.deliveryForecast, "Insufficient Data")
+  assert.equal(metrics.forecastCompletionPercent, null)
+})
+
+test("uses issue counts when a board has no point estimation", () => {
+  const input: SprintAnalyticsInput = {
+    id: "sprint-count",
+    name: "Issue-count Sprint",
+    state: "closed",
+    startAt: START,
+    endAt: END,
+    completeAt: END,
+    evaluatedAt: "2026-06-15T12:00:00.000Z",
+    estimationBasis: "Issue Count",
+    priorSprintVelocities: [4, 6],
+    issues: [
+      timeline("20", "PAY-20", "Completed", {
+        estimate: 1,
+        completed: true,
+      }),
+      timeline("21", "PAY-21", "Incomplete", {
+        estimate: 1,
+      }),
+    ],
+  }
+
+  const metrics = calculateSprintAnalytics(input)
+  const change = sprintAnalyticsToChange(input)
+
+  assert.equal(metrics.estimationBasis, "Issue Count")
+  assert.equal(metrics.velocity, 1)
+  assert.equal(metrics.rollingVelocity3, 11 / 3)
+  assert.equal(metrics.completionPercent, 0.5)
+  assert.equal("Committed Points" in change.properties, false)
+  assert.match(change.pageContentMarkdown, /1 issue/)
+})
+
+test("renders an auditable, grouped issue roster", () => {
+  const roster = renderSprintIssueRoster(closedSprintInput())
+
+  assert.match(roster, /## Sprint Goal\n\nShip checkout recovery/)
+  assert.match(roster, /## Committed and completed[\s\S]*PAY-1/)
+  assert.match(roster, /## Removed from sprint[\s\S]*PAY-2/)
+  assert.match(roster, /## Rolled over[\s\S]*PAY-3[\s\S]*Sprint 2/)
+  assert.match(roster, /## Subtasks[\s\S]*PAY-4/)
+})
+
+test("transforms sprint analytics into a stable Notion upsert", () => {
+  const change = sprintAnalyticsToChange(closedSprintInput())
+  const properties = JSON.stringify(change.properties)
+
+  assert.equal(change.type, "upsert")
+  assert.equal(change.key, "sprint-1")
+  assert.equal(change.upstreamUpdatedAt, "2026-06-15T12:00:00.000Z")
+  assert.match(change.pageContentMarkdown, /PAY-1/)
+  assert.match(properties, /Sprint 1/)
+  assert.match(properties, /Payments/)
+  assert.match(properties, /Missed/)
+  assert.match(properties, /sprint-1/)
+  assert.ok("Committed Points" in change.properties)
+  assert.ok("Completion %" in change.properties)
+  assert.ok("3-Sprint Velocity" in change.properties)
+})
+
+test("normalizes Jira changelogs into an API-independent issue timeline", () => {
+  const sprint: JiraSprint = {
+    id: 42,
+    name: "Sprint 42",
+    state: "closed",
+    startDate: START,
+    endDate: END,
+    completeDate: END,
+    goal: "Recover failed payments",
+    originBoardId: 10,
+  }
+  const issue: JiraIssue = {
+    id: "10042",
+    key: "PAY-42",
+    self: "https://acme.atlassian.net/rest/api/3/issue/10042",
+    fields: {
+      summary: "Retry failed card",
+      status: { id: "3", name: "Done", statusCategory: { name: "Done" } },
+      issuetype: { name: "Story", subtask: false, hierarchyLevel: 0 },
+      priority: null,
+      assignee: null,
+      reporter: null,
+      project: { key: "PAY", name: "Payments" },
+      labels: [],
+      components: [],
+      fixVersions: [],
+      resolution: null,
+      description: null,
+      duedate: null,
+      created: "2026-05-20T00:00:00.000Z",
+      updated: "2026-06-15T00:00:00.000Z",
+      customfield_10020: [{ id: 42 }, { id: 43 }],
+      customfield_10016: 5,
+    },
+  }
+  const histories: JiraChangeHistory[] = [
+    {
+      id: "4",
+      created: "2026-06-14T00:01:00.000Z",
+      items: [
+        {
+          field: "Sprint",
+          fieldId: "customfield_10020",
+          from: "id=40,id=42",
+          to: "id=40,id=42,id=43",
+          toString: undefined,
+        },
+      ],
+    },
+    {
+      id: "2",
+      created: "2026-06-05T12:00:00.000Z",
+      items: [
+        {
+          field: "Story Points",
+          fieldId: "customfield_10016",
+          from: null,
+          fromString: "3",
+          to: null,
+          toString: "5",
+        },
+      ],
+    },
+    {
+      id: "1",
+      created: "2026-05-31T12:00:00.000Z",
+      items: [
+        {
+          field: "Sprint",
+          fieldId: "customfield_10020",
+          from: "id=40",
+          to: "id=40,id=42",
+          toString: undefined,
+        },
+      ],
+    },
+    {
+      id: "3",
+      created: "2026-06-10T12:00:00.000Z",
+      items: [
+        {
+          field: "status",
+          fieldId: "status",
+          from: "2",
+          to: "3",
+          toString: undefined,
+        },
+      ],
+    },
+  ]
+
+  const normalized = normalizeSprintIssueTimeline(issue, histories, {
+    sprint,
+    sprintFieldId: "customfield_10020",
+    estimateFieldId: "customfield_10016",
+    estimationType: "field",
+    doneStatusIds: ["3"],
+    baseUrl: "https://acme.atlassian.net",
+    sprintNamesById: { "43": "Sprint 43" },
+  })
+
+  assert.deepEqual(normalized.memberships, [
+    { enteredAt: "2026-05-31T12:00:00.000Z", exitedAt: null },
+  ])
+  assert.deepEqual(normalized.estimates, [
+    { at: null, value: 3 },
+    { at: "2026-06-05T12:00:00.000Z", value: 5 },
+  ])
+  assert.deepEqual(normalized.completion, [
+    { at: null, completed: false },
+    { at: "2026-06-10T12:00:00.000Z", completed: true },
+  ])
+  assert.deepEqual(normalized.rollover, {
+    sprintId: "43",
+    sprintName: "Sprint 43",
+  })
+  assert.equal(normalized.url, "https://acme.atlassian.net/browse/PAY-42")
+  assert.equal(normalized.isSubtask, false)
+
+  const createdInSprint = normalizeSprintIssueTimeline(
+    {
+      ...issue,
+      id: "10043",
+      key: "PAY-43",
+      fields: {
+        ...issue.fields,
+        created: "2026-06-06T12:00:00.000Z",
+        status: {
+          id: "99",
+          name: "Cancelled",
+          statusCategory: { name: "Done" },
+        },
+      },
+    },
+    [],
+    {
+      sprint,
+      sprintFieldId: "customfield_10020",
+      estimateFieldId: "customfield_10016",
+      estimationType: "field",
+      doneStatusIds: ["3"],
+      baseUrl: "https://acme.atlassian.net",
+      sprintNamesById: { "43": "Sprint 43" },
+    }
+  )
+
+  assert.deepEqual(createdInSprint.memberships, [
+    { enteredAt: "2026-06-06T12:00:00.000Z", exitedAt: null },
+  ])
+  assert.deepEqual(createdInSprint.completion, [{ at: null, completed: false }])
+})

--- a/examples/workers/syncs/jira/src/all-sprints.ts
+++ b/examples/workers/syncs/jira/src/all-sprints.ts
@@ -1,0 +1,466 @@
+import {
+  browseUrl,
+  fetchBulkChangelogsPage,
+  fetchSprintIssuesPage,
+} from "./jira.js"
+import type {
+  JiraBoardConfiguration,
+  JiraChangeHistory,
+  JiraIssue,
+  JiraSprint,
+} from "./jira.js"
+import type {
+  NormalizedCompletion,
+  NormalizedEstimate,
+  NormalizedSprintIssueTimeline,
+  NormalizedSprintMembership,
+  SprintAnalyticsInput,
+} from "./sprint-analytics.js"
+
+type WaitFn = () => Promise<void>
+
+export type SprintAnalyticsFetchOptions = {
+  sprint: JiraSprint
+  boardName: string
+  boardConfig: JiraBoardConfiguration
+  sprintFieldId?: string
+  fallbackEstimateFieldId?: string
+  storyPointFieldIds?: string[]
+  priorSprintVelocities: number[]
+  evaluatedAt: string
+  baseUrl: string
+  sprintNamesById: Record<string, string>
+  waitFn?: WaitFn
+}
+
+type FieldChange = {
+  at: string
+  from?: string | null
+  fromString?: string | null
+  to?: string | null
+  toString?: string | null
+}
+
+function historyTimestamp(value: string | number): string {
+  if (typeof value === "number") {
+    const milliseconds = value < 1_000_000_000_000 ? value * 1_000 : value
+    return new Date(milliseconds).toISOString()
+  }
+
+  const milliseconds = Date.parse(value)
+  if (Number.isNaN(milliseconds)) {
+    throw new Error(`Invalid Jira changelog timestamp: ${value}`)
+  }
+  return new Date(milliseconds).toISOString()
+}
+
+function fieldChanges(
+  histories: JiraChangeHistory[],
+  fieldId: string,
+  fieldName?: string
+): FieldChange[] {
+  const normalizedName = fieldName?.toLowerCase()
+  const changes: FieldChange[] = []
+
+  for (const history of histories) {
+    const at = historyTimestamp(history.created)
+    for (const item of history.items) {
+      if (
+        item.fieldId !== fieldId &&
+        (!normalizedName || item.field.toLowerCase() !== normalizedName)
+      ) {
+        continue
+      }
+      changes.push({
+        at,
+        from: item.from,
+        fromString: item.fromString,
+        to: item.to,
+        toString: item.toString,
+      })
+    }
+  }
+
+  return changes.sort((left, right) => left.at.localeCompare(right.at))
+}
+
+function sprintIds(value: string | null | undefined): number[] {
+  if (!value) return []
+
+  const explicitIds = [...value.matchAll(/\bid=(\d+)/g)].map((match) =>
+    Number(match[1])
+  )
+  if (explicitIds.length > 0) return [...new Set(explicitIds)]
+
+  return [...new Set((value.match(/\d+/g) ?? []).map((match) => Number(match)))]
+}
+
+function currentSprintIds(issue: JiraIssue, sprintFieldId?: string): number[] {
+  if (!sprintFieldId) return []
+  const value = issue.fields[sprintFieldId]
+  if (!Array.isArray(value)) return []
+
+  const ids: number[] = []
+  for (const sprint of value) {
+    if (typeof sprint === "number") {
+      ids.push(sprint)
+    } else if (typeof sprint === "string") {
+      ids.push(...sprintIds(sprint))
+    } else if (sprint && typeof sprint === "object") {
+      const id = (sprint as Record<string, unknown>).id
+      if (typeof id === "number") ids.push(id)
+      if (typeof id === "string" && /^\d+$/.test(id)) ids.push(Number(id))
+    }
+  }
+  return [...new Set(ids)]
+}
+
+function normalizeMemberships(
+  sprintId: number,
+  issue: JiraIssue,
+  changes: FieldChange[],
+  sprintFieldId?: string
+): NormalizedSprintMembership[] {
+  const earliestPossibleEntry = issue.fields.created || null
+
+  if (changes.length === 0) {
+    // The sprint endpoint itself proves membership even if Jira does not
+    // expose the custom field or its history for this issue.
+    return [{ enteredAt: earliestPossibleEntry, exitedAt: null }]
+  }
+
+  const memberships: NormalizedSprintMembership[] = []
+  let active = sprintIds(changes[0].from).includes(sprintId)
+  let enteredAt: string | null = active ? earliestPossibleEntry : null
+
+  for (const change of changes) {
+    const before = sprintIds(change.from).includes(sprintId)
+    const after = sprintIds(change.to).includes(sprintId)
+
+    if (!before && after && !active) {
+      active = true
+      enteredAt = change.at
+    } else if (before && !after && active) {
+      memberships.push({ enteredAt, exitedAt: change.at })
+      active = false
+      enteredAt = null
+    } else {
+      active = after
+    }
+  }
+
+  if (active) memberships.push({ enteredAt, exitedAt: null })
+
+  if (
+    memberships.length === 0 &&
+    currentSprintIds(issue, sprintFieldId).includes(sprintId)
+  ) {
+    memberships.push({ enteredAt: earliestPossibleEntry, exitedAt: null })
+  }
+
+  return memberships
+}
+
+function numberValue(value: string | null | undefined): number | null {
+  if (value == null || value.trim() === "") return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeEstimates(
+  issue: JiraIssue,
+  estimateFieldId: string | undefined,
+  changes: FieldChange[],
+  issueCount: boolean
+): NormalizedEstimate[] {
+  if (issueCount) return [{ at: null, value: 1 }]
+
+  const currentValue = estimateFieldId
+    ? issue.fields[estimateFieldId]
+    : undefined
+  const currentEstimate = typeof currentValue === "number" ? currentValue : null
+
+  if (changes.length === 0) {
+    return [{ at: null, value: currentEstimate }]
+  }
+
+  return [
+    {
+      at: null,
+      value: numberValue(changes[0].from ?? changes[0].fromString),
+    },
+    ...changes.map((change) => ({
+      at: change.at,
+      value: numberValue(change.to ?? change.toString),
+    })),
+  ]
+}
+
+function normalizeCompletion(
+  issue: JiraIssue,
+  changes: FieldChange[],
+  doneStatusIds: Set<string>
+): NormalizedCompletion[] {
+  const currentDone = Boolean(
+    issue.fields.status?.id && doneStatusIds.has(issue.fields.status.id)
+  )
+  if (changes.length === 0) {
+    return [{ at: null, completed: currentDone }]
+  }
+
+  return [
+    {
+      at: null,
+      completed: Boolean(changes[0].from && doneStatusIds.has(changes[0].from)),
+    },
+    ...changes.map((change) => ({
+      at: change.at,
+      completed: Boolean(change.to && doneStatusIds.has(change.to)),
+    })),
+  ]
+}
+
+function findRollover(
+  sprintId: number,
+  completeAt: string | undefined,
+  changes: FieldChange[],
+  sprintNamesById: Record<string, string>
+): { sprintId: string; sprintName: string } | null {
+  if (!completeAt) return null
+  const completeTime = Date.parse(completeAt)
+  const lowerBound = completeTime - 5 * 60 * 1_000
+  const upperBound = completeTime + 5 * 60 * 1_000
+
+  for (const change of changes) {
+    const changeTime = Date.parse(change.at)
+    if (changeTime < lowerBound || changeTime > upperBound) continue
+    const before = new Set(sprintIds(change.from))
+    if (!before.has(sprintId)) continue
+    const added = sprintIds(change.to).filter(
+      (candidate) =>
+        candidate !== sprintId &&
+        !before.has(candidate) &&
+        Object.prototype.hasOwnProperty.call(sprintNamesById, String(candidate))
+    )
+    if (added.length === 0) continue
+
+    const nextSprintId = String(added[0])
+    return {
+      sprintId: nextSprintId,
+      sprintName: sprintNamesById[nextSprintId] ?? `Sprint ${nextSprintId}`,
+    }
+  }
+  return null
+}
+
+export function normalizeSprintIssueTimeline(
+  issue: JiraIssue,
+  histories: JiraChangeHistory[],
+  options: {
+    sprint: JiraSprint
+    sprintFieldId?: string
+    estimateFieldId?: string
+    estimationType?: string
+    doneStatusIds: string[]
+    baseUrl: string
+    sprintNamesById: Record<string, string>
+  }
+): NormalizedSprintIssueTimeline {
+  const sprintChanges = options.sprintFieldId
+    ? fieldChanges(histories, options.sprintFieldId, "sprint")
+    : []
+  const estimateChanges = options.estimateFieldId
+    ? fieldChanges(histories, options.estimateFieldId)
+    : []
+  const statusChanges = fieldChanges(histories, "status", "status")
+
+  return {
+    id: issue.id,
+    key: issue.key,
+    summary: issue.fields.summary,
+    url: browseUrl(options.baseUrl, issue.key),
+    isSubtask: Boolean(
+      issue.fields.issuetype?.subtask ||
+        issue.fields.issuetype?.hierarchyLevel === -1
+    ),
+    memberships: normalizeMemberships(
+      options.sprint.id,
+      issue,
+      sprintChanges,
+      options.sprintFieldId
+    ),
+    estimates: normalizeEstimates(
+      issue,
+      options.estimateFieldId,
+      estimateChanges,
+      options.estimationType === "issueCount"
+    ),
+    completion: normalizeCompletion(
+      issue,
+      statusChanges,
+      new Set(options.doneStatusIds)
+    ),
+    rollover: findRollover(
+      options.sprint.id,
+      options.sprint.state === "closed"
+        ? options.sprint.completeDate ?? undefined
+        : undefined,
+      sprintChanges,
+      options.sprintNamesById
+    ),
+  }
+}
+
+async function fetchAllSprintIssues(
+  sprintId: number,
+  fields: string[],
+  waitFn?: WaitFn
+): Promise<JiraIssue[]> {
+  const issues: JiraIssue[] = []
+  let nextPageToken: string | undefined
+
+  do {
+    if (waitFn) await waitFn()
+    const page = await fetchSprintIssuesPage(sprintId, {
+      fields,
+      nextPageToken,
+    })
+    issues.push(...page.issues)
+    nextPageToken = page.hasMore ? page.nextPageToken : undefined
+  } while (nextPageToken)
+
+  return issues
+}
+
+async function fetchAllChangelogs(
+  issueIds: string[],
+  fieldIds: string[],
+  waitFn?: WaitFn
+): Promise<Map<string, JiraChangeHistory[]>> {
+  const result = new Map<string, JiraChangeHistory[]>()
+
+  for (let offset = 0; offset < issueIds.length; offset += 1_000) {
+    const chunk = issueIds.slice(offset, offset + 1_000)
+    let nextPageToken: string | undefined
+
+    do {
+      if (waitFn) await waitFn()
+      const page = await fetchBulkChangelogsPage(chunk, {
+        fieldIds,
+        nextPageToken,
+      })
+      for (const issue of page.issueChangeLogs) {
+        const histories = result.get(issue.issueId) ?? []
+        histories.push(...issue.changeHistories)
+        result.set(issue.issueId, histories)
+      }
+      nextPageToken = page.hasMore ? page.nextPageToken : undefined
+    } while (nextPageToken)
+  }
+
+  return result
+}
+
+export async function fetchSprintAnalyticsInput(
+  options: SprintAnalyticsFetchOptions
+): Promise<SprintAnalyticsInput> {
+  const sprintFieldId = options.sprintFieldId
+  const boardUsesIssueCount =
+    options.boardConfig.estimationType === "issueCount" ||
+    options.boardConfig.estimationType === "none"
+  const configuredEstimateIsStoryPoints = Boolean(
+    options.boardConfig.estimationType === "field" &&
+      (options.boardConfig.estimationFieldName
+        ?.toLowerCase()
+        .includes("story point") ||
+        (options.boardConfig.estimationFieldId &&
+          [
+            ...(options.storyPointFieldIds ?? []),
+            options.fallbackEstimateFieldId,
+          ]
+            .filter(Boolean)
+            .includes(options.boardConfig.estimationFieldId)))
+  )
+  const useStoryPoints =
+    !boardUsesIssueCount &&
+    (configuredEstimateIsStoryPoints ||
+      (!options.boardConfig.estimationType &&
+        Boolean(options.fallbackEstimateFieldId)))
+  const estimateFieldId = useStoryPoints
+    ? options.boardConfig.estimationFieldId ?? options.fallbackEstimateFieldId
+    : undefined
+  const fields = [
+    "summary",
+    "status",
+    "issuetype",
+    "created",
+    sprintFieldId,
+    estimateFieldId,
+  ].filter((field): field is string => Boolean(field))
+  const issues = await fetchAllSprintIssues(
+    options.sprint.id,
+    fields,
+    options.waitFn
+  )
+  const fieldIds = [sprintFieldId, estimateFieldId, "status"].filter(
+    (field): field is string => Boolean(field)
+  )
+  const histories =
+    issues.length > 0
+      ? await fetchAllChangelogs(
+          issues.map((issue) => issue.id),
+          fieldIds,
+          options.waitFn
+        )
+      : new Map<string, JiraChangeHistory[]>()
+
+  const startAt =
+    options.sprint.startDate ?? options.sprint.endDate ?? options.evaluatedAt
+  const endAt = options.sprint.endDate ?? options.evaluatedAt
+
+  return {
+    id: String(options.sprint.id),
+    name: options.sprint.name,
+    state: options.sprint.state as SprintAnalyticsInput["state"],
+    boardId: String(options.sprint.originBoardId),
+    boardName: options.boardName,
+    goal: options.sprint.goal ?? undefined,
+    startAt,
+    endAt,
+    completeAt: options.sprint.completeDate ?? undefined,
+    evaluatedAt: options.evaluatedAt,
+    issues: issues.map((issue) =>
+      normalizeSprintIssueTimeline(issue, histories.get(issue.id) ?? [], {
+        sprint: options.sprint,
+        sprintFieldId,
+        estimateFieldId,
+        estimationType: useStoryPoints ? "field" : "issueCount",
+        doneStatusIds: options.boardConfig.doneStatusIds,
+        baseUrl: options.baseUrl,
+        sprintNamesById: options.sprintNamesById,
+      })
+    ),
+    estimationBasis: useStoryPoints ? "Story Points" : "Issue Count",
+    priorSprintVelocities: options.priorSprintVelocities,
+    historyQuality: {
+      candidateSetComplete: false,
+      membershipComplete: Boolean(sprintFieldId),
+      estimatesComplete: Boolean(!useStoryPoints || estimateFieldId),
+      completionComplete: options.boardConfig.doneStatusIds.length > 0,
+      rolloverComplete: Boolean(
+        sprintFieldId &&
+          (options.sprint.state !== "closed" || options.sprint.completeDate)
+      ),
+      notes: [
+        "Historical metrics are reconstructed from issues still associated with this sprint; issues removed before synchronization may be missing.",
+        ...(options.boardConfig.estimationType === "field" && !useStoryPoints
+          ? [
+              `The board's ${
+                options.boardConfig.estimationFieldName ?? "configured estimate"
+              } is not a Story Points field, so this scorecard uses issue counts.`,
+            ]
+          : []),
+      ],
+    },
+  }
+}

--- a/examples/workers/syncs/jira/src/helpers.ts
+++ b/examples/workers/syncs/jira/src/helpers.ts
@@ -1,0 +1,5 @@
+export function dateOnly(value: string): string {
+  if (!value) return ""
+  if (value.includes("T")) return value.slice(0, 10)
+  return value.slice(0, 10)
+}

--- a/examples/workers/syncs/jira/src/index.ts
+++ b/examples/workers/syncs/jira/src/index.ts
@@ -1,10 +1,12 @@
-// Entry point — syncs Jira Cloud issues, sprints, and projects into
+// Entry point — syncs Jira Cloud issues, sprints, sprint performance, and
+// projects into
 // managed Notion databases.
 //
-// Three databases are created:
-//   1. Issues    — status, priority, assignee, sprint, project (every 2 min)
-//   2. Sprints   — state, board, dates, goal (every 5 min)
-//   3. Projects  — key, lead, category, type (every 5 min)
+// Four databases are created:
+//   1. Issues              — engineering workflow (every 5 min)
+//   2. Current Sprints     — active and future sprint mirror (every 15 min)
+//   3. Sprint Performance  — daily historical analytics and issue roster
+//   4. Projects            — project reference data (daily)
 //
 // Issues are scoped to specific projects via the JIRA_PROJECTS env var.
 // Board names are fetched once per sprint sync cycle to resolve board IDs.
@@ -20,10 +22,15 @@ import {
   fetchIssueFieldConfig,
   fetchIssuesPage,
   fetchAllBoards,
+  fetchBoardConfiguration,
   fetchSprintsForBoard,
   fetchProjectsPage,
 } from "./jira.js"
-import type { BoardLookup, IssueFieldConfig } from "./jira.js"
+import type {
+  IssueFieldConfig,
+  JiraBoardConfiguration,
+  JiraSprint,
+} from "./jira.js"
 import {
   INITIAL_TITLE as ISSUES_TITLE,
   PRIMARY_KEY as ISSUES_PK,
@@ -42,6 +49,14 @@ import {
   projectSchema,
   projectToChange,
 } from "./projects.js"
+import {
+  ALL_SPRINTS_INITIAL_TITLE,
+  ALL_SPRINTS_PRIMARY_KEY,
+  allSprintsSchema,
+  calculateSprintAnalytics,
+  sprintAnalyticsToChange,
+} from "./sprint-analytics.js"
+import { fetchSprintAnalyticsInput } from "./all-sprints.js"
 
 const worker = new Worker()
 
@@ -72,7 +87,7 @@ const issues = worker.database("issues", {
 worker.sync("issuesSync", {
   database: issues,
   mode: "replace",
-  schedule: "2m",
+  schedule: "5m",
   execute: async (state: IssueSyncState | undefined) => {
     const baseUrl = getBaseUrl()
     let fieldConfig = state?.fieldConfig
@@ -104,69 +119,280 @@ worker.sync("issuesSync", {
 })
 
 // ---------------------------------------------------------------------------
-// Sprints — iterates all Scrum boards, fetches sprints for each
+// Current Sprints — lightweight mirror of active and future sprints
 // ---------------------------------------------------------------------------
 
-type SprintSyncState = {
+type BoardRef = {
+  id: number
+  name: string
+}
+
+type CurrentSprintSyncState = {
+  boards: BoardRef[]
   boardIndex: number
   startAt: number
 }
 
-let sprintBoards: BoardLookup | undefined
-let sprintBoardIds: number[] | undefined
+async function fetchBoardRefs(): Promise<BoardRef[]> {
+  const boards = await fetchAllBoards(() => pacer.wait())
+  return [...boards].map(([id, name]) => ({ id, name }))
+}
 
-const sprints = worker.database("sprints", {
+const currentSprints = worker.database("currentSprints", {
   type: "managed",
   initialTitle: SPRINTS_TITLE,
   primaryKeyProperty: SPRINTS_PK,
   schema: sprintSchema,
 })
 
-worker.sync("sprintsSync", {
-  database: sprints,
+worker.sync("currentSprintsSync", {
+  database: currentSprints,
   mode: "replace",
-  schedule: "5m",
-  execute: async (state: SprintSyncState | undefined) => {
-    await pacer.wait()
-
-    if (!sprintBoards) {
-      sprintBoards = await fetchAllBoards(() => pacer.wait())
-      sprintBoardIds = [...sprintBoards.keys()]
-    }
+  schedule: "15m",
+  execute: async (state: CurrentSprintSyncState | undefined) => {
+    const boards = state?.boards ?? (await fetchBoardRefs())
 
     const boardIndex = state?.boardIndex ?? 0
     const startAt = state?.startAt ?? 0
-    const boardId = sprintBoardIds![boardIndex]
+    const board = boards[boardIndex]
 
-    if (boardId === undefined) {
-      sprintBoards = undefined
-      sprintBoardIds = undefined
+    if (!board) {
       return { changes: [], hasMore: false }
     }
 
     await pacer.wait()
-    const result = await fetchSprintsForBoard(boardId, startAt)
-    const changes = result.sprints.map((s) => sprintToChange(s, sprintBoards!))
+    const result = await fetchSprintsForBoard(board.id, startAt, [
+      "active",
+      "future",
+    ])
+    const boardLookup = new Map(boards.map(({ id, name }) => [id, name]))
+    const changes = result.sprints
+      .filter((sprint) => sprint.originBoardId === board.id)
+      .map((sprint) => sprintToChange(sprint, boardLookup))
 
     if (result.hasMore) {
       return {
         changes,
         hasMore: true,
-        nextState: { boardIndex, startAt: result.nextStartAt },
+        nextState: {
+          boards,
+          boardIndex,
+          startAt: result.nextStartAt,
+        },
       }
     }
 
     const nextBoard = boardIndex + 1
-    if (nextBoard < sprintBoardIds!.length) {
+    if (nextBoard < boards.length) {
       return {
         changes,
         hasMore: true,
-        nextState: { boardIndex: nextBoard, startAt: 0 },
+        nextState: { boards, boardIndex: nextBoard, startAt: 0 },
       }
     }
 
-    sprintBoards = undefined
-    sprintBoardIds = undefined
+    return { changes, hasMore: false }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// All Sprints — daily sprint performance reconstructed from Jira history
+// ---------------------------------------------------------------------------
+
+type AllSprintsLoadState = {
+  phase: "load-sprints"
+  boards: BoardRef[]
+  fieldConfig: IssueFieldConfig
+  boardIndex: number
+  startAt: number
+  sprints: JiraSprint[]
+}
+
+type AllSprintsAnalyzeState = {
+  phase: "analyze"
+  boards: BoardRef[]
+  fieldConfig: IssueFieldConfig
+  boardIndex: number
+  sprints: JiraSprint[]
+  sprintNamesById: Record<string, string>
+  sprintIndex: number
+  boardConfig: JiraBoardConfiguration
+  priorSprintVelocities: number[]
+}
+
+type AllSprintsSyncState = AllSprintsLoadState | AllSprintsAnalyzeState
+
+const allSprints = worker.database("allSprints", {
+  type: "managed",
+  initialTitle: ALL_SPRINTS_INITIAL_TITLE,
+  primaryKeyProperty: ALL_SPRINTS_PRIMARY_KEY,
+  schema: allSprintsSchema,
+})
+
+function nextBoardLoadState(
+  state: AllSprintsSyncState,
+  boardIndex: number
+): AllSprintsLoadState {
+  return {
+    phase: "load-sprints",
+    boards: state.boards,
+    fieldConfig: state.fieldConfig,
+    boardIndex,
+    startAt: 0,
+    sprints: [],
+  }
+}
+
+worker.sync("allSprintsSync", {
+  database: allSprints,
+  mode: "replace",
+  schedule: "1d",
+  execute: async (previousState: AllSprintsSyncState | undefined) => {
+    let state = previousState
+
+    if (!state) {
+      const boards = await fetchBoardRefs()
+      await pacer.wait()
+      const fieldConfig = await fetchIssueFieldConfig()
+      state = {
+        phase: "load-sprints",
+        boards,
+        fieldConfig,
+        boardIndex: 0,
+        startAt: 0,
+        sprints: [],
+      }
+    }
+
+    const board = state.boards[state.boardIndex]
+    if (!board) return { changes: [], hasMore: false }
+
+    if (state.phase === "load-sprints") {
+      await pacer.wait()
+      const page = await fetchSprintsForBoard(board.id, state.startAt)
+      const allBoardSprints = [
+        ...state.sprints,
+        ...page.sprints.filter((sprint) => sprint.originBoardId === board.id),
+      ]
+
+      if (page.hasMore) {
+        return {
+          changes: [],
+          hasMore: true,
+          nextState: {
+            ...state,
+            startAt: page.nextStartAt,
+            sprints: allBoardSprints,
+          },
+        }
+      }
+
+      const sprintNamesById = Object.fromEntries(
+        allBoardSprints.map((sprint) => [String(sprint.id), sprint.name])
+      )
+      const analyzableSprints = allBoardSprints
+        .filter(
+          (sprint) =>
+            (sprint.state === "active" || sprint.state === "closed") &&
+            Boolean(sprint.startDate && sprint.endDate)
+        )
+        .sort((left, right) => {
+          if (left.state !== right.state) {
+            return left.state === "active" ? 1 : -1
+          }
+          const leftDate = left.completeDate ?? left.startDate ?? ""
+          const rightDate = right.completeDate ?? right.startDate ?? ""
+          return leftDate.localeCompare(rightDate)
+        })
+
+      if (analyzableSprints.length === 0) {
+        const nextBoardIndex = state.boardIndex + 1
+        if (nextBoardIndex >= state.boards.length) {
+          return { changes: [], hasMore: false }
+        }
+        return {
+          changes: [],
+          hasMore: true,
+          nextState: nextBoardLoadState(state, nextBoardIndex),
+        }
+      }
+
+      await pacer.wait()
+      const boardConfig = await fetchBoardConfiguration(board.id)
+      const nextState: AllSprintsAnalyzeState = {
+        phase: "analyze",
+        boards: state.boards,
+        fieldConfig: state.fieldConfig,
+        boardIndex: state.boardIndex,
+        sprints: analyzableSprints,
+        sprintNamesById,
+        sprintIndex: 0,
+        boardConfig,
+        priorSprintVelocities: [],
+      }
+      return {
+        changes: [],
+        hasMore: true,
+        nextState,
+      }
+    }
+
+    const sprint = state.sprints[state.sprintIndex]
+    if (!sprint) {
+      const nextBoardIndex = state.boardIndex + 1
+      if (nextBoardIndex >= state.boards.length) {
+        return { changes: [], hasMore: false }
+      }
+      return {
+        changes: [],
+        hasMore: true,
+        nextState: nextBoardLoadState(state, nextBoardIndex),
+      }
+    }
+
+    const evaluatedAt = new Date().toISOString()
+    const input = await fetchSprintAnalyticsInput({
+      sprint,
+      boardName: board.name,
+      boardConfig: state.boardConfig,
+      sprintFieldId: state.fieldConfig.sprintField,
+      fallbackEstimateFieldId: state.fieldConfig.storyPointsFields[0],
+      storyPointFieldIds: state.fieldConfig.storyPointsFields,
+      priorSprintVelocities: state.priorSprintVelocities,
+      evaluatedAt,
+      baseUrl: getBaseUrl(),
+      sprintNamesById: state.sprintNamesById,
+      waitFn: () => pacer.wait(),
+    })
+    const metrics = calculateSprintAnalytics(input)
+    const changes = [sprintAnalyticsToChange(input)]
+    const priorSprintVelocities =
+      sprint.state === "closed"
+        ? [metrics.velocity, ...state.priorSprintVelocities].slice(0, 5)
+        : state.priorSprintVelocities
+    const nextSprintIndex = state.sprintIndex + 1
+
+    if (nextSprintIndex < state.sprints.length) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: {
+          ...state,
+          sprintIndex: nextSprintIndex,
+          priorSprintVelocities,
+        },
+      }
+    }
+
+    const nextBoardIndex = state.boardIndex + 1
+    if (nextBoardIndex < state.boards.length) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: nextBoardLoadState(state, nextBoardIndex),
+      }
+    }
+
     return { changes, hasMore: false }
   },
 })
@@ -189,7 +415,7 @@ const projects = worker.database("projects", {
 worker.sync("projectsSync", {
   database: projects,
   mode: "replace",
-  schedule: "5m",
+  schedule: "1d",
   execute: async (state: ProjectSyncState | undefined) => {
     await pacer.wait()
     const baseUrl = getBaseUrl()

--- a/examples/workers/syncs/jira/src/index.ts
+++ b/examples/workers/syncs/jira/src/index.ts
@@ -9,7 +9,7 @@
 // Issues are scoped to specific projects via the JIRA_PROJECTS env var.
 // Board names are fetched once per sprint sync cycle to resolve board IDs.
 // Three pagination models are used because each Jira endpoint differs:
-//   - Issues: startAt/total (classic search endpoint)
+//   - Issues: nextPageToken/isLast (enhanced search endpoint)
 //   - Sprints: multi-board iteration with startAt/isLast per board
 //   - Projects: startAt/isLast
 
@@ -17,12 +17,13 @@ import { Worker } from "@notionhq/workers"
 
 import {
   getBaseUrl,
+  fetchIssueFieldConfig,
   fetchIssuesPage,
   fetchAllBoards,
   fetchSprintsForBoard,
   fetchProjectsPage,
 } from "./jira.js"
-import type { BoardLookup } from "./jira.js"
+import type { BoardLookup, IssueFieldConfig } from "./jira.js"
 import {
   INITIAL_TITLE as ISSUES_TITLE,
   PRIMARY_KEY as ISSUES_PK,
@@ -44,7 +45,9 @@ import {
 
 const worker = new Worker()
 
-// Jira Cloud rate-limits to 10 requests per second on Standard plans.
+// Keep normal traffic conservative. Jira can also return quota- and
+// burst-based 429s, which the API client surfaces as RateLimitError so the
+// Workers runtime can honor Retry-After.
 const pacer = worker.pacer("jira", {
   allowedRequests: 9,
   intervalMs: 1_000,
@@ -55,7 +58,8 @@ const pacer = worker.pacer("jira", {
 // ---------------------------------------------------------------------------
 
 type IssueSyncState = {
-  startAt: number
+  nextPageToken?: string
+  fieldConfig: IssueFieldConfig
 }
 
 const issues = worker.database("issues", {
@@ -70,17 +74,28 @@ worker.sync("issuesSync", {
   mode: "replace",
   schedule: "2m",
   execute: async (state: IssueSyncState | undefined) => {
-    await pacer.wait()
     const baseUrl = getBaseUrl()
+    let fieldConfig = state?.fieldConfig
 
-    const page = await fetchIssuesPage(state?.startAt)
-    const changes = page.issues.map((i) => issueToChange(i, baseUrl))
+    if (!fieldConfig) {
+      await pacer.wait()
+      fieldConfig = await fetchIssueFieldConfig()
+    }
+
+    await pacer.wait()
+    const page = await fetchIssuesPage(fieldConfig, state?.nextPageToken)
+    const changes = page.issues.map((issue) =>
+      issueToChange(issue, baseUrl, fieldConfig)
+    )
 
     if (page.hasMore) {
       return {
         changes,
         hasMore: true,
-        nextState: { startAt: page.nextStartAt },
+        nextState: {
+          nextPageToken: page.nextPageToken,
+          fieldConfig,
+        },
       }
     }
 
@@ -131,9 +146,7 @@ worker.sync("sprintsSync", {
 
     await pacer.wait()
     const result = await fetchSprintsForBoard(boardId, startAt)
-    const changes = result.sprints.map((s) =>
-      sprintToChange(s, sprintBoards!)
-    )
+    const changes = result.sprints.map((s) => sprintToChange(s, sprintBoards!))
 
     if (result.hasMore) {
       return {

--- a/examples/workers/syncs/jira/src/index.ts
+++ b/examples/workers/syncs/jira/src/index.ts
@@ -1,0 +1,200 @@
+// Entry point — syncs Jira Cloud issues, sprints, and projects into
+// managed Notion databases.
+//
+// Three databases are created:
+//   1. Issues    — status, priority, assignee, sprint, project (every 2 min)
+//   2. Sprints   — state, board, dates, goal (every 5 min)
+//   3. Projects  — key, lead, category, type (every 5 min)
+//
+// Issues are scoped to specific projects via the JIRA_PROJECTS env var.
+// Board names are fetched once per sprint sync cycle to resolve board IDs.
+// Three pagination models are used because each Jira endpoint differs:
+//   - Issues: startAt/total (classic search endpoint)
+//   - Sprints: multi-board iteration with startAt/isLast per board
+//   - Projects: startAt/isLast
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  getBaseUrl,
+  fetchIssuesPage,
+  fetchAllBoards,
+  fetchSprintsForBoard,
+  fetchProjectsPage,
+} from "./jira.js"
+import type { BoardLookup } from "./jira.js"
+import {
+  INITIAL_TITLE as ISSUES_TITLE,
+  PRIMARY_KEY as ISSUES_PK,
+  issueSchema,
+  issueToChange,
+} from "./issues.js"
+import {
+  INITIAL_TITLE as SPRINTS_TITLE,
+  PRIMARY_KEY as SPRINTS_PK,
+  sprintSchema,
+  sprintToChange,
+} from "./sprints.js"
+import {
+  INITIAL_TITLE as PROJECTS_TITLE,
+  PRIMARY_KEY as PROJECTS_PK,
+  projectSchema,
+  projectToChange,
+} from "./projects.js"
+
+const worker = new Worker()
+
+// Jira Cloud rate-limits to 10 requests per second on Standard plans.
+const pacer = worker.pacer("jira", {
+  allowedRequests: 9,
+  intervalMs: 1_000,
+})
+
+// ---------------------------------------------------------------------------
+// Issues — core engineering workflow
+// ---------------------------------------------------------------------------
+
+type IssueSyncState = {
+  startAt: number
+}
+
+const issues = worker.database("issues", {
+  type: "managed",
+  initialTitle: ISSUES_TITLE,
+  primaryKeyProperty: ISSUES_PK,
+  schema: issueSchema,
+})
+
+worker.sync("issuesSync", {
+  database: issues,
+  mode: "replace",
+  schedule: "2m",
+  execute: async (state: IssueSyncState | undefined) => {
+    await pacer.wait()
+    const baseUrl = getBaseUrl()
+
+    const page = await fetchIssuesPage(state?.startAt)
+    const changes = page.issues.map((i) => issueToChange(i, baseUrl))
+
+    if (page.hasMore) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { startAt: page.nextStartAt },
+      }
+    }
+
+    return { changes, hasMore: false }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Sprints — iterates all Scrum boards, fetches sprints for each
+// ---------------------------------------------------------------------------
+
+type SprintSyncState = {
+  boardIndex: number
+  startAt: number
+}
+
+let sprintBoards: BoardLookup | undefined
+let sprintBoardIds: number[] | undefined
+
+const sprints = worker.database("sprints", {
+  type: "managed",
+  initialTitle: SPRINTS_TITLE,
+  primaryKeyProperty: SPRINTS_PK,
+  schema: sprintSchema,
+})
+
+worker.sync("sprintsSync", {
+  database: sprints,
+  mode: "replace",
+  schedule: "5m",
+  execute: async (state: SprintSyncState | undefined) => {
+    await pacer.wait()
+
+    if (!sprintBoards) {
+      sprintBoards = await fetchAllBoards(() => pacer.wait())
+      sprintBoardIds = [...sprintBoards.keys()]
+    }
+
+    const boardIndex = state?.boardIndex ?? 0
+    const startAt = state?.startAt ?? 0
+    const boardId = sprintBoardIds![boardIndex]
+
+    if (boardId === undefined) {
+      sprintBoards = undefined
+      sprintBoardIds = undefined
+      return { changes: [], hasMore: false }
+    }
+
+    await pacer.wait()
+    const result = await fetchSprintsForBoard(boardId, startAt)
+    const changes = result.sprints.map((s) =>
+      sprintToChange(s, sprintBoards!)
+    )
+
+    if (result.hasMore) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { boardIndex, startAt: result.nextStartAt },
+      }
+    }
+
+    const nextBoard = boardIndex + 1
+    if (nextBoard < sprintBoardIds!.length) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { boardIndex: nextBoard, startAt: 0 },
+      }
+    }
+
+    sprintBoards = undefined
+    sprintBoardIds = undefined
+    return { changes, hasMore: false }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Projects — reference data
+// ---------------------------------------------------------------------------
+
+type ProjectSyncState = {
+  startAt: number
+}
+
+const projects = worker.database("projects", {
+  type: "managed",
+  initialTitle: PROJECTS_TITLE,
+  primaryKeyProperty: PROJECTS_PK,
+  schema: projectSchema,
+})
+
+worker.sync("projectsSync", {
+  database: projects,
+  mode: "replace",
+  schedule: "5m",
+  execute: async (state: ProjectSyncState | undefined) => {
+    await pacer.wait()
+    const baseUrl = getBaseUrl()
+    const startAt = state?.startAt ?? 0
+
+    const page = await fetchProjectsPage(startAt)
+    const changes = page.projects.map((p) => projectToChange(p, baseUrl))
+
+    if (page.hasMore) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: { startAt: page.nextStartAt },
+      }
+    }
+
+    return { changes, hasMore: false }
+  },
+})
+
+export default worker

--- a/examples/workers/syncs/jira/src/issues.ts
+++ b/examples/workers/syncs/jira/src/issues.ts
@@ -1,0 +1,141 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import type { JiraIssue } from "./jira.js"
+import { browseUrl, getStoryPoints, getEpicName, extractTextFromAdf } from "./jira.js"
+import { dateOnly } from "./helpers.js"
+
+export const INITIAL_TITLE = "Jira Issues"
+export const PRIMARY_KEY = "Issue Key"
+
+export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("bug"),
+  properties: {
+    Summary: Schema.title(),
+
+    Status: Schema.select([
+      { name: "To Do" },
+      { name: "In Progress" },
+      { name: "In Review" },
+      { name: "Done" },
+    ]),
+
+    "Issue Type": Schema.select([
+      { name: "Bug" },
+      { name: "Story" },
+      { name: "Task" },
+      { name: "Epic" },
+      { name: "Sub-task" },
+    ]),
+
+    Assignee: Schema.richText(),
+
+    Sprint: Schema.richText(),
+
+    Updated: Schema.date(),
+
+    "Status Category": Schema.select([
+      { name: "To Do" },
+      { name: "In Progress" },
+      { name: "Done" },
+    ]),
+
+    Priority: Schema.select([
+      { name: "Highest" },
+      { name: "High" },
+      { name: "Medium" },
+      { name: "Low" },
+      { name: "Lowest" },
+    ]),
+
+    Reporter: Schema.richText(),
+
+    Project: Schema.richText(),
+
+    "Issue Link": Schema.url(),
+
+    Labels: Schema.multiSelect([]),
+
+    Components: Schema.multiSelect([]),
+
+    "Fix Versions": Schema.multiSelect([]),
+
+    Resolution: Schema.select([]),
+
+    "Due Date": Schema.date(),
+
+    Epic: Schema.richText(),
+
+    "Story Points": Schema.number(),
+
+    Created: Schema.date(),
+
+    "Issue Key": Schema.richText(),
+  },
+}
+
+export function issueToChange(issue: JiraIssue, baseUrl: string) {
+  const f = issue.fields
+  const storyPoints = getStoryPoints(issue)
+  const epicName = getEpicName(issue)
+  const statusCategory = f.status?.statusCategory?.name ?? null
+
+  return {
+    type: "upsert" as const,
+    key: issue.key,
+    upstreamUpdatedAt: f.updated,
+    pageContentMarkdown: extractTextFromAdf(f.description),
+    properties: {
+      Summary: Builder.title(f.summary ?? ""),
+      ...(f.status
+        ? { Status: Builder.select(f.status.name) }
+        : {}),
+      ...(f.issuetype
+        ? { "Issue Type": Builder.select(f.issuetype.name) }
+        : {}),
+      ...(f.assignee
+        ? { Assignee: Builder.richText(f.assignee.displayName) }
+        : {}),
+      ...(f.sprint
+        ? { Sprint: Builder.richText(f.sprint.name) }
+        : {}),
+      Updated: Builder.date(dateOnly(f.updated)),
+      ...(statusCategory
+        ? { "Status Category": Builder.select(statusCategory) }
+        : {}),
+      ...(f.priority
+        ? { Priority: Builder.select(f.priority.name) }
+        : {}),
+      ...(f.reporter
+        ? { Reporter: Builder.richText(f.reporter.displayName) }
+        : {}),
+      ...(f.project
+        ? { Project: Builder.richText(f.project.name) }
+        : {}),
+      "Issue Link": Builder.url(browseUrl(baseUrl, issue.key)),
+      ...(f.labels.length > 0
+        ? { Labels: Builder.multiSelect(...f.labels) }
+        : {}),
+      ...(f.components.length > 0
+        ? { Components: Builder.multiSelect(...f.components.map((c) => c.name)) }
+        : {}),
+      ...(f.fixVersions.length > 0
+        ? { "Fix Versions": Builder.multiSelect(...f.fixVersions.map((v) => v.name)) }
+        : {}),
+      ...(f.resolution
+        ? { Resolution: Builder.select(f.resolution.name) }
+        : {}),
+      ...(f.duedate
+        ? { "Due Date": Builder.date(dateOnly(f.duedate)) }
+        : {}),
+      ...(epicName
+        ? { Epic: Builder.richText(epicName) }
+        : {}),
+      ...(storyPoints != null
+        ? { "Story Points": Builder.number(storyPoints) }
+        : {}),
+      Created: Builder.date(dateOnly(f.created)),
+      "Issue Key": Builder.richText(issue.key),
+    },
+  }
+}

--- a/examples/workers/syncs/jira/src/issues.ts
+++ b/examples/workers/syncs/jira/src/issues.ts
@@ -1,12 +1,18 @@
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
 import { notionIcon } from "@notionhq/workers"
-import type { JiraIssue } from "./jira.js"
-import { browseUrl, getStoryPoints, getEpicName, extractTextFromAdf } from "./jira.js"
+import type { IssueFieldConfig, JiraIssue } from "./jira.js"
+import {
+  browseUrl,
+  extractTextFromAdf,
+  getEpicName,
+  getSprintName,
+  getStoryPoints,
+} from "./jira.js"
 import { dateOnly } from "./helpers.js"
 
 export const INITIAL_TITLE = "Jira Issues"
-export const PRIMARY_KEY = "Issue Key"
+export const PRIMARY_KEY = "Jira Issue ID"
 
 export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
   databaseIcon: notionIcon("bug"),
@@ -71,71 +77,73 @@ export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     Created: Schema.date(),
 
     "Issue Key": Schema.richText(),
+
+    "Jira Issue ID": Schema.richText(),
   },
 }
 
-export function issueToChange(issue: JiraIssue, baseUrl: string) {
+export function issueToChange(
+  issue: JiraIssue,
+  baseUrl: string,
+  fieldConfig: IssueFieldConfig
+) {
   const f = issue.fields
-  const storyPoints = getStoryPoints(issue)
-  const epicName = getEpicName(issue)
+  const storyPoints = getStoryPoints(issue, fieldConfig)
+  const epicName = getEpicName(issue, fieldConfig)
+  const sprintName = getSprintName(issue, fieldConfig)
   const statusCategory = f.status?.statusCategory?.name ?? null
 
   return {
     type: "upsert" as const,
-    key: issue.key,
+    key: issue.id,
     upstreamUpdatedAt: f.updated,
     pageContentMarkdown: extractTextFromAdf(f.description),
     properties: {
       Summary: Builder.title(f.summary ?? ""),
-      ...(f.status
-        ? { Status: Builder.select(f.status.name) }
-        : {}),
+      ...(f.status ? { Status: Builder.select(f.status.name) } : {}),
       ...(f.issuetype
         ? { "Issue Type": Builder.select(f.issuetype.name) }
         : {}),
       ...(f.assignee
         ? { Assignee: Builder.richText(f.assignee.displayName) }
         : {}),
-      ...(f.sprint
-        ? { Sprint: Builder.richText(f.sprint.name) }
-        : {}),
+      ...(sprintName ? { Sprint: Builder.richText(sprintName) } : {}),
       Updated: Builder.date(dateOnly(f.updated)),
       ...(statusCategory
         ? { "Status Category": Builder.select(statusCategory) }
         : {}),
-      ...(f.priority
-        ? { Priority: Builder.select(f.priority.name) }
-        : {}),
+      ...(f.priority ? { Priority: Builder.select(f.priority.name) } : {}),
       ...(f.reporter
         ? { Reporter: Builder.richText(f.reporter.displayName) }
         : {}),
-      ...(f.project
-        ? { Project: Builder.richText(f.project.name) }
-        : {}),
+      ...(f.project ? { Project: Builder.richText(f.project.name) } : {}),
       "Issue Link": Builder.url(browseUrl(baseUrl, issue.key)),
       ...(f.labels.length > 0
         ? { Labels: Builder.multiSelect(...f.labels) }
         : {}),
       ...(f.components.length > 0
-        ? { Components: Builder.multiSelect(...f.components.map((c) => c.name)) }
+        ? {
+            Components: Builder.multiSelect(...f.components.map((c) => c.name)),
+          }
         : {}),
       ...(f.fixVersions.length > 0
-        ? { "Fix Versions": Builder.multiSelect(...f.fixVersions.map((v) => v.name)) }
+        ? {
+            "Fix Versions": Builder.multiSelect(
+              ...f.fixVersions.map((v) => v.name)
+            ),
+          }
         : {}),
       ...(f.resolution
         ? { Resolution: Builder.select(f.resolution.name) }
         : {}),
-      ...(f.duedate
-        ? { "Due Date": Builder.date(dateOnly(f.duedate)) }
-        : {}),
-      ...(epicName
-        ? { Epic: Builder.richText(epicName) }
-        : {}),
+      ...(f.duedate ? { "Due Date": Builder.date(dateOnly(f.duedate)) } : {}),
+      ...(epicName ? { Epic: Builder.richText(epicName) } : {}),
       ...(storyPoints != null
         ? { "Story Points": Builder.number(storyPoints) }
         : {}),
       Created: Builder.date(dateOnly(f.created)),
       "Issue Key": Builder.richText(issue.key),
+      "Jira Issue ID": Builder.richText(issue.id),
     },
   }
 }

--- a/examples/workers/syncs/jira/src/jira.ts
+++ b/examples/workers/syncs/jira/src/jira.ts
@@ -1,9 +1,10 @@
 // Jira Cloud REST API client. Handles authentication and paginated fetching
 // for issues, sprints, and projects.
 //
-// Uses two API surfaces:
+// Uses three API surfaces:
 //   - Platform REST API v3 (/rest/api/3) for issues and projects
 //   - Agile REST API (/rest/agile/1.0) for boards and sprints
+//   - Enhanced Software REST API (/rest/software/1.0) for sprint issues
 //
 // To add a new resource:
 //   1. Add a type for the response shape
@@ -35,12 +36,14 @@ function getAuthHeader(): string {
   return `Basic ${Buffer.from(`${email}:${token}`).toString("base64")}`
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const headers = new Headers(init?.headers)
+  headers.set("Authorization", getAuthHeader())
+  headers.set("Accept", "application/json")
+
   const response = await fetch(url, {
-    headers: {
-      Authorization: getAuthHeader(),
-      Accept: "application/json",
-    },
+    ...init,
+    headers,
   })
 
   const text = await response.text()
@@ -57,10 +60,7 @@ async function fetchJson<T>(url: string): Promise<T> {
 }
 
 class JiraApiError extends Error {
-  constructor(
-    readonly status: number,
-    body: string
-  ) {
+  constructor(readonly status: number, body: string) {
     super(`Jira API error (${status}): ${body || "No response body"}`)
     this.name = "JiraApiError"
   }
@@ -156,7 +156,11 @@ export type JiraIssue = {
   self: string
   fields: {
     summary: string
-    status: { name: string; statusCategory?: { name: string } } | null
+    status: {
+      id?: string
+      name: string
+      statusCategory?: { name: string }
+    } | null
     issuetype: {
       name: string
       subtask?: boolean
@@ -402,6 +406,8 @@ export type JiraSprint = {
   originBoardId: number
 }
 
+export type JiraSprintState = "future" | "active" | "closed"
+
 type BoardListResponse = {
   values: { id: number; name: string }[]
   startAt: number
@@ -443,14 +449,20 @@ export async function fetchAllBoards(
 
 export async function fetchSprintsForBoard(
   boardId: number,
-  startAt?: number
+  startAt?: number,
+  states?: readonly JiraSprintState[]
 ): Promise<{ sprints: JiraSprint[]; hasMore: boolean; nextStartAt: number }> {
   const baseUrl = getBaseUrl()
   const s = startAt ?? 0
-  const url = `${baseUrl}/rest/agile/1.0/board/${boardId}/sprint?startAt=${s}&maxResults=50`
+  const url = new URL(`${baseUrl}/rest/agile/1.0/board/${boardId}/sprint`)
+  url.searchParams.set("startAt", String(s))
+  url.searchParams.set("maxResults", "50")
+  if (states && states.length > 0) {
+    url.searchParams.set("state", [...new Set(states)].join(","))
+  }
 
   try {
-    const body = await fetchJson<SprintListResponse>(url)
+    const body = await fetchJson<SprintListResponse>(url.toString())
     return {
       sprints: body.values,
       hasMore: !body.isLast,
@@ -461,6 +473,185 @@ export async function fetchSprintsForBoard(
       return { sprints: [], hasMore: false, nextStartAt: s }
     }
     throw err
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sprint analytics — board configuration, sprint issues, and issue history
+// ---------------------------------------------------------------------------
+
+type BoardConfigurationResponse = {
+  estimation?: {
+    type?: string
+    field?: {
+      fieldId?: string
+      displayName?: string
+    }
+  }
+  columnConfig?: {
+    columns?: {
+      statuses?: { id: string }[]
+    }[]
+  }
+}
+
+export type JiraBoardConfiguration = {
+  estimationType?: string
+  estimationFieldId?: string
+  estimationFieldName?: string
+  doneStatusIds: string[]
+}
+
+// Jira considers issues in the board's rightmost column complete. Returning
+// those status IDs keeps that board-specific definition available to sprint
+// analytics instead of assuming every globally "Done" status is equivalent.
+export async function fetchBoardConfiguration(
+  boardId: number
+): Promise<JiraBoardConfiguration> {
+  const baseUrl = getBaseUrl()
+  const body = await fetchJson<BoardConfigurationResponse>(
+    `${baseUrl}/rest/agile/1.0/board/${boardId}/configuration`
+  )
+  const columns = body.columnConfig?.columns ?? []
+  let doneStatuses: { id: string }[] = []
+  for (let index = columns.length - 1; index >= 0; index -= 1) {
+    if ((columns[index].statuses?.length ?? 0) > 0) {
+      doneStatuses = columns[index].statuses ?? []
+      break
+    }
+  }
+
+  return {
+    estimationType: body.estimation?.type,
+    estimationFieldId: body.estimation?.field?.fieldId,
+    estimationFieldName: body.estimation?.field?.displayName,
+    doneStatusIds: [...new Set(doneStatuses.map((status) => status.id))],
+  }
+}
+
+type SprintIssueSearchResponse = {
+  issues: JiraIssue[]
+  isLast?: boolean
+  nextPageToken?: string
+}
+
+export type SprintIssuePageOptions = {
+  fields?: readonly string[]
+  nextPageToken?: string
+  jql?: string
+}
+
+// Jira's enhanced sprint issue endpoint uses opaque cursor pagination. Callers
+// should persist only nextPageToken and must not infer offsets from page size.
+export async function fetchSprintIssuesPage(
+  sprintId: number,
+  options: SprintIssuePageOptions = {}
+): Promise<{
+  issues: JiraIssue[]
+  hasMore: boolean
+  nextPageToken?: string
+}> {
+  const baseUrl = getBaseUrl()
+  const url = new URL(`${baseUrl}/rest/software/1.0/sprint/${sprintId}/issue`)
+  url.searchParams.set("maxResults", "100")
+  if (options.fields && options.fields.length > 0) {
+    url.searchParams.set("fields", [...new Set(options.fields)].join(","))
+  }
+  if (options.nextPageToken) {
+    url.searchParams.set("nextPageToken", options.nextPageToken)
+  }
+  if (options.jql) {
+    url.searchParams.set("jql", options.jql)
+  }
+
+  const body = await fetchJson<SprintIssueSearchResponse>(url.toString())
+  const nextPageToken = body.nextPageToken || undefined
+  return {
+    issues: body.issues,
+    hasMore: body.isLast !== true && nextPageToken !== undefined,
+    nextPageToken,
+  }
+}
+
+export type JiraChangelogItem = {
+  field: string
+  fieldId?: string
+  from?: string | null
+  fromString?: string | null
+  to?: string | null
+  toString?: string | null
+}
+
+export type JiraChangeHistory = {
+  id: string
+  created: string | number
+  items: JiraChangelogItem[]
+}
+
+export type JiraIssueChangeLog = {
+  issueId: string
+  changeHistories: JiraChangeHistory[]
+}
+
+type BulkChangelogResponse = {
+  issueChangeLogs: JiraIssueChangeLog[]
+  nextPageToken?: string
+}
+
+export type BulkChangelogPageOptions = {
+  fieldIds?: readonly string[]
+  nextPageToken?: string
+  maxResults?: number
+}
+
+// The bulk endpoint accepts at most 1,000 issues and 10 fields. It returns all
+// matching histories in chronological order across the requested issue set.
+export async function fetchBulkChangelogsPage(
+  issueIdsOrKeys: readonly string[],
+  options: BulkChangelogPageOptions = {}
+): Promise<{
+  issueChangeLogs: JiraIssueChangeLog[]
+  hasMore: boolean
+  nextPageToken?: string
+}> {
+  if (issueIdsOrKeys.length === 0 || issueIdsOrKeys.length > 1_000) {
+    throw new Error(
+      "Bulk changelog requests require between 1 and 1,000 issues."
+    )
+  }
+  if ((options.fieldIds?.length ?? 0) > 10) {
+    throw new Error("Bulk changelog requests support at most 10 field IDs.")
+  }
+
+  const requestBody: {
+    issueIdsOrKeys: string[]
+    fieldIds?: string[]
+    maxResults: number
+    nextPageToken?: string
+  } = {
+    issueIdsOrKeys: [...new Set(issueIdsOrKeys)],
+    maxResults: options.maxResults ?? 1_000,
+  }
+  if (options.fieldIds && options.fieldIds.length > 0) {
+    requestBody.fieldIds = [...new Set(options.fieldIds)]
+  }
+  if (options.nextPageToken) {
+    requestBody.nextPageToken = options.nextPageToken
+  }
+
+  const body = await fetchJson<BulkChangelogResponse>(
+    `${getBaseUrl()}/rest/api/3/changelog/bulkfetch`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+    }
+  )
+  const nextPageToken = body.nextPageToken || undefined
+  return {
+    issueChangeLogs: body.issueChangeLogs,
+    hasMore: nextPageToken !== undefined,
+    nextPageToken,
   }
 }
 

--- a/examples/workers/syncs/jira/src/jira.ts
+++ b/examples/workers/syncs/jira/src/jira.ts
@@ -10,6 +10,8 @@
 //   2. Add a fetch function
 //   3. Wire it into index.ts
 
+import { RateLimitError } from "@notionhq/workers"
+
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim()
   if (!value) {
@@ -42,23 +44,106 @@ async function fetchJson<T>(url: string): Promise<T> {
   })
 
   const text = await response.text()
+  if (response.status === 429) {
+    throw new RateLimitError({
+      retryAfter: parseRetryAfter(response.headers.get("Retry-After")),
+    })
+  }
   if (!response.ok) {
-    throw new Error(
-      `Jira API error (${response.status}): ${text || "No response body"}`
-    )
+    throw new JiraApiError(response.status, text)
   }
 
   return JSON.parse(text) as T
+}
+
+class JiraApiError extends Error {
+  constructor(
+    readonly status: number,
+    body: string
+  ) {
+    super(`Jira API error (${status}): ${body || "No response body"}`)
+    this.name = "JiraApiError"
+  }
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds)
+  }
+
+  const retryAt = Date.parse(value)
+  if (Number.isNaN(retryAt)) return undefined
+  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1_000))
 }
 
 export function browseUrl(baseUrl: string, key: string): string {
   return `${baseUrl}/browse/${key}`
 }
 
-// Custom field IDs cached at module level — these never change within a process.
-// Most Jira Cloud instances use customfield_10016 for story points.
-const STORY_POINTS_FIELD = optionalEnv("JIRA_STORY_POINTS_FIELD") ?? "customfield_10016"
-const EPIC_FIELD = optionalEnv("JIRA_EPIC_FIELD")
+// Jira Software fields are custom fields whose IDs vary by site. Resolve them
+// from Jira's field metadata once per issue sync cycle, with optional env vars
+// taking precedence when a site has multiple matching fields.
+export type IssueFieldConfig = {
+  sprintField?: string
+  storyPointsFields: string[]
+  epicField?: string
+}
+
+export type JiraFieldDefinition = {
+  id: string
+  name: string
+  schema?: {
+    custom?: string
+    type?: string
+  }
+}
+
+const SPRINT_FIELD_TYPE = "com.pyxis.greenhopper.jira:gh-sprint"
+const EPIC_FIELD_TYPE = "com.pyxis.greenhopper.jira:gh-epic-link"
+
+export async function fetchIssueFieldConfig(): Promise<IssueFieldConfig> {
+  const fields = await fetchJson<JiraFieldDefinition[]>(
+    `${getBaseUrl()}/rest/api/3/field`
+  )
+  return resolveIssueFieldConfig(fields)
+}
+
+export function resolveIssueFieldConfig(
+  fields: JiraFieldDefinition[]
+): IssueFieldConfig {
+  const sprintField =
+    optionalEnv("JIRA_SPRINT_FIELD") ??
+    fields.find((field) => field.schema?.custom === SPRINT_FIELD_TYPE)?.id
+
+  const storyPointsOverride = optionalEnv("JIRA_STORY_POINTS_FIELD")
+  const storyPointsFields = storyPointsOverride
+    ? storyPointsOverride
+        .split(",")
+        .map((field) => field.trim())
+        .filter(Boolean)
+    : fields
+        .filter((field) => {
+          const name = field.name.trim().toLowerCase()
+          return (
+            field.schema?.type === "number" &&
+            (name === "story points" || name === "story point estimate")
+          )
+        })
+        .map((field) => field.id)
+
+  const epicField =
+    optionalEnv("JIRA_EPIC_FIELD") ??
+    fields.find((field) => field.schema?.custom === EPIC_FIELD_TYPE)?.id
+
+  return {
+    sprintField,
+    storyPointsFields: [...new Set(storyPointsFields)],
+    epicField,
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Issues — searched via JQL
@@ -66,12 +151,17 @@ const EPIC_FIELD = optionalEnv("JIRA_EPIC_FIELD")
 // ---------------------------------------------------------------------------
 
 export type JiraIssue = {
+  id: string
   key: string
   self: string
   fields: {
     summary: string
     status: { name: string; statusCategory?: { name: string } } | null
-    issuetype: { name: string } | null
+    issuetype: {
+      name: string
+      subtask?: boolean
+      hierarchyLevel?: number
+    } | null
     priority: { name: string } | null
     assignee: { displayName: string } | null
     reporter: { displayName: string } | null
@@ -84,7 +174,6 @@ export type JiraIssue = {
     duedate: string | null
     created: string
     updated: string
-    sprint?: { name: string; state: string } | null
     parent?: { key: string; fields?: { summary: string } } | null
     [key: string]: unknown
   }
@@ -106,15 +195,20 @@ const ISSUE_FIELDS = [
   "duedate",
   "created",
   "updated",
-  "sprint",
   "parent",
 ]
 
-export function getIssueFields(): string[] {
-  const fields = [...ISSUE_FIELDS]
-  if (STORY_POINTS_FIELD) fields.push(STORY_POINTS_FIELD)
-  if (EPIC_FIELD) fields.push(EPIC_FIELD)
-  return fields
+export function getIssueFields(config: IssueFieldConfig): string[] {
+  return [
+    ...new Set(
+      [
+        ...ISSUE_FIELDS,
+        config.sprintField,
+        ...config.storyPointsFields,
+        config.epicField,
+      ].filter((field): field is string => Boolean(field))
+    ),
+  ]
 }
 
 // Jira Cloud v3 returns descriptions in Atlassian Document Format (ADF),
@@ -125,6 +219,9 @@ export function extractTextFromAdf(adf: unknown): string {
 
   if (node.type === "text" && typeof node.text === "string") {
     return node.text
+  }
+  if (node.type === "hardBreak") {
+    return "\n"
   }
 
   const content = node.content
@@ -152,59 +249,140 @@ export function extractTextFromAdf(adf: unknown): string {
   return parts.join("")
 }
 
-export function getStoryPoints(issue: JiraIssue): number | null {
-  if (!STORY_POINTS_FIELD) return null
-  const value = issue.fields[STORY_POINTS_FIELD]
-  return typeof value === "number" ? value : null
-}
-
-export function getEpicName(issue: JiraIssue): string | null {
-  if (EPIC_FIELD) {
-    const value = issue.fields[EPIC_FIELD]
-    if (typeof value === "string") return value
-  }
-  if (issue.fields.parent?.fields?.summary) {
-    return issue.fields.parent.fields.summary
-  }
-  if (issue.fields.parent?.key) {
-    return issue.fields.parent.key
+export function getStoryPoints(
+  issue: JiraIssue,
+  config: IssueFieldConfig
+): number | null {
+  for (const field of config.storyPointsFields) {
+    const value = issue.fields[field]
+    if (typeof value === "number") return value
   }
   return null
+}
+
+export function getSprintName(
+  issue: JiraIssue,
+  config: IssueFieldConfig
+): string | null {
+  if (!config.sprintField) return null
+  const value = issue.fields[config.sprintField]
+  if (!Array.isArray(value)) return null
+
+  const sprints = value.filter(
+    (sprint): sprint is { name: string; state?: string } =>
+      Boolean(
+        sprint &&
+          typeof sprint === "object" &&
+          typeof (sprint as Record<string, unknown>).name === "string"
+      )
+  )
+  const current =
+    sprints.find((sprint) => sprint.state === "active") ??
+    sprints.find((sprint) => sprint.state === "future") ??
+    sprints[sprints.length - 1]
+  return current?.name ?? null
+}
+
+export function getEpicName(
+  issue: JiraIssue,
+  config: IssueFieldConfig
+): string | null {
+  const customValue = config.epicField
+    ? issue.fields[config.epicField]
+    : undefined
+  const customEpic = typeof customValue === "string" ? customValue : null
+
+  // A subtask's direct parent is a story/task, not its epic. Use an explicit
+  // Epic Link value when Jira exposes one instead of mislabeling that parent.
+  if (
+    issue.fields.issuetype?.subtask ||
+    issue.fields.issuetype?.hierarchyLevel === -1
+  ) {
+    return customEpic
+  }
+
+  // Only standard issues have an Epic as their direct parent. Higher-level
+  // issue types can have an Initiative or another custom hierarchy parent.
+  const hierarchyLevel = issue.fields.issuetype?.hierarchyLevel
+  if (hierarchyLevel === 0 || hierarchyLevel === undefined) {
+    if (issue.fields.parent?.fields?.summary) {
+      return issue.fields.parent.fields.summary
+    }
+    if (issue.fields.parent?.key) {
+      return issue.fields.parent.key
+    }
+  }
+  return customEpic
 }
 
 function buildJql(): string {
   const projects = optionalEnv("JIRA_PROJECTS")
   if (projects) {
-    const keys = projects.split(",").map((k) => k.trim()).filter(Boolean)
-    return `project IN (${keys.join(",")}) ORDER BY updated DESC`
+    const keys = projects
+      .split(",")
+      .map((key) => key.trim())
+      .filter(Boolean)
+      .map((key) => `"${key.replace(/"/g, '\\"')}"`)
+    if (keys.length > 0) {
+      return `project IN (${keys.join(",")}) ORDER BY updated DESC`
+    }
   }
-  return "ORDER BY updated DESC"
+
+  // Enhanced search rejects unbounded JQL. Jira issue timestamps cannot
+  // predate Unix time, so this preserves the documented all-projects behavior.
+  return 'created >= "1970-01-01" ORDER BY updated DESC'
 }
 
 type IssueSearchResponse = {
   issues: JiraIssue[]
-  startAt: number
-  maxResults: number
-  total: number
+  isLast?: boolean
+  nextPageToken?: string
+  warnings?: {
+    type?: string
+    message?: string
+  }[]
 }
 
+const INCOMPLETE_SEARCH_WARNINGS = new Set([
+  "CLAUSE_LIMIT_EXCEEDED",
+  "CLAUSE_RESULT_TRUNCATED",
+])
+
 export async function fetchIssuesPage(
-  startAt?: number
-): Promise<{ issues: JiraIssue[]; hasMore: boolean; nextStartAt: number }> {
+  config: IssueFieldConfig,
+  nextPageToken?: string
+): Promise<{
+  issues: JiraIssue[]
+  hasMore: boolean
+  nextPageToken?: string
+}> {
   const baseUrl = getBaseUrl()
-  const fields = getIssueFields()
-  const s = startAt ?? 0
-  const url = new URL(`${baseUrl}/rest/api/3/search`)
+  const fields = getIssueFields(config)
+  const url = new URL(`${baseUrl}/rest/api/3/search/jql`)
   url.searchParams.set("jql", buildJql())
   url.searchParams.set("fields", fields.join(","))
   url.searchParams.set("maxResults", "100")
-  url.searchParams.set("startAt", String(s))
+  url.searchParams.set("failFast", "true")
+  if (nextPageToken) {
+    url.searchParams.set("nextPageToken", nextPageToken)
+  }
 
   const body = await fetchJson<IssueSearchResponse>(url.toString())
+  const incompleteWarnings = (body.warnings ?? []).filter(
+    (warning) => warning.type && INCOMPLETE_SEARCH_WARNINGS.has(warning.type)
+  )
+  if (incompleteWarnings.length > 0) {
+    const details = incompleteWarnings
+      .map((warning) => warning.message || warning.type)
+      .join("; ")
+    throw new Error(`Jira search returned incomplete results: ${details}`)
+  }
+
+  const nextToken = body.nextPageToken || undefined
   return {
     issues: body.issues,
-    hasMore: s + body.issues.length < body.total,
-    nextStartAt: s + body.issues.length,
+    hasMore: body.isLast !== true && nextToken !== undefined,
+    nextPageToken: nextToken,
   }
 }
 
@@ -279,7 +457,7 @@ export async function fetchSprintsForBoard(
       nextStartAt: s + body.maxResults,
     }
   } catch (err) {
-    if (err instanceof Error && err.message.includes("404")) {
+    if (err instanceof JiraApiError && err.status === 404) {
       return { sprints: [], hasMore: false, nextStartAt: s }
     }
     throw err
@@ -315,9 +493,12 @@ export async function fetchProjectsPage(
 ): Promise<{ projects: JiraProject[]; hasMore: boolean; nextStartAt: number }> {
   const baseUrl = getBaseUrl()
   const s = startAt ?? 0
-  const url = `${baseUrl}/rest/api/3/project/search?startAt=${s}&maxResults=50`
+  const url = new URL(`${baseUrl}/rest/api/3/project/search`)
+  url.searchParams.set("startAt", String(s))
+  url.searchParams.set("maxResults", "50")
+  url.searchParams.set("expand", "description,lead")
 
-  const body = await fetchJson<ProjectSearchResponse>(url)
+  const body = await fetchJson<ProjectSearchResponse>(url.toString())
   return {
     projects: body.values,
     hasMore: !body.isLast,

--- a/examples/workers/syncs/jira/src/jira.ts
+++ b/examples/workers/syncs/jira/src/jira.ts
@@ -1,0 +1,326 @@
+// Jira Cloud REST API client. Handles authentication and paginated fetching
+// for issues, sprints, and projects.
+//
+// Uses two API surfaces:
+//   - Platform REST API v3 (/rest/api/3) for issues and projects
+//   - Agile REST API (/rest/agile/1.0) for boards and sprints
+//
+// To add a new resource:
+//   1. Add a type for the response shape
+//   2. Add a fetch function
+//   3. Wire it into index.ts
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`${name} is not set.`)
+  }
+  return value
+}
+
+function optionalEnv(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined
+}
+
+export function getBaseUrl(): string {
+  const domain = requireEnv("JIRA_DOMAIN")
+  return `https://${domain}.atlassian.net`
+}
+
+function getAuthHeader(): string {
+  const email = requireEnv("JIRA_EMAIL")
+  const token = requireEnv("JIRA_API_TOKEN")
+  return `Basic ${Buffer.from(`${email}:${token}`).toString("base64")}`
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: getAuthHeader(),
+      Accept: "application/json",
+    },
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Jira API error (${response.status}): ${text || "No response body"}`
+    )
+  }
+
+  return JSON.parse(text) as T
+}
+
+export function browseUrl(baseUrl: string, key: string): string {
+  return `${baseUrl}/browse/${key}`
+}
+
+// Custom field IDs cached at module level — these never change within a process.
+// Most Jira Cloud instances use customfield_10016 for story points.
+const STORY_POINTS_FIELD = optionalEnv("JIRA_STORY_POINTS_FIELD") ?? "customfield_10016"
+const EPIC_FIELD = optionalEnv("JIRA_EPIC_FIELD")
+
+// ---------------------------------------------------------------------------
+// Issues — searched via JQL
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/
+// ---------------------------------------------------------------------------
+
+export type JiraIssue = {
+  key: string
+  self: string
+  fields: {
+    summary: string
+    status: { name: string; statusCategory?: { name: string } } | null
+    issuetype: { name: string } | null
+    priority: { name: string } | null
+    assignee: { displayName: string } | null
+    reporter: { displayName: string } | null
+    project: { key: string; name: string } | null
+    labels: string[]
+    components: { name: string }[]
+    fixVersions: { name: string }[]
+    resolution: { name: string } | null
+    description: unknown
+    duedate: string | null
+    created: string
+    updated: string
+    sprint?: { name: string; state: string } | null
+    parent?: { key: string; fields?: { summary: string } } | null
+    [key: string]: unknown
+  }
+}
+
+const ISSUE_FIELDS = [
+  "summary",
+  "status",
+  "issuetype",
+  "priority",
+  "assignee",
+  "reporter",
+  "project",
+  "labels",
+  "components",
+  "fixVersions",
+  "resolution",
+  "description",
+  "duedate",
+  "created",
+  "updated",
+  "sprint",
+  "parent",
+]
+
+export function getIssueFields(): string[] {
+  const fields = [...ISSUE_FIELDS]
+  if (STORY_POINTS_FIELD) fields.push(STORY_POINTS_FIELD)
+  if (EPIC_FIELD) fields.push(EPIC_FIELD)
+  return fields
+}
+
+// Jira Cloud v3 returns descriptions in Atlassian Document Format (ADF),
+// a JSON tree structure. This extracts readable plain text from it.
+export function extractTextFromAdf(adf: unknown): string {
+  if (!adf || typeof adf !== "object") return ""
+  const node = adf as Record<string, unknown>
+
+  if (node.type === "text" && typeof node.text === "string") {
+    return node.text
+  }
+
+  const content = node.content
+  if (!Array.isArray(content)) return ""
+
+  const parts: string[] = []
+  for (const child of content) {
+    const text = extractTextFromAdf(child)
+    if (text) parts.push(text)
+  }
+
+  if (node.type === "paragraph" || node.type === "heading") {
+    return parts.join("") + "\n"
+  }
+  if (node.type === "bulletList" || node.type === "orderedList") {
+    return parts.map((p) => `- ${p.trim()}`).join("\n") + "\n"
+  }
+  if (node.type === "listItem") {
+    return parts.join("")
+  }
+  if (node.type === "codeBlock") {
+    return "```\n" + parts.join("") + "\n```\n"
+  }
+
+  return parts.join("")
+}
+
+export function getStoryPoints(issue: JiraIssue): number | null {
+  if (!STORY_POINTS_FIELD) return null
+  const value = issue.fields[STORY_POINTS_FIELD]
+  return typeof value === "number" ? value : null
+}
+
+export function getEpicName(issue: JiraIssue): string | null {
+  if (EPIC_FIELD) {
+    const value = issue.fields[EPIC_FIELD]
+    if (typeof value === "string") return value
+  }
+  if (issue.fields.parent?.fields?.summary) {
+    return issue.fields.parent.fields.summary
+  }
+  if (issue.fields.parent?.key) {
+    return issue.fields.parent.key
+  }
+  return null
+}
+
+function buildJql(): string {
+  const projects = optionalEnv("JIRA_PROJECTS")
+  if (projects) {
+    const keys = projects.split(",").map((k) => k.trim()).filter(Boolean)
+    return `project IN (${keys.join(",")}) ORDER BY updated DESC`
+  }
+  return "ORDER BY updated DESC"
+}
+
+type IssueSearchResponse = {
+  issues: JiraIssue[]
+  startAt: number
+  maxResults: number
+  total: number
+}
+
+export async function fetchIssuesPage(
+  startAt?: number
+): Promise<{ issues: JiraIssue[]; hasMore: boolean; nextStartAt: number }> {
+  const baseUrl = getBaseUrl()
+  const fields = getIssueFields()
+  const s = startAt ?? 0
+  const url = new URL(`${baseUrl}/rest/api/3/search`)
+  url.searchParams.set("jql", buildJql())
+  url.searchParams.set("fields", fields.join(","))
+  url.searchParams.set("maxResults", "100")
+  url.searchParams.set("startAt", String(s))
+
+  const body = await fetchJson<IssueSearchResponse>(url.toString())
+  return {
+    issues: body.issues,
+    hasMore: s + body.issues.length < body.total,
+    nextStartAt: s + body.issues.length,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sprints — fetched per Scrum board via the Agile API
+// https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/
+// ---------------------------------------------------------------------------
+
+export type JiraSprint = {
+  id: number
+  name: string
+  state: string
+  startDate: string | null
+  endDate: string | null
+  completeDate: string | null
+  goal: string | null
+  originBoardId: number
+}
+
+type BoardListResponse = {
+  values: { id: number; name: string }[]
+  startAt: number
+  maxResults: number
+  isLast: boolean
+}
+
+type SprintListResponse = {
+  values: JiraSprint[]
+  startAt: number
+  maxResults: number
+  isLast: boolean
+}
+
+export type BoardLookup = Map<number, string>
+
+export async function fetchAllBoards(
+  waitFn?: () => Promise<void>
+): Promise<BoardLookup> {
+  const baseUrl = getBaseUrl()
+  const boards: BoardLookup = new Map()
+  let startAt = 0
+
+  do {
+    if (waitFn) await waitFn()
+    const url = `${baseUrl}/rest/agile/1.0/board?type=scrum&startAt=${startAt}&maxResults=50`
+    const body = await fetchJson<BoardListResponse>(url)
+
+    for (const board of body.values) {
+      boards.set(board.id, board.name)
+    }
+
+    if (body.isLast) break
+    startAt += body.maxResults
+  } while (true)
+
+  return boards
+}
+
+export async function fetchSprintsForBoard(
+  boardId: number,
+  startAt?: number
+): Promise<{ sprints: JiraSprint[]; hasMore: boolean; nextStartAt: number }> {
+  const baseUrl = getBaseUrl()
+  const s = startAt ?? 0
+  const url = `${baseUrl}/rest/agile/1.0/board/${boardId}/sprint?startAt=${s}&maxResults=50`
+
+  try {
+    const body = await fetchJson<SprintListResponse>(url)
+    return {
+      sprints: body.values,
+      hasMore: !body.isLast,
+      nextStartAt: s + body.maxResults,
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("404")) {
+      return { sprints: [], hasMore: false, nextStartAt: s }
+    }
+    throw err
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/
+// ---------------------------------------------------------------------------
+
+export type JiraProject = {
+  id: string
+  key: string
+  name: string
+  description: string | null
+  self: string
+  projectTypeKey: string
+  lead?: { displayName: string } | null
+  projectCategory?: { name: string } | null
+}
+
+type ProjectSearchResponse = {
+  values: JiraProject[]
+  startAt: number
+  maxResults: number
+  isLast: boolean
+  total: number
+}
+
+export async function fetchProjectsPage(
+  startAt?: number
+): Promise<{ projects: JiraProject[]; hasMore: boolean; nextStartAt: number }> {
+  const baseUrl = getBaseUrl()
+  const s = startAt ?? 0
+  const url = `${baseUrl}/rest/api/3/project/search?startAt=${s}&maxResults=50`
+
+  const body = await fetchJson<ProjectSearchResponse>(url)
+  return {
+    projects: body.values,
+    hasMore: !body.isLast,
+    nextStartAt: s + body.maxResults,
+  }
+}

--- a/examples/workers/syncs/jira/src/projects.ts
+++ b/examples/workers/syncs/jira/src/projects.ts
@@ -5,7 +5,7 @@ import type { JiraProject } from "./jira.js"
 import { browseUrl } from "./jira.js"
 
 export const INITIAL_TITLE = "Jira Projects"
-export const PRIMARY_KEY = "Project Key"
+export const PRIMARY_KEY = "Jira Project ID"
 
 export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
   databaseIcon: notionIcon("folder"),
@@ -25,6 +25,8 @@ export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     ]),
 
     "Project Link": Schema.url(),
+
+    "Jira Project ID": Schema.richText(),
   },
 }
 
@@ -35,11 +37,12 @@ const TYPE_LABELS: Record<string, string> = {
 }
 
 export function projectToChange(project: JiraProject, baseUrl: string) {
-  const projectType = TYPE_LABELS[project.projectTypeKey] ?? project.projectTypeKey
+  const projectType =
+    TYPE_LABELS[project.projectTypeKey] ?? project.projectTypeKey
 
   return {
     type: "upsert" as const,
-    key: project.key,
+    key: project.id,
     pageContentMarkdown: project.description ?? "",
     properties: {
       Name: Builder.title(project.name),
@@ -52,6 +55,7 @@ export function projectToChange(project: JiraProject, baseUrl: string) {
         : {}),
       "Project Type": Builder.select(projectType),
       "Project Link": Builder.url(browseUrl(baseUrl, project.key)),
+      "Jira Project ID": Builder.richText(project.id),
     },
   }
 }

--- a/examples/workers/syncs/jira/src/projects.ts
+++ b/examples/workers/syncs/jira/src/projects.ts
@@ -1,0 +1,57 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import type { JiraProject } from "./jira.js"
+import { browseUrl } from "./jira.js"
+
+export const INITIAL_TITLE = "Jira Projects"
+export const PRIMARY_KEY = "Project Key"
+
+export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("folder"),
+  properties: {
+    Name: Schema.title(),
+
+    "Project Key": Schema.richText(),
+
+    Lead: Schema.richText(),
+
+    Category: Schema.select([]),
+
+    "Project Type": Schema.select([
+      { name: "Software" },
+      { name: "Business" },
+      { name: "Service Desk" },
+    ]),
+
+    "Project Link": Schema.url(),
+  },
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  software: "Software",
+  business: "Business",
+  service_desk: "Service Desk",
+}
+
+export function projectToChange(project: JiraProject, baseUrl: string) {
+  const projectType = TYPE_LABELS[project.projectTypeKey] ?? project.projectTypeKey
+
+  return {
+    type: "upsert" as const,
+    key: project.key,
+    pageContentMarkdown: project.description ?? "",
+    properties: {
+      Name: Builder.title(project.name),
+      "Project Key": Builder.richText(project.key),
+      ...(project.lead
+        ? { Lead: Builder.richText(project.lead.displayName) }
+        : {}),
+      ...(project.projectCategory
+        ? { Category: Builder.select(project.projectCategory.name) }
+        : {}),
+      "Project Type": Builder.select(projectType),
+      "Project Link": Builder.url(browseUrl(baseUrl, project.key)),
+    },
+  }
+}

--- a/examples/workers/syncs/jira/src/sprint-analytics.ts
+++ b/examples/workers/syncs/jira/src/sprint-analytics.ts
@@ -1,0 +1,809 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import { dateOnly } from "./helpers.js"
+
+export const ALL_SPRINTS_INITIAL_TITLE = "Jira Sprint Performance"
+export const ALL_SPRINTS_PRIMARY_KEY = "Sprint ID"
+
+export const allSprintsSchema: Schema.Schema<typeof ALL_SPRINTS_PRIMARY_KEY> = {
+  databaseIcon: notionIcon("chart-line"),
+  properties: {
+    Name: Schema.title(),
+    State: Schema.select([
+      { name: "Active" },
+      { name: "Closed" },
+      { name: "Future" },
+    ]),
+    Board: Schema.richText(),
+    Goal: Schema.richText(),
+    "Start Date": Schema.date(),
+    "End Date": Schema.date(),
+    "Complete Date": Schema.date(),
+    "Committed Issues": Schema.number(),
+    "Committed Points": Schema.number(),
+    "Current Issues": Schema.number(),
+    "Current Points": Schema.number(),
+    "Completed Issues": Schema.number(),
+    "Completed Points": Schema.number(),
+    "Added Issues": Schema.number(),
+    "Added Points": Schema.number(),
+    "Removed Issues": Schema.number(),
+    "Removed Points": Schema.number(),
+    "Estimate Change": Schema.number(),
+    "Net Scope Change": Schema.number(),
+    "Scope Change %": Schema.number("percent"),
+    "Rolled Over Issues": Schema.number(),
+    "Rolled Over Points": Schema.number(),
+    "Completion %": Schema.number("percent"),
+    "Predictability %": Schema.number("percent"),
+    Velocity: Schema.number(),
+    "3-Sprint Velocity": Schema.number(),
+    "5-Sprint Velocity": Schema.number(),
+    "Delivery Forecast": Schema.select([
+      { name: "Not Started" },
+      { name: "On Track" },
+      { name: "At Risk" },
+      { name: "Off Track" },
+      { name: "Delivered" },
+      { name: "Partially Delivered" },
+      { name: "Missed" },
+      { name: "No Scope" },
+      { name: "Insufficient Data" },
+    ]),
+    "Forecast Completion %": Schema.number("percent"),
+    "Days Remaining": Schema.number(),
+    "Estimation Basis": Schema.select([
+      { name: "Story Points" },
+      { name: "Issue Count" },
+    ]),
+    "Data Quality": Schema.select([
+      { name: "Complete" },
+      { name: "Partial" },
+      { name: "Limited" },
+    ]),
+    "Unestimated Issues": Schema.number(),
+    "Metrics Updated": Schema.date(),
+    "Board ID": Schema.richText(),
+    "Sprint ID": Schema.richText(),
+  },
+}
+
+export type SprintAnalyticsState = "active" | "closed" | "future"
+
+/**
+ * A period during which an issue belonged to this sprint. `enteredAt: null`
+ * means it was already in the sprint before the available history starts;
+ * `exitedAt: null` means it had not left by `evaluatedAt`.
+ */
+export type NormalizedSprintMembership = {
+  enteredAt: string | null
+  exitedAt: string | null
+}
+
+/**
+ * A point-in-time estimate. `at: null` is the baseline before the first known
+ * change. A null value is an explicitly unestimated issue, not missing data.
+ */
+export type NormalizedEstimate = {
+  at: string | null
+  value: number | null
+}
+
+/**
+ * A point-in-time completion state based on the board's Done column. `at:
+ * null` is the baseline state before the first known transition.
+ */
+export type NormalizedCompletion = {
+  at: string | null
+  completed: boolean
+}
+
+export type NormalizedSprintIssueTimeline = {
+  id: string
+  key: string
+  summary: string
+  url?: string
+  isSubtask?: boolean
+  memberships: NormalizedSprintMembership[]
+  estimates: NormalizedEstimate[]
+  completion: NormalizedCompletion[]
+  rollover?: {
+    sprintId: string
+    sprintName: string
+  } | null
+}
+
+export type SprintAnalyticsHistoryQuality = {
+  candidateSetComplete?: boolean
+  membershipComplete?: boolean
+  estimatesComplete?: boolean
+  completionComplete?: boolean
+  rolloverComplete?: boolean
+  notes?: string[]
+}
+
+/**
+ * Jira-specific changelog and board responses should be normalized into this
+ * input before calling the analytics helpers. `priorSprintVelocities` must be
+ * from the same board, newest first, and must not include the current sprint.
+ */
+export type SprintAnalyticsInput = {
+  id: string
+  name: string
+  state: SprintAnalyticsState
+  boardId?: string
+  boardName?: string
+  goal?: string
+  startAt: string
+  endAt: string
+  completeAt?: string
+  evaluatedAt: string
+  issues: NormalizedSprintIssueTimeline[]
+  estimationBasis?: "Story Points" | "Issue Count"
+  priorSprintVelocities?: number[]
+  historyQuality?: SprintAnalyticsHistoryQuality
+}
+
+export type DeliveryForecast =
+  | "Not Started"
+  | "On Track"
+  | "At Risk"
+  | "Off Track"
+  | "Delivered"
+  | "Partially Delivered"
+  | "Missed"
+  | "No Scope"
+  | "Insufficient Data"
+
+export type SprintDataQuality = "Complete" | "Partial" | "Limited"
+
+export type SprintAnalytics = {
+  cutoffAt: string
+  committedIssueCount: number
+  committedPoints: number
+  currentIssueCount: number
+  currentPoints: number
+  completedIssueCount: number
+  completedPoints: number
+  addedIssueCount: number
+  addedPoints: number
+  removedIssueCount: number
+  removedPoints: number
+  estimateChange: number
+  reconstructedScopePoints: number
+  netScopeChangePoints: number
+  scopeChangePercent: number | null
+  rolledOverIssueCount: number
+  rolledOverPoints: number
+  completionPercent: number | null
+  predictabilityPercent: number | null
+  velocity: number
+  rollingVelocity3: number | null
+  rollingVelocity5: number | null
+  deliveryForecast: DeliveryForecast
+  forecastCompletionPercent: number | null
+  daysRemaining: number
+  estimationBasis: "Story Points" | "Issue Count"
+  dataQuality: SprintDataQuality
+  dataQualityNotes: string[]
+  unestimatedIssueCount: number
+}
+
+type ClassifiedIssue = {
+  issue: NormalizedSprintIssueTimeline
+  committed: boolean
+  current: boolean
+  completed: boolean
+  added: boolean
+  removed: boolean
+  rolledOver: boolean
+  estimateAtCutoff: number | null
+  pointsAtCutoff: number
+}
+
+type Calculation = {
+  analytics: SprintAnalytics
+  issues: ClassifiedIssue[]
+}
+
+const DAY_MS = 24 * 60 * 60 * 1_000
+
+function timestamp(value: string, field: string): number {
+  const result = Date.parse(value)
+  if (Number.isNaN(result)) {
+    throw new Error(`${field} must be an ISO 8601 timestamp; received ${value}`)
+  }
+  return result
+}
+
+function optionalTimestamp(value: string | null): number {
+  return value === null
+    ? Number.NEGATIVE_INFINITY
+    : timestamp(value, "event.at")
+}
+
+function evaluationCutoff(input: SprintAnalyticsInput): number {
+  const evaluatedAt = timestamp(input.evaluatedAt, "evaluatedAt")
+  if (input.state !== "closed") return evaluatedAt
+
+  return timestamp(input.completeAt ?? input.endAt, "completeAt")
+}
+
+function isMemberAt(issue: NormalizedSprintIssueTimeline, at: number): boolean {
+  return issue.memberships.some((membership) => {
+    const enteredAt = optionalTimestamp(membership.enteredAt)
+    const exitedAt = membership.exitedAt
+      ? timestamp(membership.exitedAt, "membership.exitedAt")
+      : Number.POSITIVE_INFINITY
+    return enteredAt <= at && at < exitedAt
+  })
+}
+
+function estimateAt(
+  issue: NormalizedSprintIssueTimeline,
+  at: number
+): number | null {
+  let selected: NormalizedEstimate | undefined
+  let selectedAt = Number.NEGATIVE_INFINITY
+
+  for (const estimate of issue.estimates) {
+    const effectiveAt = optionalTimestamp(estimate.at)
+    if (effectiveAt <= at && effectiveAt >= selectedAt) {
+      selected = estimate
+      selectedAt = effectiveAt
+    }
+  }
+
+  return selected?.value ?? null
+}
+
+function completedAt(
+  issue: NormalizedSprintIssueTimeline,
+  at: number
+): boolean {
+  let selected: NormalizedCompletion | undefined
+  let selectedAt = Number.NEGATIVE_INFINITY
+
+  for (const state of issue.completion) {
+    const effectiveAt = optionalTimestamp(state.at)
+    if (effectiveAt <= at && effectiveAt >= selectedAt) {
+      selected = state
+      selectedAt = effectiveAt
+    }
+  }
+
+  return selected?.completed ?? false
+}
+
+function points(value: number | null): number {
+  return value ?? 0
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) return null
+  return values.reduce((total, value) => total + value, 0) / values.length
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator
+}
+
+function calculateDataQuality(
+  input: SprintAnalyticsInput,
+  unestimatedIssueCount: number
+): { quality: SprintDataQuality; notes: string[] } {
+  const quality = input.historyQuality
+  const notes = [...(quality?.notes ?? [])]
+
+  if (
+    quality?.candidateSetComplete === false &&
+    !notes.some((note) =>
+      note.toLowerCase().includes("removed before synchronization")
+    )
+  ) {
+    notes.push("Issues removed before synchronization may be missing.")
+  }
+  if (quality?.membershipComplete === false) {
+    notes.push("Sprint membership history is incomplete.")
+  }
+  if (quality?.completionComplete === false) {
+    notes.push("Completion history is incomplete.")
+  }
+  if (quality?.estimatesComplete === false) {
+    notes.push("Estimate history is incomplete.")
+  }
+  if (quality?.rolloverComplete === false) {
+    notes.push("Rollover detection is incomplete.")
+  }
+  if (unestimatedIssueCount > 0) {
+    notes.push(`${unestimatedIssueCount} in-scope issue(s) have no estimate.`)
+  }
+
+  const limited =
+    quality?.membershipComplete === false ||
+    quality?.completionComplete === false
+  const partial =
+    quality?.candidateSetComplete === false ||
+    quality?.estimatesComplete === false ||
+    quality?.rolloverComplete === false ||
+    unestimatedIssueCount > 0
+
+  return {
+    quality: limited ? "Limited" : partial ? "Partial" : "Complete",
+    notes: [...new Set(notes)],
+  }
+}
+
+function forecast(
+  input: SprintAnalyticsInput,
+  completedPoints: number,
+  completedIssueCount: number,
+  currentPoints: number,
+  currentIssueCount: number,
+  rollingVelocity3: number | null,
+  startAt: number,
+  endAt: number,
+  cutoffAt: number
+): {
+  label: DeliveryForecast
+  completion: number | null
+  basis: "Story Points" | "Issue Count"
+} {
+  const usePoints =
+    input.estimationBasis === "Story Points" ||
+    (input.estimationBasis === undefined && currentPoints > 0)
+  const scope = usePoints ? currentPoints : currentIssueCount
+  const completed = usePoints ? completedPoints : completedIssueCount
+  const basis = usePoints ? "Story Points" : "Issue Count"
+
+  if (scope === 0) {
+    return { label: "No Scope", completion: null, basis }
+  }
+
+  if (input.state === "future" || cutoffAt < startAt) {
+    return { label: "Not Started", completion: 0, basis }
+  }
+
+  if (input.state === "closed") {
+    const completion = completed / scope
+    const label =
+      completion >= 1
+        ? "Delivered"
+        : completion >= 0.8
+        ? "Partially Delivered"
+        : "Missed"
+    return { label, completion, basis }
+  }
+
+  if (rollingVelocity3 == null) {
+    return { label: "Insufficient Data", completion: null, basis }
+  }
+
+  const duration = Math.max(1, endAt - startAt)
+  const elapsedFraction = Math.min(
+    1,
+    Math.max(0, (cutoffAt - startAt) / duration)
+  )
+  const remainingFraction = 1 - elapsedFraction
+
+  const projected = completed + rollingVelocity3 * remainingFraction
+
+  const completion = Math.min(1, projected / scope)
+  const label =
+    completion >= 1 ? "On Track" : completion >= 0.8 ? "At Risk" : "Off Track"
+  return { label, completion, basis }
+}
+
+function calculate(input: SprintAnalyticsInput): Calculation {
+  const startAt = timestamp(input.startAt, "startAt")
+  const endAt = timestamp(input.endAt, "endAt")
+  const cutoffAt = evaluationCutoff(input)
+  if (endAt <= startAt) {
+    throw new Error("endAt must be after startAt")
+  }
+
+  const includedIssues = input.issues.filter((issue) => !issue.isSubtask)
+  const classified: ClassifiedIssue[] = includedIssues.map((issue) => {
+    const committed = isMemberAt(issue, startAt)
+    const current =
+      isMemberAt(issue, cutoffAt) ||
+      (input.state === "closed" && Boolean(issue.rollover))
+    const added = issue.memberships.some((membership) => {
+      if (!membership.enteredAt) return false
+      const enteredAt = timestamp(membership.enteredAt, "membership.enteredAt")
+      return enteredAt > startAt && enteredAt <= cutoffAt
+    })
+    const removed = issue.memberships.some((membership) => {
+      if (!membership.exitedAt) return false
+      const exitedAt = timestamp(membership.exitedAt, "membership.exitedAt")
+      return exitedAt > startAt && exitedAt < cutoffAt
+    })
+    const completed = current && completedAt(issue, cutoffAt)
+    const rolledOver =
+      input.state === "closed" &&
+      current &&
+      !completed &&
+      Boolean(issue.rollover)
+    const estimateAtCutoff = estimateAt(issue, cutoffAt)
+
+    return {
+      issue,
+      committed,
+      current,
+      completed,
+      added,
+      removed,
+      rolledOver,
+      estimateAtCutoff,
+      pointsAtCutoff: points(estimateAtCutoff),
+    }
+  })
+
+  const committed = classified.filter((item) => item.committed)
+  const current = classified.filter((item) => item.current)
+  const completed = classified.filter((item) => item.completed)
+  const added = classified.filter((item) => item.added)
+  const removed = classified.filter((item) => item.removed)
+  const rolledOver = classified.filter((item) => item.rolledOver)
+
+  const committedPoints = committed.reduce(
+    (total, item) => total + points(estimateAt(item.issue, startAt)),
+    0
+  )
+  const currentPoints = current.reduce(
+    (total, item) => total + item.pointsAtCutoff,
+    0
+  )
+  const completedPoints = completed.reduce(
+    (total, item) => total + item.pointsAtCutoff,
+    0
+  )
+
+  let addedPoints = 0
+  let removedPoints = 0
+  let estimateChange = 0
+
+  for (const item of classified) {
+    const enteredAt = item.issue.memberships
+      .map((membership) => membership.enteredAt)
+      .filter((value): value is string => value !== null)
+      .map((value) => timestamp(value, "membership.enteredAt"))
+      .filter((value) => value > startAt && value <= cutoffAt)
+      .sort((left, right) => left - right)[0]
+    if (enteredAt !== undefined) {
+      addedPoints += points(estimateAt(item.issue, enteredAt))
+    }
+
+    const exitedAt = item.issue.memberships
+      .map((membership) => membership.exitedAt)
+      .filter((value): value is string => value !== null)
+      .map((value) => timestamp(value, "membership.exitedAt"))
+      .filter((value) => value > startAt && value < cutoffAt)
+      .sort((left, right) => left - right)[0]
+    if (exitedAt !== undefined) {
+      removedPoints += points(estimateAt(item.issue, exitedAt))
+    }
+
+    const estimateEvents = item.issue.estimates
+      .filter((event) => event.at !== null)
+      .map((event) => ({
+        ...event,
+        time: timestamp(event.at as string, "estimate.at"),
+      }))
+      .filter((event) => event.time > startAt && event.time <= cutoffAt)
+      .sort((a, b) => a.time - b.time)
+
+    for (const event of estimateEvents) {
+      // Looking one millisecond before the change prevents an estimate set at
+      // the exact moment an issue enters the sprint from being double-counted.
+      if (!isMemberAt(item.issue, event.time - 1)) continue
+      const before = points(estimateAt(item.issue, event.time - 1))
+      estimateChange += points(event.value) - before
+    }
+  }
+
+  const rolledOverPoints = rolledOver.reduce(
+    (total, item) => total + item.pointsAtCutoff,
+    0
+  )
+  const unestimatedIssueCount = current.filter(
+    (item) => item.estimateAtCutoff === null
+  ).length
+  const previousVelocities = input.priorSprintVelocities ?? []
+  const usePoints =
+    input.estimationBasis === "Story Points" ||
+    (input.estimationBasis === undefined && currentPoints > 0)
+  const velocity = usePoints ? completedPoints : completed.length
+  const velocities =
+    input.state === "closed"
+      ? [velocity, ...previousVelocities]
+      : previousVelocities
+  const rollingVelocity3 =
+    velocities.length >= 3 ? average(velocities.slice(0, 3)) : null
+  const rollingVelocity5 =
+    velocities.length >= 5 ? average(velocities.slice(0, 5)) : null
+  const forecastResult = forecast(
+    input,
+    completedPoints,
+    completed.length,
+    currentPoints,
+    current.length,
+    rollingVelocity3,
+    startAt,
+    endAt,
+    cutoffAt
+  )
+  const quality = calculateDataQuality(input, unestimatedIssueCount)
+  const netScopeChangePoints = currentPoints - committedPoints
+
+  return {
+    issues: classified,
+    analytics: {
+      cutoffAt: new Date(cutoffAt).toISOString(),
+      committedIssueCount: committed.length,
+      committedPoints,
+      currentIssueCount: current.length,
+      currentPoints,
+      completedIssueCount: completed.length,
+      completedPoints,
+      addedIssueCount: added.length,
+      addedPoints,
+      removedIssueCount: removed.length,
+      removedPoints,
+      estimateChange,
+      reconstructedScopePoints:
+        committedPoints + addedPoints - removedPoints + estimateChange,
+      netScopeChangePoints,
+      scopeChangePercent: usePoints
+        ? ratio(netScopeChangePoints, committedPoints)
+        : ratio(current.length - committed.length, committed.length),
+      rolledOverIssueCount: rolledOver.length,
+      rolledOverPoints,
+      completionPercent:
+        forecastResult.basis === "Story Points"
+          ? ratio(completedPoints, currentPoints)
+          : ratio(completed.length, current.length),
+      predictabilityPercent:
+        forecastResult.basis === "Story Points"
+          ? ratio(completedPoints, committedPoints)
+          : ratio(completed.length, committed.length),
+      velocity,
+      rollingVelocity3,
+      rollingVelocity5,
+      deliveryForecast: forecastResult.label,
+      forecastCompletionPercent: forecastResult.completion,
+      daysRemaining:
+        input.state === "closed"
+          ? 0
+          : Math.max(0, Math.ceil((endAt - cutoffAt) / DAY_MS)),
+      estimationBasis: forecastResult.basis,
+      dataQuality: quality.quality,
+      dataQualityNotes: quality.notes,
+      unestimatedIssueCount,
+    },
+  }
+}
+
+export function calculateSprintAnalytics(
+  input: SprintAnalyticsInput
+): SprintAnalytics {
+  return calculate(input).analytics
+}
+
+export type SprintRosterOptions = {
+  maxIssuesPerGroup?: number
+}
+
+function issueMarkdown(
+  item: ClassifiedIssue,
+  estimationBasis: "Story Points" | "Issue Count"
+): string {
+  const key = item.issue.url
+    ? `[${item.issue.key}](${item.issue.url})`
+    : item.issue.key
+  const summary = item.issue.summary.replace(/[\r\n]+/g, " ").trim()
+  const estimate =
+    estimationBasis === "Issue Count"
+      ? "1 issue"
+      : item.estimateAtCutoff === null
+      ? "unestimated"
+      : `${item.pointsAtCutoff} pt${item.pointsAtCutoff === 1 ? "" : "s"}`
+  const rollover = item.issue.rollover
+    ? ` → ${item.issue.rollover.sprintName}`
+    : ""
+  return `- ${key} — ${summary} — ${estimate}${rollover}`
+}
+
+function rawIssueMarkdown(issue: NormalizedSprintIssueTimeline): string {
+  const key = issue.url ? `[${issue.key}](${issue.url})` : issue.key
+  const summary = issue.summary.replace(/[\r\n]+/g, " ").trim()
+  return `- ${key} — ${summary}`
+}
+
+function section(
+  title: string,
+  items: ClassifiedIssue[],
+  maxIssues: number,
+  estimationBasis: "Story Points" | "Issue Count"
+): string {
+  if (items.length === 0) return ""
+
+  const shown = items
+    .slice(0, maxIssues)
+    .map((item) => issueMarkdown(item, estimationBasis))
+  if (items.length > shown.length) {
+    shown.push(`- …and ${items.length - shown.length} more`)
+  }
+  return `## ${title}\n\n${shown.join("\n")}`
+}
+
+function rawIssueSection(
+  title: string,
+  issues: NormalizedSprintIssueTimeline[],
+  maxIssues: number
+): string {
+  if (issues.length === 0) return ""
+
+  const shown = issues.slice(0, maxIssues).map(rawIssueMarkdown)
+  if (issues.length > shown.length) {
+    shown.push(`- …and ${issues.length - shown.length} more`)
+  }
+  return `## ${title}\n\n${shown.join("\n")}`
+}
+
+export function renderSprintIssueRoster(
+  input: SprintAnalyticsInput,
+  options: SprintRosterOptions = {}
+): string {
+  const result = calculate(input)
+  const maxIssues = Math.max(1, options.maxIssuesPerGroup ?? 100)
+  const issues = result.issues
+  const estimationBasis = result.analytics.estimationBasis
+  const committed = issues.filter((item) => item.committed)
+  const added = issues.filter((item) => !item.committed && item.added)
+  const sections = [
+    input.goal ? `## Sprint Goal\n\n${input.goal.trim()}` : "",
+    section(
+      "Committed and completed",
+      committed.filter((item) => item.completed),
+      maxIssues,
+      estimationBasis
+    ),
+    section(
+      "Committed and incomplete",
+      committed.filter(
+        (item) => !item.completed && !item.removed && !item.rolledOver
+      ),
+      maxIssues,
+      estimationBasis
+    ),
+    section(
+      "Added after start and completed",
+      added.filter((item) => item.completed),
+      maxIssues,
+      estimationBasis
+    ),
+    section(
+      "Added after start and incomplete",
+      added.filter(
+        (item) => !item.completed && !item.removed && !item.rolledOver
+      ),
+      maxIssues,
+      estimationBasis
+    ),
+    section(
+      "Removed from sprint",
+      issues.filter((item) => item.removed),
+      maxIssues,
+      estimationBasis
+    ),
+    section(
+      "Rolled over",
+      issues.filter((item) => item.rolledOver),
+      maxIssues,
+      estimationBasis
+    ),
+    rawIssueSection(
+      "Subtasks",
+      input.issues.filter((issue) => issue.isSubtask),
+      maxIssues
+    ),
+  ].filter(Boolean)
+
+  if (result.analytics.dataQualityNotes.length > 0) {
+    sections.push(
+      `## Data quality\n\n${result.analytics.dataQualityNotes
+        .map((note) => `- ${note}`)
+        .join("\n")}`
+    )
+  }
+
+  return sections.join("\n\n")
+}
+
+const STATE_LABELS: Record<SprintAnalyticsState, string> = {
+  active: "Active",
+  closed: "Closed",
+  future: "Future",
+}
+
+export function sprintAnalyticsToChange(input: SprintAnalyticsInput) {
+  const metrics = calculateSprintAnalytics(input)
+  const pointProperties: Record<string, ReturnType<typeof Builder.number>> = {}
+  if (metrics.estimationBasis === "Story Points") {
+    pointProperties["Committed Points"] = Builder.number(
+      metrics.committedPoints
+    )
+    pointProperties["Current Points"] = Builder.number(metrics.currentPoints)
+    pointProperties["Completed Points"] = Builder.number(
+      metrics.completedPoints
+    )
+    pointProperties["Added Points"] = Builder.number(metrics.addedPoints)
+    pointProperties["Removed Points"] = Builder.number(metrics.removedPoints)
+    pointProperties["Estimate Change"] = Builder.number(metrics.estimateChange)
+    pointProperties["Rolled Over Points"] = Builder.number(
+      metrics.rolledOverPoints
+    )
+  }
+  return {
+    type: "upsert" as const,
+    key: input.id,
+    upstreamUpdatedAt: input.evaluatedAt,
+    pageContentMarkdown: renderSprintIssueRoster(input),
+    properties: {
+      Name: Builder.title(input.name),
+      State: Builder.select(STATE_LABELS[input.state]),
+      ...(input.boardName ? { Board: Builder.richText(input.boardName) } : {}),
+      ...(input.goal ? { Goal: Builder.richText(input.goal) } : {}),
+      "Start Date": Builder.date(dateOnly(input.startAt)),
+      "End Date": Builder.date(dateOnly(input.endAt)),
+      ...(input.completeAt
+        ? { "Complete Date": Builder.date(dateOnly(input.completeAt)) }
+        : {}),
+      "Committed Issues": Builder.number(metrics.committedIssueCount),
+      "Current Issues": Builder.number(metrics.currentIssueCount),
+      "Completed Issues": Builder.number(metrics.completedIssueCount),
+      "Added Issues": Builder.number(metrics.addedIssueCount),
+      "Removed Issues": Builder.number(metrics.removedIssueCount),
+      ...pointProperties,
+      "Net Scope Change": Builder.number(metrics.netScopeChangePoints),
+      ...(metrics.scopeChangePercent != null
+        ? { "Scope Change %": Builder.number(metrics.scopeChangePercent) }
+        : {}),
+      "Rolled Over Issues": Builder.number(metrics.rolledOverIssueCount),
+      ...(metrics.completionPercent != null
+        ? { "Completion %": Builder.number(metrics.completionPercent) }
+        : {}),
+      ...(metrics.predictabilityPercent != null
+        ? {
+            "Predictability %": Builder.number(metrics.predictabilityPercent),
+          }
+        : {}),
+      ...(input.state === "closed"
+        ? { Velocity: Builder.number(metrics.velocity) }
+        : {}),
+      ...(metrics.rollingVelocity3 != null
+        ? { "3-Sprint Velocity": Builder.number(metrics.rollingVelocity3) }
+        : {}),
+      ...(metrics.rollingVelocity5 != null
+        ? { "5-Sprint Velocity": Builder.number(metrics.rollingVelocity5) }
+        : {}),
+      "Delivery Forecast": Builder.select(metrics.deliveryForecast),
+      ...(metrics.forecastCompletionPercent != null
+        ? {
+            "Forecast Completion %": Builder.number(
+              metrics.forecastCompletionPercent
+            ),
+          }
+        : {}),
+      "Days Remaining": Builder.number(metrics.daysRemaining),
+      "Estimation Basis": Builder.select(metrics.estimationBasis),
+      "Data Quality": Builder.select(metrics.dataQuality),
+      "Unestimated Issues": Builder.number(metrics.unestimatedIssueCount),
+      "Metrics Updated": Builder.dateTime(input.evaluatedAt),
+      ...(input.boardId ? { "Board ID": Builder.richText(input.boardId) } : {}),
+      "Sprint ID": Builder.richText(input.id),
+    },
+  }
+}

--- a/examples/workers/syncs/jira/src/sprints.ts
+++ b/examples/workers/syncs/jira/src/sprints.ts
@@ -1,0 +1,74 @@
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import type { JiraSprint, BoardLookup } from "./jira.js"
+import { dateOnly } from "./helpers.js"
+
+export const INITIAL_TITLE = "Jira Sprints"
+export const PRIMARY_KEY = "Sprint ID"
+
+export const sprintSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("run"),
+  properties: {
+    Name: Schema.title(),
+
+    State: Schema.select([
+      { name: "Active" },
+      { name: "Closed" },
+      { name: "Future" },
+    ]),
+
+    Board: Schema.richText(),
+
+    "Start Date": Schema.date(),
+
+    "End Date": Schema.date(),
+
+    Goal: Schema.richText(),
+
+    "Complete Date": Schema.date(),
+
+    "Sprint ID": Schema.richText(),
+  },
+}
+
+const STATE_LABELS: Record<string, string> = {
+  active: "Active",
+  closed: "Closed",
+  future: "Future",
+}
+
+export function sprintToChange(
+  sprint: JiraSprint,
+  boards: BoardLookup
+) {
+  const state = STATE_LABELS[sprint.state] ?? sprint.state
+  const boardName = boards.get(sprint.originBoardId) ?? null
+
+  return {
+    type: "upsert" as const,
+    key: String(sprint.id),
+    upstreamUpdatedAt: sprint.endDate ?? sprint.startDate ?? "",
+    pageContentMarkdown: sprint.goal ?? "",
+    properties: {
+      Name: Builder.title(sprint.name),
+      State: Builder.select(state),
+      ...(boardName
+        ? { Board: Builder.richText(boardName) }
+        : {}),
+      ...(sprint.startDate
+        ? { "Start Date": Builder.date(dateOnly(sprint.startDate)) }
+        : {}),
+      ...(sprint.endDate
+        ? { "End Date": Builder.date(dateOnly(sprint.endDate)) }
+        : {}),
+      ...(sprint.goal
+        ? { Goal: Builder.richText(sprint.goal) }
+        : {}),
+      ...(sprint.completeDate
+        ? { "Complete Date": Builder.date(dateOnly(sprint.completeDate)) }
+        : {}),
+      "Sprint ID": Builder.richText(String(sprint.id)),
+    },
+  }
+}

--- a/examples/workers/syncs/jira/src/sprints.ts
+++ b/examples/workers/syncs/jira/src/sprints.ts
@@ -4,11 +4,11 @@ import { notionIcon } from "@notionhq/workers"
 import type { JiraSprint, BoardLookup } from "./jira.js"
 import { dateOnly } from "./helpers.js"
 
-export const INITIAL_TITLE = "Jira Sprints"
+export const INITIAL_TITLE = "Jira Current Sprints"
 export const PRIMARY_KEY = "Sprint ID"
 
 export const sprintSchema: Schema.Schema<typeof PRIMARY_KEY> = {
-  databaseIcon: notionIcon("run"),
+  databaseIcon: notionIcon("stopwatch"),
   properties: {
     Name: Schema.title(),
 

--- a/examples/workers/syncs/jira/src/sprints.ts
+++ b/examples/workers/syncs/jira/src/sprints.ts
@@ -38,33 +38,25 @@ const STATE_LABELS: Record<string, string> = {
   future: "Future",
 }
 
-export function sprintToChange(
-  sprint: JiraSprint,
-  boards: BoardLookup
-) {
+export function sprintToChange(sprint: JiraSprint, boards: BoardLookup) {
   const state = STATE_LABELS[sprint.state] ?? sprint.state
   const boardName = boards.get(sprint.originBoardId) ?? null
 
   return {
     type: "upsert" as const,
     key: String(sprint.id),
-    upstreamUpdatedAt: sprint.endDate ?? sprint.startDate ?? "",
     pageContentMarkdown: sprint.goal ?? "",
     properties: {
       Name: Builder.title(sprint.name),
       State: Builder.select(state),
-      ...(boardName
-        ? { Board: Builder.richText(boardName) }
-        : {}),
+      ...(boardName ? { Board: Builder.richText(boardName) } : {}),
       ...(sprint.startDate
         ? { "Start Date": Builder.date(dateOnly(sprint.startDate)) }
         : {}),
       ...(sprint.endDate
         ? { "End Date": Builder.date(dateOnly(sprint.endDate)) }
         : {}),
-      ...(sprint.goal
-        ? { Goal: Builder.richText(sprint.goal) }
-        : {}),
+      ...(sprint.goal ? { Goal: Builder.richText(sprint.goal) } : {}),
       ...(sprint.completeDate
         ? { "Complete Date": Builder.date(dateOnly(sprint.completeDate)) }
         : {}),

--- a/examples/workers/syncs/jira/test.ts
+++ b/examples/workers/syncs/jira/test.ts
@@ -1,13 +1,29 @@
 // Offline tests for the jira sync worker.
-// No Jira connection is made — all assertions run against pure functions.
+// No Jira connection is made — API assertions use mocked fetch responses.
 // Run: npm test  (or: npx tsx test.ts)
 
 import { issueToChange } from "./src/issues.js"
 import { sprintToChange } from "./src/sprints.js"
 import { projectToChange } from "./src/projects.js"
-import { browseUrl, getEpicName, getStoryPoints, extractTextFromAdf } from "./src/jira.js"
+import {
+  browseUrl,
+  extractTextFromAdf,
+  fetchIssuesPage,
+  fetchProjectsPage,
+  getEpicName,
+  getSprintName,
+  getStoryPoints,
+  resolveIssueFieldConfig,
+} from "./src/jira.js"
 import { dateOnly } from "./src/helpers.js"
-import type { JiraIssue, JiraSprint, JiraProject, BoardLookup } from "./src/jira.js"
+import { RateLimitError } from "@notionhq/workers"
+import type {
+  BoardLookup,
+  IssueFieldConfig,
+  JiraIssue,
+  JiraProject,
+  JiraSprint,
+} from "./src/jira.js"
 
 let passed = 0
 let failed = 0
@@ -23,6 +39,11 @@ function ok(name: string, cond: boolean) {
 }
 
 const BASE_URL = "https://acme.atlassian.net"
+const ISSUE_FIELD_CONFIG: IssueFieldConfig = {
+  sprintField: "customfield_10020",
+  storyPointsFields: ["customfield_10016", "customfield_10026"],
+  epicField: "customfield_10014",
+}
 
 // ---------------------------------------------------------------------------
 // issueToChange — standard issue
@@ -31,12 +52,13 @@ const BASE_URL = "https://acme.atlassian.net"
 console.log("issueToChange — standard issue:")
 
 const standardIssue: JiraIssue = {
+  id: "10001",
   key: "PROJ-123",
   self: "https://acme.atlassian.net/rest/api/3/issue/10001",
   fields: {
     summary: "Login button is broken on mobile",
     status: { name: "In Progress", statusCategory: { name: "In Progress" } },
-    issuetype: { name: "Bug" },
+    issuetype: { name: "Bug", subtask: false, hierarchyLevel: 0 },
     priority: { name: "High" },
     assignee: { displayName: "Alice Smith" },
     reporter: { displayName: "Bob Jones" },
@@ -48,26 +70,60 @@ const standardIssue: JiraIssue = {
     description: {
       type: "doc",
       content: [
-        { type: "paragraph", content: [{ type: "text", text: "The login button doesn't respond on iOS Safari." }] },
-        { type: "paragraph", content: [{ type: "text", text: "Steps to reproduce:" }] },
-        { type: "orderedList", content: [
-          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Open app on iPhone" }] }] },
-          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Tap login button" }] }] },
-        ] },
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "The login button doesn't respond on iOS Safari.",
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Steps to reproduce:" }],
+        },
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Open app on iPhone" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Tap login button" }],
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
     duedate: "2024-06-30",
     created: "2024-06-01T10:00:00.000Z",
     updated: "2024-06-16T14:00:00.000Z",
-    sprint: { name: "Sprint 42", state: "active" },
     parent: { key: "PROJ-100", fields: { summary: "Mobile Improvements" } },
+    customfield_10020: [
+      { id: 40, name: "Sprint 40", state: "closed" },
+      { id: 42, name: "Sprint 42", state: "active" },
+    ],
+    customfield_10016: 5,
   },
 }
 
-const issueChange = issueToChange(standardIssue, BASE_URL)
+const issueChange = issueToChange(standardIssue, BASE_URL, ISSUE_FIELD_CONFIG)
 
 ok("type is upsert", issueChange.type === "upsert")
-ok("key is issue key", issueChange.key === "PROJ-123")
+ok("key is immutable issue id", issueChange.key === "10001")
 ok(
   "Summary is set",
   JSON.stringify(issueChange.properties.Summary).includes("Login button")
@@ -89,12 +145,18 @@ ok(
   JSON.stringify(issueChange.properties.Sprint).includes("Sprint 42")
 )
 ok(
+  "Story Points is set",
+  JSON.stringify(issueChange.properties["Story Points"]).includes("5")
+)
+ok(
   "Updated is set",
   JSON.stringify(issueChange.properties.Updated).includes("2024-06-16")
 )
 ok(
   "Status Category is set",
-  JSON.stringify(issueChange.properties["Status Category"]).includes("In Progress")
+  JSON.stringify(issueChange.properties["Status Category"]).includes(
+    "In Progress"
+  )
 )
 ok(
   "Priority is set",
@@ -128,7 +190,10 @@ ok(
   "Fix Versions is set",
   JSON.stringify(issueChange.properties["Fix Versions"]).includes("v2.1")
 )
-ok("null resolution omits Resolution", issueChange.properties.Resolution === undefined)
+ok(
+  "null resolution omits Resolution",
+  issueChange.properties.Resolution === undefined
+)
 ok(
   "Due Date is set",
   JSON.stringify(issueChange.properties["Due Date"]).includes("2024-06-30")
@@ -142,8 +207,12 @@ ok(
   JSON.stringify(issueChange.properties.Created).includes("2024-06-01")
 )
 ok(
-  "Issue Key is last",
+  "Issue Key is set",
   JSON.stringify(issueChange.properties["Issue Key"]).includes("PROJ-123")
+)
+ok(
+  "Jira Issue ID is set",
+  JSON.stringify(issueChange.properties["Jira Issue ID"]).includes("10001")
 )
 ok(
   "pageContentMarkdown contains description text",
@@ -165,7 +234,11 @@ const resolvedIssue: JiraIssue = {
   },
 }
 
-const resolvedChange = issueToChange(resolvedIssue, BASE_URL)
+const resolvedChange = issueToChange(
+  resolvedIssue,
+  BASE_URL,
+  ISSUE_FIELD_CONFIG
+)
 
 ok(
   "Status is Done",
@@ -187,6 +260,7 @@ ok(
 console.log("issueToChange — minimal issue:")
 
 const minimalIssue: JiraIssue = {
+  id: "1",
   key: "PROJ-1",
   self: "https://acme.atlassian.net/rest/api/3/issue/1",
   fields: {
@@ -205,27 +279,53 @@ const minimalIssue: JiraIssue = {
     duedate: null,
     created: "2024-01-01",
     updated: "2024-01-01",
-    sprint: null,
     parent: null,
   },
 }
 
-const minimalChange = issueToChange(minimalIssue, BASE_URL)
+const minimalChange = issueToChange(minimalIssue, BASE_URL, ISSUE_FIELD_CONFIG)
 
 ok("null status omits Status", minimalChange.properties.Status === undefined)
-ok("null status omits Status Category", minimalChange.properties["Status Category"] === undefined)
-ok("null issuetype omits Issue Type", minimalChange.properties["Issue Type"] === undefined)
-ok("null priority omits Priority", minimalChange.properties.Priority === undefined)
-ok("null assignee omits Assignee", minimalChange.properties.Assignee === undefined)
-ok("null reporter omits Reporter", minimalChange.properties.Reporter === undefined)
+ok(
+  "null status omits Status Category",
+  minimalChange.properties["Status Category"] === undefined
+)
+ok(
+  "null issuetype omits Issue Type",
+  minimalChange.properties["Issue Type"] === undefined
+)
+ok(
+  "null priority omits Priority",
+  minimalChange.properties.Priority === undefined
+)
+ok(
+  "null assignee omits Assignee",
+  minimalChange.properties.Assignee === undefined
+)
+ok(
+  "null reporter omits Reporter",
+  minimalChange.properties.Reporter === undefined
+)
 ok("null project omits Project", minimalChange.properties.Project === undefined)
 ok("null sprint omits Sprint", minimalChange.properties.Sprint === undefined)
 ok("null parent omits Epic", minimalChange.properties.Epic === undefined)
 ok("empty labels omits Labels", minimalChange.properties.Labels === undefined)
-ok("empty components omits Components", minimalChange.properties.Components === undefined)
-ok("empty fixVersions omits Fix Versions", minimalChange.properties["Fix Versions"] === undefined)
-ok("null duedate omits Due Date", minimalChange.properties["Due Date"] === undefined)
-ok("null description gives empty pageContentMarkdown", minimalChange.pageContentMarkdown === "")
+ok(
+  "empty components omits Components",
+  minimalChange.properties.Components === undefined
+)
+ok(
+  "empty fixVersions omits Fix Versions",
+  minimalChange.properties["Fix Versions"] === undefined
+)
+ok(
+  "null duedate omits Due Date",
+  minimalChange.properties["Due Date"] === undefined
+)
+ok(
+  "null description gives empty pageContentMarkdown",
+  minimalChange.pageContentMarkdown === ""
+)
 
 // ---------------------------------------------------------------------------
 // getEpicName — resolves epic from parent
@@ -235,15 +335,61 @@ console.log("getEpicName:")
 
 ok(
   "parent with summary returns summary",
-  getEpicName(standardIssue) === "Mobile Improvements"
+  getEpicName(standardIssue, ISSUE_FIELD_CONFIG) === "Mobile Improvements"
 )
 
 const parentKeyOnly: JiraIssue = {
   ...minimalIssue,
   fields: { ...minimalIssue.fields, parent: { key: "PROJ-50" } },
 }
-ok("parent with key only returns key", getEpicName(parentKeyOnly) === "PROJ-50")
-ok("null parent returns null", getEpicName(minimalIssue) === null)
+ok(
+  "parent with key only returns key",
+  getEpicName(parentKeyOnly, ISSUE_FIELD_CONFIG) === "PROJ-50"
+)
+ok(
+  "null parent returns null",
+  getEpicName(minimalIssue, ISSUE_FIELD_CONFIG) === null
+)
+
+const subtaskIssue: JiraIssue = {
+  ...minimalIssue,
+  fields: {
+    ...minimalIssue.fields,
+    issuetype: { name: "Sub-task", subtask: true, hierarchyLevel: -1 },
+    parent: {
+      key: "PROJ-10",
+      fields: { summary: "Parent task, not an epic" },
+    },
+  },
+}
+ok(
+  "subtask parent is not mislabeled as epic",
+  getEpicName(subtaskIssue, ISSUE_FIELD_CONFIG) === null
+)
+
+const epicWithInitiativeParent: JiraIssue = {
+  ...minimalIssue,
+  fields: {
+    ...minimalIssue.fields,
+    issuetype: { name: "Epic", subtask: false, hierarchyLevel: 1 },
+    parent: {
+      key: "PROJ-5",
+      fields: { summary: "Initiative, not an epic" },
+    },
+  },
+}
+ok(
+  "higher-level parent is not mislabeled as epic",
+  getEpicName(epicWithInitiativeParent, ISSUE_FIELD_CONFIG) === null
+)
+ok(
+  "active sprint is selected from custom field array",
+  getSprintName(standardIssue, ISSUE_FIELD_CONFIG) === "Sprint 42"
+)
+ok(
+  "story points use the configured custom field",
+  getStoryPoints(standardIssue, ISSUE_FIELD_CONFIG) === 5
+)
 
 // ---------------------------------------------------------------------------
 // sprintToChange — standard sprint
@@ -251,9 +397,7 @@ ok("null parent returns null", getEpicName(minimalIssue) === null)
 
 console.log("sprintToChange — standard sprint:")
 
-const boards: BoardLookup = new Map([
-  [10, "Engineering Board"],
-])
+const boards: BoardLookup = new Map([[10, "Engineering Board"]])
 
 const activeSprint: JiraSprint = {
   id: 42,
@@ -293,7 +437,10 @@ ok(
   "Goal is set",
   JSON.stringify(sprintChange.properties.Goal).includes("mobile login")
 )
-ok("null completeDate omits Complete Date", sprintChange.properties["Complete Date"] === undefined)
+ok(
+  "null completeDate omits Complete Date",
+  sprintChange.properties["Complete Date"] === undefined
+)
 ok(
   "pageContentMarkdown contains goal",
   sprintChange.pageContentMarkdown.includes("mobile login")
@@ -319,7 +466,9 @@ ok(
 )
 ok(
   "Complete Date is set",
-  JSON.stringify(closedSprintChange.properties["Complete Date"]).includes("2024-06-23")
+  JSON.stringify(closedSprintChange.properties["Complete Date"]).includes(
+    "2024-06-23"
+  )
 )
 
 // ---------------------------------------------------------------------------
@@ -341,9 +490,18 @@ const minimalSprint: JiraSprint = {
 
 const minimalSprintChange = sprintToChange(minimalSprint, boards)
 
-ok("unknown board omits Board", minimalSprintChange.properties.Board === undefined)
-ok("null startDate omits Start Date", minimalSprintChange.properties["Start Date"] === undefined)
-ok("null endDate omits End Date", minimalSprintChange.properties["End Date"] === undefined)
+ok(
+  "unknown board omits Board",
+  minimalSprintChange.properties.Board === undefined
+)
+ok(
+  "null startDate omits Start Date",
+  minimalSprintChange.properties["Start Date"] === undefined
+)
+ok(
+  "null endDate omits End Date",
+  minimalSprintChange.properties["End Date"] === undefined
+)
 ok("null goal omits Goal", minimalSprintChange.properties.Goal === undefined)
 
 // ---------------------------------------------------------------------------
@@ -365,7 +523,7 @@ const standardProject: JiraProject = {
 
 const projectChange = projectToChange(standardProject, BASE_URL)
 
-ok("key is project key", projectChange.key === "PROJ")
+ok("key is immutable project id", projectChange.key === "10001")
 ok(
   "Name is set",
   JSON.stringify(projectChange.properties.Name).includes("Project Alpha")
@@ -393,6 +551,10 @@ ok(
   )
 )
 ok(
+  "Jira Project ID is set",
+  JSON.stringify(projectChange.properties["Jira Project ID"]).includes("10001")
+)
+ok(
   "pageContentMarkdown contains description",
   projectChange.pageContentMarkdown === "The main engineering project."
 )
@@ -417,8 +579,14 @@ const minimalProject: JiraProject = {
 const minimalProjectChange = projectToChange(minimalProject, BASE_URL)
 
 ok("null lead omits Lead", minimalProjectChange.properties.Lead === undefined)
-ok("null category omits Category", minimalProjectChange.properties.Category === undefined)
-ok("null description gives empty pageContentMarkdown", minimalProjectChange.pageContentMarkdown === "")
+ok(
+  "null category omits Category",
+  minimalProjectChange.properties.Category === undefined
+)
+ok(
+  "null description gives empty pageContentMarkdown",
+  minimalProjectChange.pageContentMarkdown === ""
+)
 
 // ---------------------------------------------------------------------------
 // extractTextFromAdf — converts Atlassian Document Format to plain text
@@ -448,13 +616,13 @@ ok(
       { type: "paragraph", content: [{ type: "text", text: "Second" }] },
     ],
   }).includes("First") &&
-  extractTextFromAdf({
-    type: "doc",
-    content: [
-      { type: "paragraph", content: [{ type: "text", text: "First" }] },
-      { type: "paragraph", content: [{ type: "text", text: "Second" }] },
-    ],
-  }).includes("Second")
+    extractTextFromAdf({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "First" }] },
+        { type: "paragraph", content: [{ type: "text", text: "Second" }] },
+      ],
+    }).includes("Second")
 )
 
 ok(
@@ -462,10 +630,29 @@ ok(
   extractTextFromAdf({
     type: "doc",
     content: [
-      { type: "bulletList", content: [
-        { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Item one" }] }] },
-        { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Item two" }] }] },
-      ] },
+      {
+        type: "bulletList",
+        content: [
+          {
+            type: "listItem",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Item one" }],
+              },
+            ],
+          },
+          {
+            type: "listItem",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Item two" }],
+              },
+            ],
+          },
+        ],
+      },
     ],
   }).includes("- Item one")
 )
@@ -478,6 +665,23 @@ ok(
       { type: "codeBlock", content: [{ type: "text", text: "const x = 1" }] },
     ],
   }).includes("```")
+)
+
+ok(
+  "hard break is preserved",
+  extractTextFromAdf({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "First line" },
+          { type: "hardBreak" },
+          { type: "text", text: "Second line" },
+        ],
+      },
+    ],
+  }).includes("First line\nSecond line")
 )
 
 // ---------------------------------------------------------------------------
@@ -498,9 +702,207 @@ ok(
 
 console.log("dateOnly:")
 
-ok("ISO timestamp returns date part", dateOnly("2024-03-15T12:00:00Z") === "2024-03-15")
+ok(
+  "ISO timestamp returns date part",
+  dateOnly("2024-03-15T12:00:00Z") === "2024-03-15"
+)
 ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
 ok("empty string returns empty", dateOnly("") === "")
 
-console.log(`\n${passed} passed, ${failed} failed`)
-if (failed > 0) process.exit(1)
+// ---------------------------------------------------------------------------
+// API client — field discovery, enhanced search, expansions, and rate limits
+// ---------------------------------------------------------------------------
+
+async function runApiClientTests() {
+  console.log("API client:")
+
+  const envNames = [
+    "JIRA_DOMAIN",
+    "JIRA_EMAIL",
+    "JIRA_API_TOKEN",
+    "JIRA_PROJECTS",
+    "JIRA_SPRINT_FIELD",
+    "JIRA_STORY_POINTS_FIELD",
+    "JIRA_EPIC_FIELD",
+  ] as const
+  const savedEnv = Object.fromEntries(
+    envNames.map((name) => [name, process.env[name]])
+  )
+  const originalFetch = globalThis.fetch
+
+  process.env.JIRA_DOMAIN = "acme"
+  process.env.JIRA_EMAIL = "test@example.com"
+  process.env.JIRA_API_TOKEN = "test-token"
+  delete process.env.JIRA_PROJECTS
+  delete process.env.JIRA_SPRINT_FIELD
+  delete process.env.JIRA_STORY_POINTS_FIELD
+  delete process.env.JIRA_EPIC_FIELD
+
+  try {
+    const discovered = resolveIssueFieldConfig([
+      {
+        id: "customfield_20001",
+        name: "Sprint",
+        schema: { custom: "com.pyxis.greenhopper.jira:gh-sprint" },
+      },
+      {
+        id: "customfield_20002",
+        name: "Story Points",
+        schema: { type: "number" },
+      },
+      {
+        id: "customfield_20004",
+        name: "Story point estimate",
+        schema: { type: "number" },
+      },
+      {
+        id: "customfield_20003",
+        name: "Epic Link",
+        schema: { custom: "com.pyxis.greenhopper.jira:gh-epic-link" },
+      },
+    ])
+    ok(
+      "discovers Jira Software custom field ids",
+      discovered.sprintField === "customfield_20001" &&
+        discovered.storyPointsFields.join(",") ===
+          "customfield_20002,customfield_20004" &&
+        discovered.epicField === "customfield_20003"
+    )
+
+    const teamManagedIssue: JiraIssue = {
+      ...minimalIssue,
+      fields: {
+        ...minimalIssue.fields,
+        customfield_20004: 8,
+      },
+    }
+    ok(
+      "uses the populated story point field for each issue",
+      getStoryPoints(teamManagedIssue, discovered) === 8
+    )
+
+    let issueRequest: URL | undefined
+    globalThis.fetch = (async (input) => {
+      issueRequest = new URL(String(input))
+      return new Response(
+        JSON.stringify({
+          issues: [minimalIssue],
+          isLast: false,
+          nextPageToken: "cursor-2",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    const issuePage = await fetchIssuesPage(ISSUE_FIELD_CONFIG, "cursor-1")
+    ok(
+      "uses enhanced issue search endpoint",
+      issueRequest?.pathname === "/rest/api/3/search/jql"
+    )
+    ok(
+      "uses token pagination",
+      issueRequest?.searchParams.get("nextPageToken") === "cursor-1" &&
+        issueRequest?.searchParams.get("failFast") === "true" &&
+        issuePage.nextPageToken === "cursor-2" &&
+        issuePage.hasMore
+    )
+    ok(
+      "uses bounded JQL when no project filter is configured",
+      issueRequest?.searchParams
+        .get("jql")
+        ?.includes('created >= "1970-01-01"') === true
+    )
+    ok(
+      "requests discovered custom fields",
+      issueRequest?.searchParams
+        .get("fields")
+        ?.includes("customfield_10020") === true
+    )
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          issues: [minimalIssue],
+          isLast: true,
+          warnings: [
+            {
+              type: "CLAUSE_RESULT_TRUNCATED",
+              message: "Results were truncated",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )) as typeof fetch
+
+    let incompleteSearchError: unknown
+    try {
+      await fetchIssuesPage(ISSUE_FIELD_CONFIG)
+    } catch (error) {
+      incompleteSearchError = error
+    }
+    ok(
+      "rejects incomplete enhanced-search snapshots",
+      incompleteSearchError instanceof Error &&
+        incompleteSearchError.message.includes("Results were truncated")
+    )
+
+    let projectRequest: URL | undefined
+    globalThis.fetch = (async (input) => {
+      projectRequest = new URL(String(input))
+      return new Response(
+        JSON.stringify({
+          values: [standardProject],
+          startAt: 0,
+          maxResults: 50,
+          isLast: true,
+          total: 1,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    await fetchProjectsPage()
+    ok(
+      "expands project description and lead",
+      projectRequest?.searchParams.get("expand") === "description,lead"
+    )
+
+    globalThis.fetch = (async () =>
+      new Response("rate limited", {
+        status: 429,
+        headers: { "Retry-After": "7" },
+      })) as typeof fetch
+
+    let rateLimitError: unknown
+    try {
+      await fetchProjectsPage()
+    } catch (error) {
+      rateLimitError = error
+    }
+    ok(
+      "surfaces Retry-After through RateLimitError",
+      rateLimitError instanceof RateLimitError &&
+        rateLimitError.retryAfter === 7
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    for (const name of envNames) {
+      const value = savedEnv[name]
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+  }
+}
+
+runApiClientTests()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`)
+    if (failed > 0) process.exit(1)
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/examples/workers/syncs/jira/test.ts
+++ b/examples/workers/syncs/jira/test.ts
@@ -1,6 +1,6 @@
 // Offline tests for the jira sync worker.
 // No Jira connection is made — API assertions use mocked fetch responses.
-// Run: npm test  (or: npx tsx test.ts)
+// Run: npm test
 
 import { issueToChange } from "./src/issues.js"
 import { sprintToChange } from "./src/sprints.js"
@@ -8,8 +8,12 @@ import { projectToChange } from "./src/projects.js"
 import {
   browseUrl,
   extractTextFromAdf,
+  fetchBoardConfiguration,
+  fetchBulkChangelogsPage,
   fetchIssuesPage,
   fetchProjectsPage,
+  fetchSprintIssuesPage,
+  fetchSprintsForBoard,
   getEpicName,
   getSprintName,
   getStoryPoints,
@@ -844,6 +848,151 @@ async function runApiClientTests() {
       "rejects incomplete enhanced-search snapshots",
       incompleteSearchError instanceof Error &&
         incompleteSearchError.message.includes("Results were truncated")
+    )
+
+    let sprintListRequest: URL | undefined
+    globalThis.fetch = (async (input) => {
+      sprintListRequest = new URL(String(input))
+      return new Response(
+        JSON.stringify({
+          values: [activeSprint],
+          startAt: 0,
+          maxResults: 50,
+          isLast: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    const sprintListPage = await fetchSprintsForBoard(10, 0, [
+      "active",
+      "future",
+      "active",
+    ])
+    ok(
+      "filters board sprints by state",
+      sprintListRequest?.pathname === "/rest/agile/1.0/board/10/sprint" &&
+        sprintListRequest.searchParams.get("state") === "active,future" &&
+        sprintListPage.sprints[0]?.id === 42 &&
+        !sprintListPage.hasMore
+    )
+
+    let boardConfigurationRequest: URL | undefined
+    globalThis.fetch = (async (input) => {
+      boardConfigurationRequest = new URL(String(input))
+      return new Response(
+        JSON.stringify({
+          estimation: {
+            type: "field",
+            field: {
+              fieldId: "customfield_10016",
+              displayName: "Story Points",
+            },
+          },
+          columnConfig: {
+            columns: [
+              { name: "To Do", statuses: [{ id: "1" }] },
+              { name: "Done", statuses: [{ id: "5" }, { id: "6" }] },
+              { name: "Unmapped", statuses: [] },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    const boardConfiguration = await fetchBoardConfiguration(10)
+    ok(
+      "reads board estimation and rightmost nonempty Done statuses",
+      boardConfigurationRequest?.pathname ===
+        "/rest/agile/1.0/board/10/configuration" &&
+        boardConfiguration.estimationType === "field" &&
+        boardConfiguration.estimationFieldId === "customfield_10016" &&
+        boardConfiguration.estimationFieldName === "Story Points" &&
+        boardConfiguration.doneStatusIds.join(",") === "5,6"
+    )
+
+    let sprintIssuesRequest: URL | undefined
+    globalThis.fetch = (async (input) => {
+      sprintIssuesRequest = new URL(String(input))
+      return new Response(
+        JSON.stringify({
+          issues: [minimalIssue],
+          isLast: false,
+          nextPageToken: "sprint-cursor-2",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    const sprintIssuesPage = await fetchSprintIssuesPage(42, {
+      fields: ["summary", "status", "summary"],
+      nextPageToken: "sprint-cursor-1",
+    })
+    ok(
+      "uses enhanced sprint issue endpoint and cursor pagination",
+      sprintIssuesRequest?.pathname === "/rest/software/1.0/sprint/42/issue" &&
+        sprintIssuesRequest.searchParams.get("nextPageToken") ===
+          "sprint-cursor-1" &&
+        sprintIssuesRequest.searchParams.get("fields") === "summary,status" &&
+        sprintIssuesPage.nextPageToken === "sprint-cursor-2" &&
+        sprintIssuesPage.hasMore
+    )
+
+    let changelogRequest: URL | undefined
+    let changelogRequestInit: RequestInit | undefined
+    globalThis.fetch = (async (input, init) => {
+      changelogRequest = new URL(String(input))
+      changelogRequestInit = init
+      return new Response(
+        JSON.stringify({
+          issueChangeLogs: [
+            {
+              issueId: "10001",
+              changeHistories: [
+                {
+                  id: "20001",
+                  created: 1_712_000_000,
+                  items: [
+                    {
+                      field: "Sprint",
+                      fieldId: "customfield_10020",
+                      from: "40",
+                      fromString: "Sprint 40",
+                      to: "42",
+                      toString: "Sprint 42",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          nextPageToken: "changelog-cursor-2",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    const changelogPage = await fetchBulkChangelogsPage(["10001"], {
+      fieldIds: ["customfield_10020", "status"],
+      nextPageToken: "changelog-cursor-1",
+      maxResults: 500,
+    })
+    const changelogRequestBody = JSON.parse(
+      String(changelogRequestInit?.body)
+    ) as Record<string, unknown>
+    ok(
+      "posts bulk changelog filters and cursor",
+      changelogRequest?.pathname === "/rest/api/3/changelog/bulkfetch" &&
+        changelogRequestInit?.method === "POST" &&
+        JSON.stringify(changelogRequestBody.issueIdsOrKeys) === '["10001"]' &&
+        JSON.stringify(changelogRequestBody.fieldIds) ===
+          '["customfield_10020","status"]' &&
+        changelogRequestBody.nextPageToken === "changelog-cursor-1" &&
+        changelogRequestBody.maxResults === 500 &&
+        changelogPage.issueChangeLogs[0]?.issueId === "10001" &&
+        changelogPage.nextPageToken === "changelog-cursor-2" &&
+        changelogPage.hasMore
     )
 
     let projectRequest: URL | undefined

--- a/examples/workers/syncs/jira/test.ts
+++ b/examples/workers/syncs/jira/test.ts
@@ -1,0 +1,506 @@
+// Offline tests for the jira sync worker.
+// No Jira connection is made — all assertions run against pure functions.
+// Run: npm test  (or: npx tsx test.ts)
+
+import { issueToChange } from "./src/issues.js"
+import { sprintToChange } from "./src/sprints.js"
+import { projectToChange } from "./src/projects.js"
+import { browseUrl, getEpicName, getStoryPoints, extractTextFromAdf } from "./src/jira.js"
+import { dateOnly } from "./src/helpers.js"
+import type { JiraIssue, JiraSprint, JiraProject, BoardLookup } from "./src/jira.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, cond: boolean) {
+  if (cond) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+const BASE_URL = "https://acme.atlassian.net"
+
+// ---------------------------------------------------------------------------
+// issueToChange — standard issue
+// ---------------------------------------------------------------------------
+
+console.log("issueToChange — standard issue:")
+
+const standardIssue: JiraIssue = {
+  key: "PROJ-123",
+  self: "https://acme.atlassian.net/rest/api/3/issue/10001",
+  fields: {
+    summary: "Login button is broken on mobile",
+    status: { name: "In Progress", statusCategory: { name: "In Progress" } },
+    issuetype: { name: "Bug" },
+    priority: { name: "High" },
+    assignee: { displayName: "Alice Smith" },
+    reporter: { displayName: "Bob Jones" },
+    project: { key: "PROJ", name: "Project Alpha" },
+    labels: ["frontend", "mobile"],
+    components: [{ name: "Web App" }, { name: "Auth" }],
+    fixVersions: [{ name: "v2.1" }],
+    resolution: null,
+    description: {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "The login button doesn't respond on iOS Safari." }] },
+        { type: "paragraph", content: [{ type: "text", text: "Steps to reproduce:" }] },
+        { type: "orderedList", content: [
+          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Open app on iPhone" }] }] },
+          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Tap login button" }] }] },
+        ] },
+      ],
+    },
+    duedate: "2024-06-30",
+    created: "2024-06-01T10:00:00.000Z",
+    updated: "2024-06-16T14:00:00.000Z",
+    sprint: { name: "Sprint 42", state: "active" },
+    parent: { key: "PROJ-100", fields: { summary: "Mobile Improvements" } },
+  },
+}
+
+const issueChange = issueToChange(standardIssue, BASE_URL)
+
+ok("type is upsert", issueChange.type === "upsert")
+ok("key is issue key", issueChange.key === "PROJ-123")
+ok(
+  "Summary is set",
+  JSON.stringify(issueChange.properties.Summary).includes("Login button")
+)
+ok(
+  "Status is set",
+  JSON.stringify(issueChange.properties.Status).includes("In Progress")
+)
+ok(
+  "Issue Type is set",
+  JSON.stringify(issueChange.properties["Issue Type"]).includes("Bug")
+)
+ok(
+  "Assignee is display name",
+  JSON.stringify(issueChange.properties.Assignee).includes("Alice Smith")
+)
+ok(
+  "Sprint name is set",
+  JSON.stringify(issueChange.properties.Sprint).includes("Sprint 42")
+)
+ok(
+  "Updated is set",
+  JSON.stringify(issueChange.properties.Updated).includes("2024-06-16")
+)
+ok(
+  "Status Category is set",
+  JSON.stringify(issueChange.properties["Status Category"]).includes("In Progress")
+)
+ok(
+  "Priority is set",
+  JSON.stringify(issueChange.properties.Priority).includes("High")
+)
+ok(
+  "Reporter is display name",
+  JSON.stringify(issueChange.properties.Reporter).includes("Bob Jones")
+)
+ok(
+  "Project name is set",
+  JSON.stringify(issueChange.properties.Project).includes("Project Alpha")
+)
+ok(
+  "Issue Link is correct",
+  JSON.stringify(issueChange.properties["Issue Link"]).includes(
+    "acme.atlassian.net/browse/PROJ-123"
+  )
+)
+ok(
+  "Labels contains both",
+  JSON.stringify(issueChange.properties.Labels).includes("frontend") &&
+    JSON.stringify(issueChange.properties.Labels).includes("mobile")
+)
+ok(
+  "Components contains both",
+  JSON.stringify(issueChange.properties.Components).includes("Web App") &&
+    JSON.stringify(issueChange.properties.Components).includes("Auth")
+)
+ok(
+  "Fix Versions is set",
+  JSON.stringify(issueChange.properties["Fix Versions"]).includes("v2.1")
+)
+ok("null resolution omits Resolution", issueChange.properties.Resolution === undefined)
+ok(
+  "Due Date is set",
+  JSON.stringify(issueChange.properties["Due Date"]).includes("2024-06-30")
+)
+ok(
+  "Epic from parent summary",
+  JSON.stringify(issueChange.properties.Epic).includes("Mobile Improvements")
+)
+ok(
+  "Created is set",
+  JSON.stringify(issueChange.properties.Created).includes("2024-06-01")
+)
+ok(
+  "Issue Key is last",
+  JSON.stringify(issueChange.properties["Issue Key"]).includes("PROJ-123")
+)
+ok(
+  "pageContentMarkdown contains description text",
+  issueChange.pageContentMarkdown.includes("login button doesn't respond")
+)
+
+// ---------------------------------------------------------------------------
+// issueToChange — resolved issue
+// ---------------------------------------------------------------------------
+
+console.log("issueToChange — resolved issue:")
+
+const resolvedIssue: JiraIssue = {
+  ...standardIssue,
+  fields: {
+    ...standardIssue.fields,
+    status: { name: "Done", statusCategory: { name: "Done" } },
+    resolution: { name: "Fixed" },
+  },
+}
+
+const resolvedChange = issueToChange(resolvedIssue, BASE_URL)
+
+ok(
+  "Status is Done",
+  JSON.stringify(resolvedChange.properties.Status).includes("Done")
+)
+ok(
+  "Status Category is Done",
+  JSON.stringify(resolvedChange.properties["Status Category"]).includes("Done")
+)
+ok(
+  "Resolution is Fixed",
+  JSON.stringify(resolvedChange.properties.Resolution).includes("Fixed")
+)
+
+// ---------------------------------------------------------------------------
+// issueToChange — minimal issue
+// ---------------------------------------------------------------------------
+
+console.log("issueToChange — minimal issue:")
+
+const minimalIssue: JiraIssue = {
+  key: "PROJ-1",
+  self: "https://acme.atlassian.net/rest/api/3/issue/1",
+  fields: {
+    summary: "First issue",
+    status: null,
+    issuetype: null,
+    priority: null,
+    assignee: null,
+    reporter: null,
+    project: null,
+    labels: [],
+    components: [],
+    fixVersions: [],
+    resolution: null,
+    description: null,
+    duedate: null,
+    created: "2024-01-01",
+    updated: "2024-01-01",
+    sprint: null,
+    parent: null,
+  },
+}
+
+const minimalChange = issueToChange(minimalIssue, BASE_URL)
+
+ok("null status omits Status", minimalChange.properties.Status === undefined)
+ok("null status omits Status Category", minimalChange.properties["Status Category"] === undefined)
+ok("null issuetype omits Issue Type", minimalChange.properties["Issue Type"] === undefined)
+ok("null priority omits Priority", minimalChange.properties.Priority === undefined)
+ok("null assignee omits Assignee", minimalChange.properties.Assignee === undefined)
+ok("null reporter omits Reporter", minimalChange.properties.Reporter === undefined)
+ok("null project omits Project", minimalChange.properties.Project === undefined)
+ok("null sprint omits Sprint", minimalChange.properties.Sprint === undefined)
+ok("null parent omits Epic", minimalChange.properties.Epic === undefined)
+ok("empty labels omits Labels", minimalChange.properties.Labels === undefined)
+ok("empty components omits Components", minimalChange.properties.Components === undefined)
+ok("empty fixVersions omits Fix Versions", minimalChange.properties["Fix Versions"] === undefined)
+ok("null duedate omits Due Date", minimalChange.properties["Due Date"] === undefined)
+ok("null description gives empty pageContentMarkdown", minimalChange.pageContentMarkdown === "")
+
+// ---------------------------------------------------------------------------
+// getEpicName — resolves epic from parent
+// ---------------------------------------------------------------------------
+
+console.log("getEpicName:")
+
+ok(
+  "parent with summary returns summary",
+  getEpicName(standardIssue) === "Mobile Improvements"
+)
+
+const parentKeyOnly: JiraIssue = {
+  ...minimalIssue,
+  fields: { ...minimalIssue.fields, parent: { key: "PROJ-50" } },
+}
+ok("parent with key only returns key", getEpicName(parentKeyOnly) === "PROJ-50")
+ok("null parent returns null", getEpicName(minimalIssue) === null)
+
+// ---------------------------------------------------------------------------
+// sprintToChange — standard sprint
+// ---------------------------------------------------------------------------
+
+console.log("sprintToChange — standard sprint:")
+
+const boards: BoardLookup = new Map([
+  [10, "Engineering Board"],
+])
+
+const activeSprint: JiraSprint = {
+  id: 42,
+  name: "Sprint 42",
+  state: "active",
+  startDate: "2024-06-10T00:00:00.000Z",
+  endDate: "2024-06-24T00:00:00.000Z",
+  completeDate: null,
+  goal: "Ship the mobile login fix",
+  originBoardId: 10,
+}
+
+const sprintChange = sprintToChange(activeSprint, boards)
+
+ok("key is sprint id", sprintChange.key === "42")
+ok(
+  "Name is set",
+  JSON.stringify(sprintChange.properties.Name).includes("Sprint 42")
+)
+ok(
+  "State is Active",
+  JSON.stringify(sprintChange.properties.State).includes("Active")
+)
+ok(
+  "Board resolved to name",
+  JSON.stringify(sprintChange.properties.Board).includes("Engineering Board")
+)
+ok(
+  "Start Date is set",
+  JSON.stringify(sprintChange.properties["Start Date"]).includes("2024-06-10")
+)
+ok(
+  "End Date is set",
+  JSON.stringify(sprintChange.properties["End Date"]).includes("2024-06-24")
+)
+ok(
+  "Goal is set",
+  JSON.stringify(sprintChange.properties.Goal).includes("mobile login")
+)
+ok("null completeDate omits Complete Date", sprintChange.properties["Complete Date"] === undefined)
+ok(
+  "pageContentMarkdown contains goal",
+  sprintChange.pageContentMarkdown.includes("mobile login")
+)
+
+// ---------------------------------------------------------------------------
+// sprintToChange — closed sprint
+// ---------------------------------------------------------------------------
+
+console.log("sprintToChange — closed sprint:")
+
+const closedSprint: JiraSprint = {
+  ...activeSprint,
+  state: "closed",
+  completeDate: "2024-06-23T12:00:00.000Z",
+}
+
+const closedSprintChange = sprintToChange(closedSprint, boards)
+
+ok(
+  "State is Closed",
+  JSON.stringify(closedSprintChange.properties.State).includes("Closed")
+)
+ok(
+  "Complete Date is set",
+  JSON.stringify(closedSprintChange.properties["Complete Date"]).includes("2024-06-23")
+)
+
+// ---------------------------------------------------------------------------
+// sprintToChange — minimal sprint
+// ---------------------------------------------------------------------------
+
+console.log("sprintToChange — minimal sprint:")
+
+const minimalSprint: JiraSprint = {
+  id: 1,
+  name: "Sprint 1",
+  state: "future",
+  startDate: null,
+  endDate: null,
+  completeDate: null,
+  goal: null,
+  originBoardId: 999,
+}
+
+const minimalSprintChange = sprintToChange(minimalSprint, boards)
+
+ok("unknown board omits Board", minimalSprintChange.properties.Board === undefined)
+ok("null startDate omits Start Date", minimalSprintChange.properties["Start Date"] === undefined)
+ok("null endDate omits End Date", minimalSprintChange.properties["End Date"] === undefined)
+ok("null goal omits Goal", minimalSprintChange.properties.Goal === undefined)
+
+// ---------------------------------------------------------------------------
+// projectToChange — standard project
+// ---------------------------------------------------------------------------
+
+console.log("projectToChange — standard project:")
+
+const standardProject: JiraProject = {
+  id: "10001",
+  key: "PROJ",
+  name: "Project Alpha",
+  description: "The main engineering project.",
+  self: "https://acme.atlassian.net/rest/api/3/project/10001",
+  projectTypeKey: "software",
+  lead: { displayName: "Carol Manager" },
+  projectCategory: { name: "Engineering" },
+}
+
+const projectChange = projectToChange(standardProject, BASE_URL)
+
+ok("key is project key", projectChange.key === "PROJ")
+ok(
+  "Name is set",
+  JSON.stringify(projectChange.properties.Name).includes("Project Alpha")
+)
+ok(
+  "Project Key is set",
+  JSON.stringify(projectChange.properties["Project Key"]).includes("PROJ")
+)
+ok(
+  "Lead is display name",
+  JSON.stringify(projectChange.properties.Lead).includes("Carol Manager")
+)
+ok(
+  "Category is set",
+  JSON.stringify(projectChange.properties.Category).includes("Engineering")
+)
+ok(
+  "Project Type maps to label",
+  JSON.stringify(projectChange.properties["Project Type"]).includes("Software")
+)
+ok(
+  "Project Link is correct",
+  JSON.stringify(projectChange.properties["Project Link"]).includes(
+    "acme.atlassian.net/browse/PROJ"
+  )
+)
+ok(
+  "pageContentMarkdown contains description",
+  projectChange.pageContentMarkdown === "The main engineering project."
+)
+
+// ---------------------------------------------------------------------------
+// projectToChange — minimal project
+// ---------------------------------------------------------------------------
+
+console.log("projectToChange — minimal project:")
+
+const minimalProject: JiraProject = {
+  id: "10002",
+  key: "MIN",
+  name: "Minimal",
+  description: null,
+  self: "https://acme.atlassian.net/rest/api/3/project/10002",
+  projectTypeKey: "business",
+  lead: null,
+  projectCategory: null,
+}
+
+const minimalProjectChange = projectToChange(minimalProject, BASE_URL)
+
+ok("null lead omits Lead", minimalProjectChange.properties.Lead === undefined)
+ok("null category omits Category", minimalProjectChange.properties.Category === undefined)
+ok("null description gives empty pageContentMarkdown", minimalProjectChange.pageContentMarkdown === "")
+
+// ---------------------------------------------------------------------------
+// extractTextFromAdf — converts Atlassian Document Format to plain text
+// ---------------------------------------------------------------------------
+
+console.log("extractTextFromAdf:")
+
+ok("null returns empty", extractTextFromAdf(null) === "")
+ok("empty object returns empty", extractTextFromAdf({}) === "")
+
+ok(
+  "simple paragraph",
+  extractTextFromAdf({
+    type: "doc",
+    content: [
+      { type: "paragraph", content: [{ type: "text", text: "Hello world" }] },
+    ],
+  }).includes("Hello world")
+)
+
+ok(
+  "multiple paragraphs",
+  extractTextFromAdf({
+    type: "doc",
+    content: [
+      { type: "paragraph", content: [{ type: "text", text: "First" }] },
+      { type: "paragraph", content: [{ type: "text", text: "Second" }] },
+    ],
+  }).includes("First") &&
+  extractTextFromAdf({
+    type: "doc",
+    content: [
+      { type: "paragraph", content: [{ type: "text", text: "First" }] },
+      { type: "paragraph", content: [{ type: "text", text: "Second" }] },
+    ],
+  }).includes("Second")
+)
+
+ok(
+  "bullet list",
+  extractTextFromAdf({
+    type: "doc",
+    content: [
+      { type: "bulletList", content: [
+        { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Item one" }] }] },
+        { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Item two" }] }] },
+      ] },
+    ],
+  }).includes("- Item one")
+)
+
+ok(
+  "code block",
+  extractTextFromAdf({
+    type: "doc",
+    content: [
+      { type: "codeBlock", content: [{ type: "text", text: "const x = 1" }] },
+    ],
+  }).includes("```")
+)
+
+// ---------------------------------------------------------------------------
+// browseUrl
+// ---------------------------------------------------------------------------
+
+console.log("browseUrl:")
+
+ok(
+  "builds correct URL",
+  browseUrl("https://acme.atlassian.net", "PROJ-42") ===
+    "https://acme.atlassian.net/browse/PROJ-42"
+)
+
+// ---------------------------------------------------------------------------
+// dateOnly
+// ---------------------------------------------------------------------------
+
+console.log("dateOnly:")
+
+ok("ISO timestamp returns date part", dateOnly("2024-03-15T12:00:00Z") === "2024-03-15")
+ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
+ok("empty string returns empty", dateOnly("") === "")
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/examples/workers/syncs/jira/tsconfig.json
+++ b/examples/workers/syncs/jira/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a Jira Cloud sync worker at `examples/workers/syncs/jira` with four independent managed databases and no cross-database relations:
  - **Jira Issues** — operational issue mirror every 5 minutes
  - **Jira Current Sprints** — lightweight active/future sprint mirror every 15 minutes
  - **Jira Sprint Performance** — daily active/closed sprint scorecards
  - **Jira Projects** — project reference data daily
- Makes Sprint Performance useful for sprint reviews and delivery planning: committed vs. completed scope, additions/removals, estimate changes, rollover, completion and predictability, 3-/5-sprint velocity, delivery forecast, and a linked issue roster.
- Reconstructs sprint metrics from Jira's enhanced sprint-issue API and bulk changelog API, using each sprint's canonical board, the board's rightmost Done column, and Story Points or issue-count fallback.
- Requires three comparable completed sprints before publishing an active delivery forecast and keeps subtasks visible in the roster without double-counting them in metrics.
- Surfaces historical limitations through `Data Quality` and page-level notes. Jira may not rediscover an issue removed before the worker first observes a sprint, so older `Partial` or `Limited` scorecards are directional rather than exact Jira sprint reports.
- Syncs issues through the enhanced `/rest/api/3/search/jql` endpoint using bounded JQL and cursor pagination; truncation warnings abort replace-mode syncs so partial snapshots cannot delete valid Notion records.
- Discovers Sprint, Story Points, and Epic Link custom fields, uses immutable Jira IDs as upsert keys, preserves `Retry-After`, safely handles Jira hierarchy/Sprint values, and expands project descriptions and leads.
- Uses resource-specific database icons: `bug`, `stopwatch`, `chart-line`, and `folder`.
- Includes setup documentation, corrected `ntn` CLI commands, and offline API/transform/analytics regression coverage.

## Test plan

- [x] `npm run check`
- [x] `npm test` — 99 existing assertions plus 7 sprint analytics tests
- [x] Prettier check
- [x] Markdown lint
- [x] `git diff --check`
- [ ] `ntn workers sync trigger issuesSync --preview`
- [ ] `ntn workers sync trigger currentSprintsSync --preview`
- [ ] `ntn workers sync trigger allSprintsSync --preview`
- [ ] `ntn workers sync trigger projectsSync --preview`
- [ ] Verify all four managed databases in a Notion workspace
