### PR TITLE
fix(workers): harden GitHub sync example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,24 @@ jobs:
         run: ./scripts/install-examples.sh
       - name: Typecheck JavaScript examples
         run: ./scripts/typecheck-examples.sh
+
+  test-github-worker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/workers/syncs/github
+
+    steps:
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Use Node.js 22.x
+        # v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        with:
+          node-version: 22.x
+      - name: Install dependencies
+        run: npm install
+      - name: Typecheck
+        run: npm run check
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,24 +23,3 @@ jobs:
         run: ./scripts/install-examples.sh
       - name: Typecheck JavaScript examples
         run: ./scripts/typecheck-examples.sh
-
-  test-github-worker:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: examples/workers/syncs/github
-
-    steps:
-      # v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Use Node.js 22.x
-        # v4.1.0
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
-        with:
-          node-version: 22.x
-      - name: Install dependencies
-        run: npm install
-      - name: Typecheck
-        run: npm run check
-      - name: Test
-        run: npm test

--- a/examples/workers/syncs/github/.env.example
+++ b/examples/workers/syncs/github/.env.example
@@ -1,10 +1,12 @@
 # Copy this file to `.env` and fill in your own values for local testing.
 # `.env` is gitignored — never commit real credentials.
 # For a deployed worker, set these with `ntn workers env set KEY=value` instead.
+# This example supports GitHub.com with personal access token authentication.
 
 # Required
-# A GitHub personal access token (classic) or fine-grained token with read
-# access to the repos you want to sync. Classic tokens need the `repo` scope.
+# A fine-grained GitHub personal access token limited to the repositories you
+# want to sync, with read access to Issues, Pull requests, Checks, and Commit
+# statuses.
 GITHUB_TOKEN=
 
 # Comma-separated list of repositories to sync, in owner/repo format.

--- a/examples/workers/syncs/github/.env.example
+++ b/examples/workers/syncs/github/.env.example
@@ -1,14 +1,24 @@
 # Copy this file to `.env` and fill in your own values for local testing.
 # `.env` is gitignored — never commit real credentials.
 # For a deployed worker, set these with `ntn workers env set KEY=value` instead.
-# This example supports GitHub.com with personal access token authentication.
 
-# Required
-# A fine-grained GitHub personal access token limited to the repositories you
-# want to sync, with read access to Issues, Pull requests, Checks, and Commit
-# statuses.
-GITHUB_TOKEN=
+# Choose an authentication mode: installation, user, or pat. Installation is
+# recommended for an unattended production sync.
+GITHUB_AUTH_MODE=installation
 
 # Comma-separated list of repositories to sync, in owner/repo format.
 # Example: makenotion/notion-cookbook,makenotion/notion-mcp-server
 GITHUB_REPOS=
+
+# GitHub App installation mode (recommended). The private key is the single-line
+# base64 encoding of the PEM file downloaded from the GitHub App settings page.
+GITHUB_APP_CLIENT_ID=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_APP_PRIVATE_KEY_BASE64=
+
+# GitHub App user OAuth mode. GITHUB_APP_CLIENT_ID above is also required.
+GITHUB_APP_CLIENT_SECRET=
+
+# Fine-grained PAT mode. Limit the token to the repositories above and grant
+# read access to Issues, Pull requests, Checks, and Commit statuses.
+GITHUB_TOKEN=

--- a/examples/workers/syncs/github/README.md
+++ b/examples/workers/syncs/github/README.md
@@ -3,7 +3,7 @@
 Syncs GitHub issues and pull requests from one or more repositories into
 Notion databases that stay up to date automatically. Once deployed, the worker
 creates three databases covering issues, all pull requests, and a focused view
-of open PRs with review and CI status.
+of open PRs with review activity and CI status.
 
 You don't need to create the Notion databases yourself. The worker declares the
 schemas and Notion creates and manages each database for you (these are called
@@ -11,93 +11,95 @@ schemas and Notion creates and manages each database for you (these are called
 
 ## What you get
 
-| Database | GitHub resource | Schedule |
-| --- | --- | --- |
-| **GitHub Issues** | Issues | Every 5 min |
-| **GitHub Pull Requests** | Pull Requests (all states) | Every 5 min |
-| **GitHub Open PRs** | Open PRs + reviews + CI | Every 2 min |
+| Database            | GitHub resource            | Schedule    |
+| ------------------- | -------------------------- | ----------- |
+| **GitHub Issues**   | Issues                     | Every 5 min |
+| **All GitHub PRs**  | Pull Requests (all states) | Every 5 min |
+| **Open GitHub PRs** | Open PRs + reviews + CI    | Every 5 min |
 
 ### GitHub Issues
 
-| Notion property | GitHub field | Type |
-| --- | --- | --- |
-| Title | `title` | title |
-| Issue Key | `owner/repo#number` | richText |
-| Issue Link | `html_url` | url |
-| State | `state` | select |
-| State Reason | `state_reason` | select |
-| Author | `user.login` | richText |
-| Assignees | `assignees[].login` | multiSelect |
-| Labels | `labels[].name` | multiSelect |
-| Milestone | `milestone.title` | richText |
-| Comments | `comments` | number |
-| Reactions | `reactions.total_count` | number |
-| Repository | `owner/repo` | richText |
-| Created | `created_at` | date |
-| Updated | `updated_at` | date |
-| Closed | `closed_at` | date |
+| Notion property | GitHub field            | Type        |
+| --------------- | ----------------------- | ----------- |
+| Title           | `title`                 | title       |
+| Issue Key       | `owner/repo#number`     | richText    |
+| Issue Link      | `html_url`              | url         |
+| State           | `state`                 | select      |
+| State Reason    | `state_reason`          | select      |
+| Author          | `user.login`            | richText    |
+| Assignees       | `assignees[].login`     | multiSelect |
+| Labels          | `labels[].name`         | multiSelect |
+| Milestone       | `milestone.title`       | richText    |
+| Comments        | `comments`              | number      |
+| Reactions       | `reactions.total_count` | number      |
+| Repository      | `owner/repo`            | richText    |
+| Created         | `created_at`            | date        |
+| Updated         | `updated_at`            | date        |
+| Closed          | `closed_at`             | date        |
 
 Each page body contains the issue body (markdown).
 
-### GitHub Pull Requests (all states)
+### All GitHub PRs
 
-| Notion property | GitHub field | Type |
-| --- | --- | --- |
-| Title | `title` | title |
-| PR Key | `owner/repo#number` | richText |
-| PR Link | `html_url` | url |
-| State | Open / Closed / Merged | select |
-| Draft | `draft` | checkbox |
-| Author | `user.login` | richText |
-| Assignees | `assignees[].login` | multiSelect |
-| Reviewers | `requested_reviewers[].login` | multiSelect |
-| Labels | `labels[].name` | multiSelect |
-| Milestone | `milestone.title` | richText |
-| Base Branch | `base.ref` | richText |
-| Head Branch | `head.ref` | richText |
-| Repository | `owner/repo` | richText |
-| Created | `created_at` | date |
-| Updated | `updated_at` | date |
-| Closed | `closed_at` | date |
-| Merged | `merged_at` | date |
-| Merged By | `merged_by.login` | richText |
+| Notion property | GitHub field                  | Type        |
+| --------------- | ----------------------------- | ----------- |
+| Title           | `title`                       | title       |
+| PR Key          | `owner/repo#number`           | richText    |
+| PR Link         | `html_url`                    | url         |
+| State           | Open / Closed / Merged        | select      |
+| Draft           | `draft`                       | checkbox    |
+| Author          | `user.login`                  | richText    |
+| Assignees       | `assignees[].login`           | multiSelect |
+| Reviewers       | `requested_reviewers[].login` | multiSelect |
+| Labels          | `labels[].name`               | multiSelect |
+| Milestone       | `milestone.title`             | richText    |
+| Base Branch     | `base.ref`                    | richText    |
+| Head Branch     | `head.ref`                    | richText    |
+| Repository      | `owner/repo`                  | richText    |
+| Created         | `created_at`                  | date        |
+| Updated         | `updated_at`                  | date        |
+| Closed          | `closed_at`                   | date        |
+| Merged          | `merged_at`                   | date        |
 
 Each page body contains the PR description (markdown). State is "Merged" when
 `merged_at` is set, regardless of the `state` field.
 
-### GitHub Open PRs
+### Open GitHub PRs
 
-A focused view of currently open pull requests, enriched with review decisions
-and CI status from per-PR API calls. Because only open PRs are fetched, the
-extra calls stay well within rate limits.
+A focused view of currently open pull requests, enriched with review activity
+and CI status from per-PR API calls.
 
-| Notion property | GitHub field | Type |
-| --- | --- | --- |
-| Title | `title` | title |
-| PR Key | `owner/repo#number` | richText |
-| PR Link | `html_url` | url |
-| Draft | `draft` | checkbox |
-| Review State | Aggregate of PR reviews | select |
-| CI Status | Aggregate of check runs | select |
-| Author | `user.login` | richText |
-| Assignees | `assignees[].login` | multiSelect |
-| Reviewers | `requested_reviewers[].login` | multiSelect |
-| Labels | `labels[].name` | multiSelect |
-| Milestone | `milestone.title` | richText |
-| Base Branch | `base.ref` | richText |
-| Head Branch | `head.ref` | richText |
-| Repository | `owner/repo` | richText |
-| Created | `created_at` | date |
-| Updated | `updated_at` | date |
+| Notion property | GitHub field                          | Type        |
+| --------------- | ------------------------------------- | ----------- |
+| Title           | `title`                               | title       |
+| PR Key          | `owner/repo#number`                   | richText    |
+| PR Link         | `html_url`                            | url         |
+| Draft           | `draft`                               | checkbox    |
+| Review Activity | Latest submitted reviews by reviewer  | select      |
+| CI Status       | Check runs and commit status contexts | select      |
+| Author          | `user.login`                          | richText    |
+| Assignees       | `assignees[].login`                   | multiSelect |
+| Reviewers       | `requested_reviewers[].login`         | multiSelect |
+| Labels          | `labels[].name`                       | multiSelect |
+| Milestone       | `milestone.title`                     | richText    |
+| Base Branch     | `base.ref`                            | richText    |
+| Head Branch     | `head.ref`                            | richText    |
+| Repository      | `owner/repo`                          | richText    |
+| Created         | `created_at`                          | date        |
+| Updated         | `updated_at`                          | date        |
 
-**Review State** is computed from individual review decisions. Each reviewer's
-latest non-comment review is used: if any reviewer has requested changes, the
-state is "Changes Requested"; if all actionable reviews are approvals, it's
-"Approved". Dismissed reviews are excluded.
+**Review Activity** summarizes submitted reviews. Each reviewer's latest
+non-comment review is used: if any reviewer has requested changes, the state is
+"Changes Requested"; otherwise, if at least one current review is an approval,
+it is "Approved". Dismissed reviews are excluded. This does not evaluate branch
+protection, required reviewers, CODEOWNERS, or whether GitHub considers the PR
+ready to merge.
 
-**CI Status** is computed from check runs on the PR's head commit: "Success"
-when all checks pass, "Failure" if any check fails, "Pending" if any are still
-running.
+**CI Status** combines check runs and commit status contexts on the PR's head
+commit. Failure, cancellation, or timeout produces "Failure"; otherwise, a
+nonterminal result produces "Pending". Completed `success`, `neutral`, and
+`skipped` checks count as passing, and all observed results must pass for
+"Success".
 
 ## Project structure
 
@@ -106,7 +108,7 @@ src/
 ├── index.ts              — registers all databases and syncs
 ├── github.ts             — API client (auth, pagination, types)
 ├── issues.ts             — issue schema + transform
-├── pull-requests.ts      — all-PRs schema + transform
+├── all-pull-requests.ts  — all-PRs schema + transform
 ├── open-pull-requests.ts — open-PRs schema + transform (reviews, CI)
 └── helpers.ts            — shared utilities (dateOnly)
 ```
@@ -114,44 +116,56 @@ src/
 ## How it works
 
 1. The worker runs three syncs across all repositories listed in `GITHUB_REPOS`:
-   - **Issues** and **All PRs** use the list endpoints (1 API call per 100
-     records) and sync every 5 minutes.
-   - **Open PRs** fetches only open pull requests, then makes two additional
-     API calls per PR (reviews and check runs) to get review state and CI
-     status. It syncs every 2 minutes.
+   - **Issues** and **All PRs** use list endpoints that return pages of up to
+     100 GitHub results and sync every 5 minutes.
+   - **Open PRs** scans pull requests in stable creation order, emits only open
+     pull requests, then fetches reviews, check runs, and commit status contexts
+     to summarize review and CI activity. It syncs every 5 minutes.
 2. Each record is converted to an `upsert` keyed by `owner/repo#number`, so
    the same issue or PR is never duplicated — even across multiple repos.
-3. All three syncs share a single rate-limit pacer (4800 requests/hour) to
-   stay within GitHub's 5000/hour limit.
-4. Because all syncs use `mode: "replace"`, records deleted or closed in
-   GitHub are automatically removed from the corresponding database.
+3. The API client follows GitHub's pagination links and surfaces rate-limit
+   reset timing to the Workers runtime so requests can be retried safely.
+4. Requests use GitHub's recommended media type and pin REST API version
+   `2026-03-10`.
+5. All three syncs use `mode: "replace"`. **GitHub Issues** and **All GitHub
+   PRs** request all states, so closed records remain in those databases. **Open
+   GitHub PRs** emits only open PRs, so a PR is removed from that database after
+   it closes. Records no longer returned by GitHub are removed after a complete
+   sweep.
 
 ## Prerequisites
 
 - Node >= 22, npm >= 10.9.2
 - A GitHub account with access to the repositories you want to sync
-- The `ntn` CLI installed and authenticated (`ntn auth login`)
+- The `ntn` CLI installed and authenticated (`ntn login`)
+
+> **Supported configuration:** This example connects to repositories on
+> GitHub.com with a personal access token. GitHub Enterprise Server base URLs
+> and GitHub App authentication/token renewal are not implemented.
 
 ### Getting a GitHub token
 
-1. Go to **Settings > Developer settings > Personal access tokens**
-2. Create a **fine-grained token** with read access to the repos you want
-   to sync (Issues and Pull Requests permissions), or a **classic token**
-   with the `repo` scope
-3. Copy the token — you'll need it for `GITHUB_TOKEN`
+1. Go to **Settings > Developer settings > Personal access tokens >
+   Fine-grained tokens**.
+2. Limit repository access to the repositories you want to sync.
+3. Grant these read-only repository permissions: **Issues**, **Pull
+   requests**, **Checks**, and **Commit statuses**.
+4. Copy the token — you'll need it for `GITHUB_TOKEN`.
 
-> **Production use:** For higher rate limits (15 000+ requests/hour) and
-> org-level permissions, consider using a
-> [GitHub App](https://docs.github.com/en/apps) instead of a personal token.
+Fine-grained tokens select a single resource owner. All private repositories in
+one deployment must be available through that selected user or organization,
+and an organization may require an administrator to approve the token.
+
+Use the shortest practical expiration and rotate the token before it expires.
 
 ## Environment variables
 
 ### Required
 
-| Variable | Description |
-| --- | --- |
-| `GITHUB_TOKEN` | Personal access token with read access to your repos |
-| `GITHUB_REPOS` | Comma-separated list of repos in `owner/repo` format |
+| Variable       | Description                                                   |
+| -------------- | ------------------------------------------------------------- |
+| `GITHUB_TOKEN` | Fine-grained personal access token with the permissions above |
+| `GITHUB_REPOS` | Comma-separated list of repos in `owner/repo` format          |
 
 No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
 automatically.
@@ -161,7 +175,7 @@ automatically.
 1. Install the Notion Workers CLI:
 
    ```sh
-   npm install -g @notionhq/ntn
+   curl -fsSL https://ntn.dev | bash
    ```
 
 2. Clone and install:
@@ -181,19 +195,19 @@ automatically.
 4. Log in to Notion:
 
    ```sh
-   ntn auth login
+   ntn login
    ```
 
 5. Deploy the worker:
 
    ```sh
-   ntn workers deploy
+   ntn workers deploy --name github-sync
    ```
 
 6. Set environment variables on the deployed worker:
 
    ```sh
-   ntn workers env set GITHUB_TOKEN=ghp_your-token-here
+   ntn workers env set GITHUB_TOKEN=github_pat_your-token-here
    ntn workers env set GITHUB_REPOS=acme/widgets,acme/api
    ```
 
@@ -219,10 +233,10 @@ in your Notion workspace after the first run.
 
 Each resource has its own file with a schema and transform function:
 
-| Resource | File |
-| --- | --- |
-| Issues | `src/issues.ts` |
-| All Pull Requests | `src/pull-requests.ts` |
+| Resource           | File                        |
+| ------------------ | --------------------------- |
+| Issues             | `src/issues.ts`             |
+| All Pull Requests  | `src/all-pull-requests.ts`  |
 | Open Pull Requests | `src/open-pull-requests.ts` |
 
 To add a new GitHub field:
@@ -242,14 +256,18 @@ npm test
 Test a sync locally against real GitHub repos:
 
 ```sh
+cp .env.example .env
+# Fill in GITHUB_TOKEN and GITHUB_REPOS in .env, then run:
 ntn workers exec issuesSync --local
 ```
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
 - [GitHub REST API — Issues](https://docs.github.com/en/rest/issues/issues)
 - [GitHub REST API — Pull Requests](https://docs.github.com/en/rest/pulls/pulls)
 - [GitHub REST API — Reviews](https://docs.github.com/en/rest/pulls/reviews)
 - [GitHub REST API — Check Runs](https://docs.github.com/en/rest/checks/runs)
+- [GitHub REST API — Commit Statuses](https://docs.github.com/en/rest/commits/statuses)
+- [GitHub REST API — Best Practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api)
 - [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/github/README.md
+++ b/examples/workers/syncs/github/README.md
@@ -106,7 +106,8 @@ nonterminal result produces "Pending". Completed `success`, `neutral`, and
 ```text
 src/
 ├── index.ts              — registers all databases and syncs
-├── github.ts             — API client (auth, pagination, types)
+├── auth.ts               — PAT, GitHub App user, and installation auth
+├── github.ts             — API client (pagination, errors, types)
 ├── issues.ts             — issue schema + transform
 ├── all-pull-requests.ts  — all-PRs schema + transform
 ├── open-pull-requests.ts — open-PRs schema + transform (reviews, CI)
@@ -123,11 +124,13 @@ src/
      to summarize review and CI activity. It syncs every 5 minutes.
 2. Each record is converted to an `upsert` keyed by `owner/repo#number`, so
    the same issue or PR is never duplicated — even across multiple repos.
-3. The API client follows GitHub's pagination links and surfaces rate-limit
+3. A token provider supplies the selected PAT, user OAuth token, or short-lived
+   installation token without changing the sync or API code.
+4. The API client follows GitHub's pagination links and surfaces rate-limit
    reset timing to the Workers runtime so requests can be retried safely.
-4. Requests use GitHub's recommended media type and pin REST API version
+5. GitHub data requests use the recommended media type and pin REST API version
    `2026-03-10`.
-5. All three syncs use `mode: "replace"`. **GitHub Issues** and **All GitHub
+6. All three syncs use `mode: "replace"`. **GitHub Issues** and **All GitHub
    PRs** request all states, so closed records remain in those databases. **Open
    GitHub PRs** emits only open PRs, so a PR is removed from that database after
    it closes. Records no longer returned by GitHub are removed after a complete
@@ -137,38 +140,65 @@ src/
 
 - Node >= 22, npm >= 10.9.2
 - A GitHub account with access to the repositories you want to sync
+- A GitHub App installed on the target account, or permission to request or
+  install one, if you choose either GitHub App mode
 - The `ntn` CLI installed and authenticated (`ntn login`)
 
-> **Supported configuration:** This example connects to repositories on
-> GitHub.com with a personal access token. GitHub Enterprise Server base URLs
-> and GitHub App authentication/token renewal are not implemented.
+> **Supported configuration:** This example connects to GitHub.com using a
+> GitHub App installation token, a GitHub App user access token, or a
+> fine-grained personal access token. GitHub Enterprise Server base URLs are
+> not implemented.
 
-### Getting a GitHub token
+## Choose an authentication mode
 
-1. Go to **Settings > Developer settings > Personal access tokens >
-   Fine-grained tokens**.
-2. Limit repository access to the repositories you want to sync.
-3. Grant these read-only repository permissions: **Issues**, **Pull
-   requests**, **Checks**, and **Commit statuses**.
-4. Copy the token — you'll need it for `GITHUB_TOKEN`.
+Set `GITHUB_AUTH_MODE` to one of these values:
 
-Fine-grained tokens select a single resource owner. All private repositories in
-one deployment must be available through that selected user or organization,
-and an organization may require an administrator to approve the token.
+| Mode                             | Best for                                        | Credential lifecycle                                       |
+| -------------------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `installation` **(recommended)** | Unattended, organization-owned scheduled syncs  | Octokit renews the GitHub App installation token           |
+| `user`                           | Access that should follow one employee          | Notion Workers stores and refreshes the GitHub App token   |
+| `pat`                            | Local evaluation and small personal deployments | You rotate the fine-grained personal access token manually |
 
-Use the shortest practical expiration and rotate the token before it expires.
+Installation authentication is recommended for a shared production sync
+because the automation belongs to the GitHub App rather than an employee. User
+authentication is useful when the sync should see only repositories that both
+the app and one particular employee can access. A PAT is the shortest setup
+path, but organizations can restrict or require approval for PATs.
+
+`GITHUB_AUTH_MODE` defaults to `pat` for compatibility. Set it explicitly so
+the deployment's credential source is clear.
+
+One GitHub App can support both `installation` and `user`. A deployment uses
+one mode at a time, and switching modes requires configuration changes only —
+the sync code stays the same.
+
+### GitHub permissions
+
+The GitHub App or fine-grained PAT needs these read-only repository
+permissions:
+
+- **Issues**
+- **Pull requests**
+- **Checks**
+- **Commit statuses**
+
+GitHub Apps also receive the required read-only **Metadata** permission
+automatically. Grant access only to the repositories listed in `GITHUB_REPOS`.
 
 ## Environment variables
 
-### Required
+| Variable                        | Modes                  | Description                                              |
+| ------------------------------- | ---------------------- | -------------------------------------------------------- |
+| `GITHUB_AUTH_MODE`              | All                    | `installation`, `user`, or `pat`                         |
+| `GITHUB_REPOS`                  | All                    | Comma-separated repositories in `owner/repo` format      |
+| `GITHUB_APP_CLIENT_ID`          | `installation`, `user` | Client ID from the GitHub App settings                   |
+| `GITHUB_APP_CLIENT_SECRET`      | `user`                 | Client secret generated for the GitHub App               |
+| `GITHUB_APP_PRIVATE_KEY_BASE64` | `installation`         | Single-line base64 encoding of the App's PEM private key |
+| `GITHUB_APP_INSTALLATION_ID`    | `installation`         | Positive numeric ID of the App installation              |
+| `GITHUB_TOKEN`                  | `pat`                  | Fine-grained personal access token                       |
 
-| Variable       | Description                                                   |
-| -------------- | ------------------------------------------------------------- |
-| `GITHUB_TOKEN` | Fine-grained personal access token with the permissions above |
-| `GITHUB_REPOS` | Comma-separated list of repos in `owner/repo` format          |
-
-No `NOTION_API_TOKEN` is needed — the platform handles Notion credentials
-automatically.
+Only set the credentials required by the selected mode. No `NOTION_API_TOKEN`
+is needed — the platform handles Notion credentials automatically.
 
 ## Setup and deploy
 
@@ -204,21 +234,141 @@ automatically.
    ntn workers deploy --name github-sync
    ```
 
-6. Set environment variables on the deployed worker:
+   This first deployment registers successfully before GitHub credentials
+   exist. Sync runs still require one option below to be configured. The
+   deployment also allocates the callback URL needed by user OAuth.
+
+6. Configure the repositories shared by every authentication mode:
 
    ```sh
-   ntn workers env set GITHUB_TOKEN=github_pat_your-token-here
    ntn workers env set GITHUB_REPOS=acme/widgets,acme/api
    ```
 
-7. Preview a sync without writing to Notion:
+7. Complete one of the authentication options below.
+
+### Option 1: GitHub App installation (recommended)
+
+This is GitHub's server-to-server model and is the recommended choice for an
+unattended scheduled sync.
+
+1. In GitHub, open **Settings > Developer settings > GitHub Apps > New GitHub
+   App**. For an organization-owned app, start from the organization's
+   settings instead.
+2. Enter a name and homepage URL, then deselect **Active** under **Webhook**.
+   This worker polls GitHub and does not use webhooks.
+3. Set **Issues**, **Pull requests**, **Checks**, and **Commit statuses** to
+   **Read-only** under **Repository permissions**.
+4. Create the app, then use **Install App** to install it on the account that
+   owns the repositories. Select only the repositories you want to sync.
+5. Copy the app's **Client ID** from its settings page.
+6. Generate and download a private key from the app's settings page.
+7. Open the installed app's **Configure** page. Copy the numeric installation
+   ID from the end of the browser URL.
+8. Encode the PEM private key as one line:
+
+   ```sh
+   openssl base64 -A -in your-github-app.private-key.pem
+   ```
+
+   Base64 is only an encoding; keep the output secret. Store the command's
+   output, not the PEM path.
+
+9. Configure and redeploy the worker:
+
+   ```sh
+   ntn workers env set GITHUB_AUTH_MODE=installation
+   ntn workers env set GITHUB_APP_CLIENT_ID=Iv1.your-client-id
+   ntn workers env set GITHUB_APP_INSTALLATION_ID=12345678
+   ntn workers env set GITHUB_APP_PRIVATE_KEY_BASE64=your-base64-value
+   ntn workers deploy
+   ```
+
+GitHub installation tokens expire after one hour. `@octokit/auth-app` creates,
+caches, and renews them automatically; do not create or store an installation
+token yourself.
+
+This example supports one GitHub App installation per worker deployment. Every
+repository in `GITHUB_REPOS` must be available through
+`GITHUB_APP_INSTALLATION_ID`.
+
+### Option 2: GitHub App user OAuth
+
+This is GitHub's user-to-server model. Use it when access should follow one
+employee and GitHub should attribute the token to that user and the app.
+
+The app must be installed on the account or organization that owns the
+repositories. Its token can access only repositories that both the installed
+app and the authorizing user can access. If the user loses access or revokes
+authorization, the sync loses that access too.
+
+1. Create and install a GitHub App by following steps 1–5 under installation
+   mode above. You do not need a private key or installation ID for this mode.
+2. Get the callback URL allocated by the first deployment:
+
+   ```sh
+   ntn workers oauth show-redirect-url
+   ```
+
+3. Add the printed URL to the GitHub App's **Callback URL** list. Keep **Expire
+   user authorization tokens** enabled. Leave **Request user authorization
+   (OAuth) during installation** disabled because the CLI starts that flow.
+4. Generate a client secret on the GitHub App's settings page.
+5. Configure the worker and redeploy so its OAuth capability contains the app
+   credentials:
+
+   ```sh
+   ntn workers env set GITHUB_AUTH_MODE=user
+   ntn workers env set GITHUB_APP_CLIENT_ID=Iv1.your-client-id
+   ntn workers env set GITHUB_APP_CLIENT_SECRET=your-client-secret
+   ntn workers deploy
+   ```
+
+6. Authorize the GitHub user whose access the sync should follow:
+
+   ```sh
+   ntn workers oauth start githubUserOAuth
+   ```
+
+GitHub App user tokens do not use OAuth scopes. Access comes from the app's
+read-only permissions, its installed repositories, and the authorizing user's
+own access. Notion Workers stores the token and handles refresh automatically.
+
+One worker deployment stores one authorization for `githubUserOAuth`; this is
+a user-scoped deployment, not a multi-user OAuth service.
+
+### Option 3: Fine-grained personal access token
+
+Use this for the quickest local evaluation or a small personal deployment:
+
+1. Open **Settings > Developer settings > Personal access tokens >
+   Fine-grained tokens**.
+2. Select the repository owner and limit access to the repositories you want
+   to sync.
+3. Grant read-only **Issues**, **Pull requests**, **Checks**, and **Commit
+   statuses** permissions.
+4. Choose the shortest practical expiration and create the token.
+5. Configure and redeploy the worker:
+
+   ```sh
+   ntn workers env set GITHUB_AUTH_MODE=pat
+   ntn workers env set GITHUB_TOKEN=github_pat_your-token-here
+   ntn workers deploy
+   ```
+
+Fine-grained PATs select one resource owner. An organization may restrict PATs
+or require administrator approval, and you must rotate the token before it
+expires.
+
+## Run the sync
+
+1. Preview a sync without writing to Notion:
 
    ```sh
    ntn workers sync trigger issuesSync --preview
    ntn workers sync trigger openPullRequestsSync --preview
    ```
 
-8. Run a real sync:
+2. Run a real sync:
 
    ```sh
    ntn workers sync trigger issuesSync
@@ -253,11 +403,21 @@ Run offline tests (no GitHub connection needed):
 npm test
 ```
 
-Test a sync locally against real GitHub repos:
+For `installation` or `pat`, test against real GitHub repositories by filling
+only the variables for that mode:
 
 ```sh
 cp .env.example .env
-# Fill in GITHUB_TOKEN and GITHUB_REPOS in .env, then run:
+# Fill in the selected mode's credentials and GITHUB_REPOS, then run:
+ntn workers exec issuesSync --local
+```
+
+For `user`, complete the deployed OAuth flow first, then pull its stored token
+for local execution:
+
+```sh
+ntn workers oauth start githubUserOAuth
+ntn workers env pull
 ntn workers exec issuesSync --local
 ```
 
@@ -270,4 +430,8 @@ ntn workers exec issuesSync --local
 - [GitHub REST API — Check Runs](https://docs.github.com/en/rest/checks/runs)
 - [GitHub REST API — Commit Statuses](https://docs.github.com/en/rest/commits/statuses)
 - [GitHub REST API — Best Practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api)
+- [GitHub App authentication modes](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app)
+- [GitHub App installation authentication](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)
+- [GitHub App user authentication](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-with-a-github-app-on-behalf-of-a-user)
+- [Notion Workers OAuth](https://developers.notion.com/workers/guides/oauth)
 - [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/github/package.json
+++ b/examples/workers/syncs/github/package.json
@@ -17,6 +17,7 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "@notionhq/workers": ">=0.0.0"
+    "@notionhq/workers": "^0.4.0",
+    "@octokit/auth-app": "^8.2.0"
   }
 }

--- a/examples/workers/syncs/github/package.json
+++ b/examples/workers/syncs/github/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit",
+    "check": "tsc --project tsconfig.test.json",
     "test": "tsx test.ts"
   },
   "engines": {

--- a/examples/workers/syncs/github/src/all-pull-requests.ts
+++ b/examples/workers/syncs/github/src/all-pull-requests.ts
@@ -52,8 +52,6 @@ export const pullRequestSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     Closed: Schema.date(),
 
     Merged: Schema.date(),
-
-    "Merged By": Schema.richText(),
   },
 }
 
@@ -77,9 +75,7 @@ export function pullRequestToChange(pr: GitHubPullRequest, repo: string) {
       ...(pr.user ? { Author: Builder.richText(pr.user.login) } : {}),
       ...(pr.assignees.length > 0
         ? {
-            Assignees: Builder.multiSelect(
-              ...pr.assignees.map((a) => a.login)
-            ),
+            Assignees: Builder.multiSelect(...pr.assignees.map((a) => a.login)),
           }
         : {}),
       ...(pr.requested_reviewers.length > 0
@@ -100,15 +96,8 @@ export function pullRequestToChange(pr: GitHubPullRequest, repo: string) {
       Repository: Builder.richText(repo),
       Created: Builder.date(dateOnly(pr.created_at)),
       Updated: Builder.date(dateOnly(pr.updated_at)),
-      ...(pr.closed_at
-        ? { Closed: Builder.date(dateOnly(pr.closed_at)) }
-        : {}),
-      ...(pr.merged_at
-        ? { Merged: Builder.date(dateOnly(pr.merged_at)) }
-        : {}),
-      ...(pr.merged_by
-        ? { "Merged By": Builder.richText(pr.merged_by.login) }
-        : {}),
+      ...(pr.closed_at ? { Closed: Builder.date(dateOnly(pr.closed_at)) } : {}),
+      ...(pr.merged_at ? { Merged: Builder.date(dateOnly(pr.merged_at)) } : {}),
     },
   }
 }

--- a/examples/workers/syncs/github/src/auth.ts
+++ b/examples/workers/syncs/github/src/auth.ts
@@ -1,0 +1,144 @@
+// GitHub authentication. One deployment uses one of three modes:
+//   - installation: a GitHub App installation token (recommended)
+//   - user: a GitHub App user access token managed by Notion Workers OAuth
+//   - pat: a fine-grained personal access token
+
+import type { UserManagedOAuthConfiguration } from "@notionhq/workers"
+import { createAppAuth } from "@octokit/auth-app"
+
+export type GitHubAuthMode = "installation" | "user" | "pat"
+export type GetAccessToken = (repo: string) => Promise<string>
+
+type Environment = Record<string, string | undefined>
+
+type OAuthRegistrar = {
+  oauth(
+    key: string,
+    config: UserManagedOAuthConfiguration
+  ): { accessToken(): Promise<string> }
+}
+
+type InstallationAuthOptions = {
+  appId: string
+  privateKey: string
+  installationId: number
+}
+
+type InstallationTokenFactory = (
+  options: InstallationAuthOptions
+) => () => Promise<string>
+
+type AuthDependencies = {
+  env?: Environment
+  createInstallationToken?: InstallationTokenFactory
+}
+
+const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+export const GITHUB_OAUTH_CAPABILITY_KEY = "githubUserOAuth"
+
+function requireEnv(env: Environment, name: string): string {
+  const value = env[name]?.trim()
+  if (!value) throw new Error(`${name} is not set.`)
+  return value
+}
+
+export function getGitHubAuthMode(
+  env: Environment = process.env
+): GitHubAuthMode {
+  const value = env.GITHUB_AUTH_MODE?.trim().toLowerCase() || "pat"
+  if (value === "installation" || value === "user" || value === "pat") {
+    return value
+  }
+
+  throw new Error(
+    'GITHUB_AUTH_MODE must be one of "installation", "user", or "pat".'
+  )
+}
+
+function positiveIntegerEnv(env: Environment, name: string): number {
+  const raw = requireEnv(env, name)
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`)
+  }
+  return value
+}
+
+function decodePrivateKey(env: Environment): string {
+  const encoded = requireEnv(env, "GITHUB_APP_PRIVATE_KEY_BASE64")
+  const privateKey = Buffer.from(encoded, "base64").toString("utf8").trim()
+
+  if (
+    !/^-----BEGIN (?:RSA )?PRIVATE KEY-----/.test(privateKey) ||
+    !/-----END (?:RSA )?PRIVATE KEY-----$/.test(privateKey)
+  ) {
+    throw new Error(
+      "GITHUB_APP_PRIVATE_KEY_BASE64 must decode to a PEM private key."
+    )
+  }
+
+  return privateKey
+}
+
+const defaultInstallationTokenFactory: InstallationTokenFactory = (options) => {
+  const auth = createAppAuth(options)
+  return async () => {
+    const authentication = await auth({ type: "installation" })
+    return authentication.token
+  }
+}
+
+/**
+ * Selects and configures one GitHub credential source for this deployment.
+ * The returned provider is repository-aware so multi-installation support can
+ * be added later without changing the GitHub API client.
+ */
+export function createGitHubAccessTokenProvider(
+  worker: OAuthRegistrar,
+  dependencies: AuthDependencies = {}
+): GetAccessToken {
+  const env = dependencies.env ?? process.env
+  const mode = getGitHubAuthMode(env)
+  const oauthClientId = env.GITHUB_APP_CLIENT_ID?.trim() ?? ""
+  const oauthClientSecret = env.GITHUB_APP_CLIENT_SECRET?.trim() ?? ""
+  const oauthIsConfigured = Boolean(oauthClientId && oauthClientSecret)
+
+  // Register this for every mode so a first deployment can expose its OAuth
+  // callback URL before the GitHub App client credentials have been created.
+  const oauth = worker.oauth(GITHUB_OAUTH_CAPABILITY_KEY, {
+    name: "github-app-user",
+    clientId: oauthIsConfigured ? oauthClientId : "",
+    clientSecret: oauthIsConfigured ? oauthClientSecret : "",
+    authorizationEndpoint: GITHUB_AUTHORIZE_URL,
+    tokenEndpoint: GITHUB_TOKEN_URL,
+    // GitHub Apps use app permissions, not OAuth scopes.
+    scope: "",
+  })
+
+  if (mode === "pat") {
+    return async () => requireEnv(env, "GITHUB_TOKEN")
+  }
+
+  if (mode === "user") {
+    return async () => oauth.accessToken()
+  }
+
+  const createInstallationToken =
+    dependencies.createInstallationToken ?? defaultInstallationTokenFactory
+  let installationToken: (() => Promise<string>) | undefined
+
+  return async (_repo: string) => {
+    // Secrets are normally added after the first deployment. Initialize the
+    // strategy on its first request so that initial deployment can succeed.
+    installationToken ??= createInstallationToken({
+      // GitHub recommends the App's client ID as the JWT issuer. Octokit's
+      // appId option accepts either the client ID or the numeric App ID.
+      appId: requireEnv(env, "GITHUB_APP_CLIENT_ID"),
+      privateKey: decodePrivateKey(env),
+      installationId: positiveIntegerEnv(env, "GITHUB_APP_INSTALLATION_ID"),
+    })
+    return installationToken()
+  }
+}

--- a/examples/workers/syncs/github/src/github.ts
+++ b/examples/workers/syncs/github/src/github.ts
@@ -1,12 +1,18 @@
 // GitHub REST API client. Handles authentication and paginated fetching
-// for issues, pull requests, reviews, and check runs.
+// for issues, pull requests, reviews, check runs, and commit statuses.
 //
 // To add a new resource (e.g. releases, actions runs):
 //   1. Add a type for the API response shape
 //   2. Add a fetchXxxPage() function using fetchPage()
 //   3. Wire it into index.ts
 
+import { RateLimitError } from "@notionhq/workers"
+
+const API_BASE_URL = "https://api.github.com"
+const API_VERSION = "2026-03-10"
 const PER_PAGE = 100
+
+export type BeforeRequest = () => Promise<void>
 
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim()
@@ -16,49 +22,166 @@ function requireEnv(name: string): string {
   return value
 }
 
-export function getRepos(): string[] {
-  const raw = requireEnv("GITHUB_REPOS")
-  return raw
-    .split(",")
-    .map((r) => r.trim())
-    .filter(Boolean)
+function isOwnerRepo(value: string): boolean {
+  const [owner, repo, extra] = value.split("/")
+  return (
+    extra === undefined &&
+    repo !== undefined &&
+    /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(owner) &&
+    repo !== "." &&
+    repo !== ".." &&
+    /^[A-Za-z0-9._-]+$/.test(repo)
+  )
 }
 
-// Generic paginated fetch for any GitHub list endpoint.
-// GitHub uses page-based pagination; hasMore is true when a full page is returned.
-async function fetchPage<T>(
-  path: string,
-  params?: Record<string, string>,
-  page?: number
-): Promise<{ items: T[]; hasMore: boolean }> {
-  const token = requireEnv("GITHUB_TOKEN")
-  const p = page ?? 1
-  const url = new URL(`https://api.github.com${path}`)
-  url.searchParams.set("per_page", String(PER_PAGE))
-  url.searchParams.set("page", String(p))
-  if (params) {
-    for (const [k, v] of Object.entries(params)) {
-      url.searchParams.set(k, v)
+export function getRepos(): string[] {
+  const raw = requireEnv("GITHUB_REPOS")
+  const repos: string[] = []
+  const seen = new Set<string>()
+
+  for (const value of raw.split(",")) {
+    const repo = value.trim()
+    if (!repo) continue
+    if (!isOwnerRepo(repo)) {
+      throw new Error(
+        `Invalid GITHUB_REPOS entry "${repo}". Expected owner/repo.`
+      )
+    }
+
+    const key = repo.toLowerCase()
+    if (!seen.has(key)) {
+      repos.push(repo)
+      seen.add(key)
     }
   }
 
-  const response = await fetch(url.toString(), {
+  if (repos.length === 0) {
+    throw new Error("GITHUB_REPOS must contain at least one owner/repo.")
+  }
+
+  return repos
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value?.trim()) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds)
+  }
+
+  const retryAt = Date.parse(value)
+  if (Number.isNaN(retryAt)) return undefined
+  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1_000))
+}
+
+function retryAfterSeconds(response: Response): number {
+  const retryAfter = parseRetryAfter(response.headers.get("Retry-After"))
+  if (retryAfter !== undefined) return retryAfter
+
+  if (response.headers.get("X-RateLimit-Remaining") === "0") {
+    const resetHeader = response.headers.get("X-RateLimit-Reset")
+    if (resetHeader !== null) {
+      const resetAt = Number(resetHeader)
+      if (Number.isFinite(resetAt) && resetAt >= 0) {
+        return Math.max(0, Math.ceil(resetAt - Date.now() / 1_000))
+      }
+    }
+  }
+
+  // GitHub recommends waiting at least one minute before retrying a secondary
+  // rate limit response that does not include Retry-After.
+  return 60
+}
+
+function isRateLimitResponse(response: Response, body: string): boolean {
+  if (response.status === 429) return true
+  if (response.status !== 403) return false
+
+  return (
+    response.headers.has("Retry-After") ||
+    response.headers.get("X-RateLimit-Remaining") === "0" ||
+    /(?:secondary |api )?rate limit|abuse detection/i.test(body)
+  )
+}
+
+type JsonResponse<T> = {
+  data: T
+  headers: Headers
+}
+
+async function fetchJson<T>(
+  url: URL,
+  beforeRequest: BeforeRequest
+): Promise<JsonResponse<T>> {
+  await beforeRequest()
+
+  const response = await fetch(url, {
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${requireEnv("GITHUB_TOKEN")}`,
       Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
+      "X-GitHub-Api-Version": API_VERSION,
+      "User-Agent": "notion-cookbook-github-sync",
     },
   })
 
   const text = await response.text()
+  if (isRateLimitResponse(response, text)) {
+    throw new RateLimitError({ retryAfter: retryAfterSeconds(response) })
+  }
   if (!response.ok) {
     throw new Error(
       `GitHub API error (${response.status}): ${text || "No response body"}`
     )
   }
 
-  const items = JSON.parse(text) as T[]
-  return { items, hasMore: items.length === PER_PAGE }
+  return {
+    data: JSON.parse(text) as T,
+    headers: response.headers,
+  }
+}
+
+function nextPageFromLink(link: string | null): number | undefined {
+  if (!link) return undefined
+
+  const entryPattern = /<([^>]+)>\s*;\s*rel="([^"]+)"/g
+  for (const match of link.matchAll(entryPattern)) {
+    if (!match[2].split(/\s+/).includes("next")) continue
+
+    const page = Number(
+      new URL(match[1], API_BASE_URL).searchParams.get("page")
+    )
+    if (!Number.isSafeInteger(page) || page < 1) {
+      throw new Error("GitHub pagination response has an invalid next page")
+    }
+    return page
+  }
+
+  return undefined
+}
+
+// Generic paginated fetch for GitHub endpoints whose response is a JSON array.
+// GitHub's Link header is authoritative; a full final page has no next link.
+async function fetchPage<T>(
+  path: string,
+  params: Record<string, string> | undefined,
+  page: number | undefined,
+  beforeRequest: BeforeRequest
+): Promise<{ items: T[]; nextPage: number | undefined }> {
+  const url = new URL(path, API_BASE_URL)
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value)
+    }
+  }
+  url.searchParams.set("per_page", String(PER_PAGE))
+  url.searchParams.set("page", String(page ?? 1))
+
+  const { data, headers } = await fetchJson<T[]>(url, beforeRequest)
+  return {
+    items: data,
+    nextPage: nextPageFromLink(headers.get("Link")),
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -88,16 +211,18 @@ export type GitHubIssue = {
 // The /issues endpoint returns both issues and PRs. We filter out PRs here.
 export async function fetchIssuesPage(
   repo: string,
-  page?: number
-): Promise<{ issues: GitHubIssue[]; hasMore: boolean }> {
-  const { items, hasMore } = await fetchPage<GitHubIssue>(
+  page: number | undefined,
+  beforeRequest: BeforeRequest
+): Promise<{ issues: GitHubIssue[]; nextPage: number | undefined }> {
+  const { items, nextPage } = await fetchPage<GitHubIssue>(
     `/repos/${repo}/issues`,
-    { state: "all", sort: "updated", direction: "desc" },
-    page
+    { state: "all", sort: "created", direction: "asc" },
+    page,
+    beforeRequest
   )
 
-  const issues = items.filter((i) => !i.pull_request)
-  return { issues, hasMore }
+  const issues = items.filter((issue) => !issue.pull_request)
+  return { issues, nextPage }
 }
 
 // ---------------------------------------------------------------------------
@@ -118,7 +243,6 @@ export type GitHubPullRequest = {
   milestone: { title: string } | null
   base: { ref: string }
   head: { ref: string; sha: string }
-  merged_by: { login: string } | null
   html_url: string
   closed_at: string | null
   merged_at: string | null
@@ -128,16 +252,21 @@ export type GitHubPullRequest = {
 
 export async function fetchPullRequestsPage(
   repo: string,
-  page?: number,
-  state?: string
-): Promise<{ pullRequests: GitHubPullRequest[]; hasMore: boolean }> {
-  const { items, hasMore } = await fetchPage<GitHubPullRequest>(
+  page: number | undefined,
+  state: string | undefined,
+  beforeRequest: BeforeRequest
+): Promise<{
+  pullRequests: GitHubPullRequest[]
+  nextPage: number | undefined
+}> {
+  const { items, nextPage } = await fetchPage<GitHubPullRequest>(
     `/repos/${repo}/pulls`,
-    { state: state ?? "all", sort: "updated", direction: "desc" },
-    page
+    { state: state ?? "all", sort: "created", direction: "asc" },
+    page,
+    beforeRequest
   )
 
-  return { pullRequests: items, hasMore }
+  return { pullRequests: items, nextPage }
 }
 
 // ---------------------------------------------------------------------------
@@ -154,12 +283,27 @@ export type GitHubReview = {
 
 export async function fetchReviews(
   repo: string,
-  prNumber: number
+  prNumber: number,
+  beforeRequest: BeforeRequest
 ): Promise<GitHubReview[]> {
-  const { items } = await fetchPage<GitHubReview>(
-    `/repos/${repo}/pulls/${prNumber}/reviews`
-  )
-  return items
+  const reviews: GitHubReview[] = []
+  let page: number | undefined = 1
+
+  while (page !== undefined) {
+    const result: {
+      items: GitHubReview[]
+      nextPage: number | undefined
+    } = await fetchPage<GitHubReview>(
+      `/repos/${repo}/pulls/${prNumber}/reviews`,
+      undefined,
+      page,
+      beforeRequest
+    )
+    reviews.push(...result.items)
+    page = result.nextPage
+  }
+
+  return reviews
 }
 
 // ---------------------------------------------------------------------------
@@ -180,26 +324,53 @@ type CheckRunsResponse = {
 
 export async function fetchCheckRuns(
   repo: string,
-  sha: string
+  sha: string,
+  beforeRequest: BeforeRequest
 ): Promise<GitHubCheckRun[]> {
-  const token = requireEnv("GITHUB_TOKEN")
-  const url = `https://api.github.com/repos/${repo}/commits/${sha}/check-runs`
+  const checkRuns: GitHubCheckRun[] = []
+  let page: number | undefined = 1
 
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  })
-
-  const text = await response.text()
-  if (!response.ok) {
-    throw new Error(
-      `GitHub API error (${response.status}): ${text || "No response body"}`
+  while (page !== undefined) {
+    const url = new URL(
+      `/repos/${repo}/commits/${sha}/check-runs`,
+      API_BASE_URL
     )
+    url.searchParams.set("per_page", String(PER_PAGE))
+    url.searchParams.set("page", String(page))
+
+    const { data, headers } = await fetchJson<CheckRunsResponse>(
+      url,
+      beforeRequest
+    )
+    checkRuns.push(...data.check_runs)
+    page = nextPageFromLink(headers.get("Link"))
   }
 
-  const body = JSON.parse(text) as CheckRunsResponse
-  return body.check_runs
+  return checkRuns
+}
+
+// ---------------------------------------------------------------------------
+// Combined Commit Status (classic status contexts)
+// https://docs.github.com/en/rest/commits/statuses#get-the-combined-status-for-a-specific-reference
+// ---------------------------------------------------------------------------
+
+export type GitHubCombinedStatus = {
+  state: string
+  total_count: number
+}
+
+type CombinedStatusResponse = GitHubCombinedStatus & {
+  statuses: unknown[]
+}
+
+export async function fetchCombinedStatus(
+  repo: string,
+  sha: string,
+  beforeRequest: BeforeRequest
+): Promise<GitHubCombinedStatus> {
+  const url = new URL(`/repos/${repo}/commits/${sha}/status`, API_BASE_URL)
+  url.searchParams.set("per_page", String(PER_PAGE))
+
+  const { data } = await fetchJson<CombinedStatusResponse>(url, beforeRequest)
+  return { state: data.state, total_count: data.total_count }
 }

--- a/examples/workers/syncs/github/src/github.ts
+++ b/examples/workers/syncs/github/src/github.ts
@@ -1,4 +1,4 @@
-// GitHub REST API client. Handles authentication and paginated fetching
+// GitHub REST API client. Handles authenticated requests and pagination
 // for issues, pull requests, reviews, check runs, and commit statuses.
 //
 // To add a new resource (e.g. releases, actions runs):
@@ -8,11 +8,18 @@
 
 import { RateLimitError } from "@notionhq/workers"
 
+import type { GetAccessToken } from "./auth.js"
+
 const API_BASE_URL = "https://api.github.com"
 const API_VERSION = "2026-03-10"
 const PER_PAGE = 100
 
 export type BeforeRequest = () => Promise<void>
+
+export type GitHubClientOptions = {
+  beforeRequest: BeforeRequest
+  getAccessToken: GetAccessToken
+}
 
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim()
@@ -60,6 +67,24 @@ export function getRepos(): string[] {
   }
 
   return repos
+}
+
+export function createGitHubClient(options: GitHubClientOptions) {
+  return {
+    fetchIssuesPage: (repo: string, page: number | undefined) =>
+      fetchIssuesPage(repo, page, options),
+    fetchPullRequestsPage: (
+      repo: string,
+      page: number | undefined,
+      state: string | undefined
+    ) => fetchPullRequestsPage(repo, page, state, options),
+    fetchReviews: (repo: string, prNumber: number) =>
+      fetchReviews(repo, prNumber, options),
+    fetchCheckRuns: (repo: string, sha: string) =>
+      fetchCheckRuns(repo, sha, options),
+    fetchCombinedStatus: (repo: string, sha: string) =>
+      fetchCombinedStatus(repo, sha, options),
+  }
 }
 
 function parseRetryAfter(value: string | null): number | undefined {
@@ -112,13 +137,15 @@ type JsonResponse<T> = {
 
 async function fetchJson<T>(
   url: URL,
-  beforeRequest: BeforeRequest
+  repo: string,
+  options: GitHubClientOptions
 ): Promise<JsonResponse<T>> {
-  await beforeRequest()
+  await options.beforeRequest()
+  const accessToken = await options.getAccessToken(repo)
 
   const response = await fetch(url, {
     headers: {
-      Authorization: `Bearer ${requireEnv("GITHUB_TOKEN")}`,
+      Authorization: `Bearer ${accessToken}`,
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": API_VERSION,
       "User-Agent": "notion-cookbook-github-sync",
@@ -163,10 +190,11 @@ function nextPageFromLink(link: string | null): number | undefined {
 // Generic paginated fetch for GitHub endpoints whose response is a JSON array.
 // GitHub's Link header is authoritative; a full final page has no next link.
 async function fetchPage<T>(
+  repo: string,
   path: string,
   params: Record<string, string> | undefined,
   page: number | undefined,
-  beforeRequest: BeforeRequest
+  options: GitHubClientOptions
 ): Promise<{ items: T[]; nextPage: number | undefined }> {
   const url = new URL(path, API_BASE_URL)
   if (params) {
@@ -177,7 +205,7 @@ async function fetchPage<T>(
   url.searchParams.set("per_page", String(PER_PAGE))
   url.searchParams.set("page", String(page ?? 1))
 
-  const { data, headers } = await fetchJson<T[]>(url, beforeRequest)
+  const { data, headers } = await fetchJson<T[]>(url, repo, options)
   return {
     items: data,
     nextPage: nextPageFromLink(headers.get("Link")),
@@ -209,16 +237,17 @@ export type GitHubIssue = {
 }
 
 // The /issues endpoint returns both issues and PRs. We filter out PRs here.
-export async function fetchIssuesPage(
+async function fetchIssuesPage(
   repo: string,
   page: number | undefined,
-  beforeRequest: BeforeRequest
+  options: GitHubClientOptions
 ): Promise<{ issues: GitHubIssue[]; nextPage: number | undefined }> {
   const { items, nextPage } = await fetchPage<GitHubIssue>(
+    repo,
     `/repos/${repo}/issues`,
     { state: "all", sort: "created", direction: "asc" },
     page,
-    beforeRequest
+    options
   )
 
   const issues = items.filter((issue) => !issue.pull_request)
@@ -250,20 +279,21 @@ export type GitHubPullRequest = {
   updated_at: string
 }
 
-export async function fetchPullRequestsPage(
+async function fetchPullRequestsPage(
   repo: string,
   page: number | undefined,
   state: string | undefined,
-  beforeRequest: BeforeRequest
+  options: GitHubClientOptions
 ): Promise<{
   pullRequests: GitHubPullRequest[]
   nextPage: number | undefined
 }> {
   const { items, nextPage } = await fetchPage<GitHubPullRequest>(
+    repo,
     `/repos/${repo}/pulls`,
     { state: state ?? "all", sort: "created", direction: "asc" },
     page,
-    beforeRequest
+    options
   )
 
   return { pullRequests: items, nextPage }
@@ -281,10 +311,10 @@ export type GitHubReview = {
   submitted_at: string | null
 }
 
-export async function fetchReviews(
+async function fetchReviews(
   repo: string,
   prNumber: number,
-  beforeRequest: BeforeRequest
+  options: GitHubClientOptions
 ): Promise<GitHubReview[]> {
   const reviews: GitHubReview[] = []
   let page: number | undefined = 1
@@ -294,10 +324,11 @@ export async function fetchReviews(
       items: GitHubReview[]
       nextPage: number | undefined
     } = await fetchPage<GitHubReview>(
+      repo,
       `/repos/${repo}/pulls/${prNumber}/reviews`,
       undefined,
       page,
-      beforeRequest
+      options
     )
     reviews.push(...result.items)
     page = result.nextPage
@@ -322,10 +353,10 @@ type CheckRunsResponse = {
   check_runs: GitHubCheckRun[]
 }
 
-export async function fetchCheckRuns(
+async function fetchCheckRuns(
   repo: string,
   sha: string,
-  beforeRequest: BeforeRequest
+  options: GitHubClientOptions
 ): Promise<GitHubCheckRun[]> {
   const checkRuns: GitHubCheckRun[] = []
   let page: number | undefined = 1
@@ -340,7 +371,8 @@ export async function fetchCheckRuns(
 
     const { data, headers } = await fetchJson<CheckRunsResponse>(
       url,
-      beforeRequest
+      repo,
+      options
     )
     checkRuns.push(...data.check_runs)
     page = nextPageFromLink(headers.get("Link"))
@@ -363,14 +395,14 @@ type CombinedStatusResponse = GitHubCombinedStatus & {
   statuses: unknown[]
 }
 
-export async function fetchCombinedStatus(
+async function fetchCombinedStatus(
   repo: string,
   sha: string,
-  beforeRequest: BeforeRequest
+  options: GitHubClientOptions
 ): Promise<GitHubCombinedStatus> {
   const url = new URL(`/repos/${repo}/commits/${sha}/status`, API_BASE_URL)
   url.searchParams.set("per_page", String(PER_PAGE))
 
-  const { data } = await fetchJson<CombinedStatusResponse>(url, beforeRequest)
+  const { data } = await fetchJson<CombinedStatusResponse>(url, repo, options)
   return { state: data.state, total_count: data.total_count }
 }

--- a/examples/workers/syncs/github/src/index.ts
+++ b/examples/workers/syncs/github/src/index.ts
@@ -4,7 +4,7 @@
 // Three databases are created:
 //   1. Issues        — all issues, synced every 5 min
 //   2. All PRs       — all pull requests (basic fields), synced every 5 min
-//   3. Open PRs      — open PRs enriched with review + CI status, synced every 2 min
+//   3. Open PRs      — open PRs enriched with review + CI status, synced every 5 min
 
 import { Worker } from "@notionhq/workers"
 
@@ -14,6 +14,7 @@ import {
   fetchPullRequestsPage,
   fetchReviews,
   fetchCheckRuns,
+  fetchCombinedStatus,
 } from "./github.js"
 import {
   INITIAL_TITLE as ISSUES_TITLE,
@@ -47,6 +48,8 @@ const pacer = worker.pacer("github", {
   intervalMs: 3_600_000,
 })
 
+const beforeGitHubRequest = () => pacer.wait()
+
 // ---------------------------------------------------------------------------
 // Issues
 // ---------------------------------------------------------------------------
@@ -63,8 +66,6 @@ worker.sync("issuesSync", {
   mode: "replace",
   schedule: "5m",
   execute: async (state: SyncState | undefined) => {
-    await pacer.wait()
-
     const repos = getRepos()
     const repoIndex = state?.repoIndex ?? 0
     const page = state?.page ?? 1
@@ -74,14 +75,14 @@ worker.sync("issuesSync", {
       return { changes: [], hasMore: false }
     }
 
-    const result = await fetchIssuesPage(repo, page)
+    const result = await fetchIssuesPage(repo, page, beforeGitHubRequest)
     const changes = result.issues.map((i) => issueToChange(i, repo))
 
-    if (result.hasMore) {
+    if (result.nextPage !== undefined) {
       return {
         changes,
         hasMore: true,
-        nextState: { repoIndex, page: page + 1 },
+        nextState: { repoIndex, page: result.nextPage },
       }
     }
 
@@ -114,8 +115,6 @@ worker.sync("allPullRequestsSync", {
   mode: "replace",
   schedule: "5m",
   execute: async (state: SyncState | undefined) => {
-    await pacer.wait()
-
     const repos = getRepos()
     const repoIndex = state?.repoIndex ?? 0
     const page = state?.page ?? 1
@@ -125,16 +124,21 @@ worker.sync("allPullRequestsSync", {
       return { changes: [], hasMore: false }
     }
 
-    const result = await fetchPullRequestsPage(repo, page)
+    const result = await fetchPullRequestsPage(
+      repo,
+      page,
+      "all",
+      beforeGitHubRequest
+    )
     const changes = result.pullRequests.map((pr) =>
       pullRequestToChange(pr, repo)
     )
 
-    if (result.hasMore) {
+    if (result.nextPage !== undefined) {
       return {
         changes,
         hasMore: true,
-        nextState: { repoIndex, page: page + 1 },
+        nextState: { repoIndex, page: result.nextPage },
       }
     }
 
@@ -165,10 +169,8 @@ const openPullRequests = worker.database("openPullRequests", {
 worker.sync("openPullRequestsSync", {
   database: openPullRequests,
   mode: "replace",
-  schedule: "2m",
+  schedule: "5m",
   execute: async (state: SyncState | undefined) => {
-    await pacer.wait()
-
     const repos = getRepos()
     const repoIndex = state?.repoIndex ?? 0
     const page = state?.page ?? 1
@@ -178,22 +180,39 @@ worker.sync("openPullRequestsSync", {
       return { changes: [], hasMore: false }
     }
 
-    const result = await fetchPullRequestsPage(repo, page, "open")
+    // Scan all PRs in stable created order so a PR closing during a replace
+    // cycle cannot shift the membership of later pages. Only open PRs are
+    // emitted, so closed PRs are still swept from this database.
+    const result = await fetchPullRequestsPage(
+      repo,
+      page,
+      "all",
+      beforeGitHubRequest
+    )
     const changes = []
 
-    for (const pr of result.pullRequests) {
-      await pacer.wait()
-      const reviews = await fetchReviews(repo, pr.number)
-      await pacer.wait()
-      const checkRuns = await fetchCheckRuns(repo, pr.head.sha)
-      changes.push(openPullRequestToChange(pr, repo, reviews, checkRuns))
+    for (const pr of result.pullRequests.filter((pr) => pr.state === "open")) {
+      const reviews = await fetchReviews(repo, pr.number, beforeGitHubRequest)
+      const checkRuns = await fetchCheckRuns(
+        repo,
+        pr.head.sha,
+        beforeGitHubRequest
+      )
+      const combinedStatus = await fetchCombinedStatus(
+        repo,
+        pr.head.sha,
+        beforeGitHubRequest
+      )
+      changes.push(
+        openPullRequestToChange(pr, repo, reviews, checkRuns, combinedStatus)
+      )
     }
 
-    if (result.hasMore) {
+    if (result.nextPage !== undefined) {
       return {
         changes,
         hasMore: true,
-        nextState: { repoIndex, page: page + 1 },
+        nextState: { repoIndex, page: result.nextPage },
       }
     }
 

--- a/examples/workers/syncs/github/src/index.ts
+++ b/examples/workers/syncs/github/src/index.ts
@@ -8,14 +8,8 @@
 
 import { Worker } from "@notionhq/workers"
 
-import {
-  getRepos,
-  fetchIssuesPage,
-  fetchPullRequestsPage,
-  fetchReviews,
-  fetchCheckRuns,
-  fetchCombinedStatus,
-} from "./github.js"
+import { createGitHubAccessTokenProvider } from "./auth.js"
+import { createGitHubClient, getRepos } from "./github.js"
 import {
   INITIAL_TITLE as ISSUES_TITLE,
   PRIMARY_KEY as ISSUES_PK,
@@ -49,6 +43,10 @@ const pacer = worker.pacer("github", {
 })
 
 const beforeGitHubRequest = () => pacer.wait()
+const github = createGitHubClient({
+  beforeRequest: beforeGitHubRequest,
+  getAccessToken: createGitHubAccessTokenProvider(worker),
+})
 
 // ---------------------------------------------------------------------------
 // Issues
@@ -75,7 +73,7 @@ worker.sync("issuesSync", {
       return { changes: [], hasMore: false }
     }
 
-    const result = await fetchIssuesPage(repo, page, beforeGitHubRequest)
+    const result = await github.fetchIssuesPage(repo, page)
     const changes = result.issues.map((i) => issueToChange(i, repo))
 
     if (result.nextPage !== undefined) {
@@ -124,12 +122,7 @@ worker.sync("allPullRequestsSync", {
       return { changes: [], hasMore: false }
     }
 
-    const result = await fetchPullRequestsPage(
-      repo,
-      page,
-      "all",
-      beforeGitHubRequest
-    )
+    const result = await github.fetchPullRequestsPage(repo, page, "all")
     const changes = result.pullRequests.map((pr) =>
       pullRequestToChange(pr, repo)
     )
@@ -183,26 +176,13 @@ worker.sync("openPullRequestsSync", {
     // Scan all PRs in stable created order so a PR closing during a replace
     // cycle cannot shift the membership of later pages. Only open PRs are
     // emitted, so closed PRs are still swept from this database.
-    const result = await fetchPullRequestsPage(
-      repo,
-      page,
-      "all",
-      beforeGitHubRequest
-    )
+    const result = await github.fetchPullRequestsPage(repo, page, "all")
     const changes = []
 
     for (const pr of result.pullRequests.filter((pr) => pr.state === "open")) {
-      const reviews = await fetchReviews(repo, pr.number, beforeGitHubRequest)
-      const checkRuns = await fetchCheckRuns(
-        repo,
-        pr.head.sha,
-        beforeGitHubRequest
-      )
-      const combinedStatus = await fetchCombinedStatus(
-        repo,
-        pr.head.sha,
-        beforeGitHubRequest
-      )
+      const reviews = await github.fetchReviews(repo, pr.number)
+      const checkRuns = await github.fetchCheckRuns(repo, pr.head.sha)
+      const combinedStatus = await github.fetchCombinedStatus(repo, pr.head.sha)
       changes.push(
         openPullRequestToChange(pr, repo, reviews, checkRuns, combinedStatus)
       )

--- a/examples/workers/syncs/github/src/open-pull-requests.ts
+++ b/examples/workers/syncs/github/src/open-pull-requests.ts
@@ -1,14 +1,18 @@
 // Open Pull Requests sync — tracks active PRs with review and CI status.
 //
 // This table only contains open PRs and is enriched with per-PR data
-// (review decisions and check run results) that the list endpoint does
-// not provide. Because only open PRs are fetched, the extra API calls
-// stay well within rate limits even at a 2-minute sync interval.
+// (review activity, check runs, and commit statuses) that the list endpoint
+// does not provide.
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
 import { notionIcon } from "@notionhq/workers"
-import type { GitHubPullRequest, GitHubReview, GitHubCheckRun } from "./github.js"
+import type {
+  GitHubPullRequest,
+  GitHubReview,
+  GitHubCheckRun,
+  GitHubCombinedStatus,
+} from "./github.js"
 import { dateOnly } from "./helpers.js"
 
 export const INITIAL_TITLE = "Open GitHub PRs"
@@ -19,7 +23,7 @@ export const openPullRequestSchema: Schema.Schema<typeof PRIMARY_KEY> = {
   properties: {
     Title: Schema.title(),
 
-    "Review State": Schema.select([
+    "Review Activity": Schema.select([
       { name: "Approved" },
       { name: "Changes Requested" },
     ]),
@@ -77,11 +81,61 @@ export function reviewState(reviews: GitHubReview[]): string | undefined {
   return undefined
 }
 
-export function ciStatus(checkRuns: GitHubCheckRun[]): string | undefined {
-  if (checkRuns.length === 0) return undefined
-  if (checkRuns.some((c) => c.conclusion === "failure")) return "Failure"
-  if (checkRuns.some((c) => c.status !== "completed")) return "Pending"
-  if (checkRuns.every((c) => c.conclusion === "success")) return "Success"
+const FAILING_CHECK_CONCLUSIONS = new Set([
+  "failure",
+  "timed_out",
+  "cancelled",
+  "action_required",
+  "startup_failure",
+  "stale",
+])
+
+const SUCCESSFUL_CHECK_CONCLUSIONS = new Set(["success", "neutral", "skipped"])
+
+export function ciStatus(
+  checkRuns: GitHubCheckRun[],
+  combinedStatus: GitHubCombinedStatus
+): string | undefined {
+  const hasCommitStatuses = combinedStatus.total_count > 0
+
+  if (
+    checkRuns.some(
+      (check) =>
+        check.conclusion !== null &&
+        FAILING_CHECK_CONCLUSIONS.has(check.conclusion)
+    ) ||
+    (hasCommitStatuses &&
+      (combinedStatus.state === "failure" || combinedStatus.state === "error"))
+  ) {
+    return "Failure"
+  }
+
+  if (
+    checkRuns.some((check) => check.status !== "completed") ||
+    (hasCommitStatuses && combinedStatus.state === "pending")
+  ) {
+    return "Pending"
+  }
+
+  const checksSucceeded =
+    checkRuns.length > 0 &&
+    checkRuns.every(
+      (check) =>
+        check.status === "completed" &&
+        check.conclusion !== null &&
+        SUCCESSFUL_CHECK_CONCLUSIONS.has(check.conclusion)
+    )
+  const statusesSucceeded =
+    hasCommitStatuses && combinedStatus.state === "success"
+
+  if (
+    (checkRuns.length === 0 || checksSucceeded) &&
+    (!hasCommitStatuses || statusesSucceeded) &&
+    (checksSucceeded || statusesSucceeded)
+  ) {
+    return "Success"
+  }
+
   return undefined
 }
 
@@ -89,29 +143,27 @@ export function openPullRequestToChange(
   pr: GitHubPullRequest,
   repo: string,
   reviews: GitHubReview[],
-  checkRuns: GitHubCheckRun[]
+  checkRuns: GitHubCheckRun[],
+  combinedStatus: GitHubCombinedStatus
 ) {
   const review = reviewState(reviews)
-  const ci = ciStatus(checkRuns)
+  const ci = ciStatus(checkRuns, combinedStatus)
 
   return {
     type: "upsert" as const,
     key: `${repo}#${pr.number}`,
-    upstreamUpdatedAt: pr.updated_at,
     pageContentMarkdown: pr.body ?? "",
     properties: {
       Title: Builder.title(pr.title),
       "PR Key": Builder.richText(`${repo}#${pr.number}`),
       "PR Link": Builder.url(pr.html_url),
       Draft: Builder.checkbox(pr.draft),
-      ...(review ? { "Review State": Builder.select(review) } : {}),
+      ...(review ? { "Review Activity": Builder.select(review) } : {}),
       ...(ci ? { "CI Status": Builder.select(ci) } : {}),
       ...(pr.user ? { Author: Builder.richText(pr.user.login) } : {}),
       ...(pr.assignees.length > 0
         ? {
-            Assignees: Builder.multiSelect(
-              ...pr.assignees.map((a) => a.login)
-            ),
+            Assignees: Builder.multiSelect(...pr.assignees.map((a) => a.login)),
           }
         : {}),
       ...(pr.requested_reviewers.length > 0

--- a/examples/workers/syncs/github/test.ts
+++ b/examples/workers/syncs/github/test.ts
@@ -2,8 +2,16 @@
 // No GitHub connection is made — API assertions use mocked fetch responses.
 // Run: npm test  (or: npx tsx test.ts)
 
-import { RateLimitError } from "@notionhq/workers"
+import {
+  RateLimitError,
+  type UserManagedOAuthConfiguration,
+} from "@notionhq/workers"
 import worker from "./src/index.js"
+import {
+  createGitHubAccessTokenProvider,
+  GITHUB_OAUTH_CAPABILITY_KEY,
+  getGitHubAuthMode,
+} from "./src/auth.js"
 import { issueToChange } from "./src/issues.js"
 import { pullRequestToChange } from "./src/all-pull-requests.js"
 import {
@@ -12,13 +20,7 @@ import {
   ciStatus,
 } from "./src/open-pull-requests.js"
 import { dateOnly } from "./src/helpers.js"
-import {
-  fetchCheckRuns,
-  fetchCombinedStatus,
-  fetchIssuesPage,
-  fetchReviews,
-  getRepos,
-} from "./src/github.js"
+import { createGitHubClient, getRepos } from "./src/github.js"
 import type {
   GitHubCombinedStatus,
   GitHubIssue,
@@ -611,6 +613,159 @@ if (origRepos) process.env.GITHUB_REPOS = origRepos
 else delete process.env.GITHUB_REPOS
 
 // ---------------------------------------------------------------------------
+// GitHub authentication modes
+// ---------------------------------------------------------------------------
+
+type OAuthRegistration = {
+  key: string
+  config: UserManagedOAuthConfiguration
+}
+
+function fakeOAuthWorker(accessToken = "github-user-token") {
+  const registrations: OAuthRegistration[] = []
+  return {
+    registrations,
+    worker: {
+      oauth(key: string, config: UserManagedOAuthConfiguration) {
+        registrations.push({ key, config })
+        return { accessToken: async () => accessToken }
+      },
+    },
+  }
+}
+
+async function runAuthTests() {
+  console.log("GitHub authentication:")
+
+  ok(
+    "PAT remains the backwards-compatible default",
+    getGitHubAuthMode({}) === "pat"
+  )
+  ok(
+    "auth mode is normalized",
+    getGitHubAuthMode({ GITHUB_AUTH_MODE: " Installation " }) === "installation"
+  )
+
+  let invalidModeThrew = false
+  try {
+    getGitHubAuthMode({ GITHUB_AUTH_MODE: "oauth-app" })
+  } catch {
+    invalidModeThrew = true
+  }
+  ok("rejects an unknown auth mode", invalidModeThrew)
+
+  const patOAuth = fakeOAuthWorker()
+  const patToken = createGitHubAccessTokenProvider(patOAuth.worker, {
+    env: { GITHUB_AUTH_MODE: "pat", GITHUB_TOKEN: " github_pat_test " },
+  })
+  ok(
+    "PAT mode returns the configured token",
+    (await patToken(REPO)) === "github_pat_test"
+  )
+  ok(
+    "OAuth is registered even before app credentials exist",
+    patOAuth.registrations.length === 1 &&
+      patOAuth.registrations[0].config.clientId === "" &&
+      patOAuth.registrations[0].config.clientSecret === ""
+  )
+
+  const userOAuth = fakeOAuthWorker("github-user-token")
+  const userToken = createGitHubAccessTokenProvider(userOAuth.worker, {
+    env: {
+      GITHUB_AUTH_MODE: "user",
+      GITHUB_APP_CLIENT_ID: "Iv1.client-id",
+      GITHUB_APP_CLIENT_SECRET: "client-secret",
+    },
+  })
+  const userRegistration = userOAuth.registrations[0]
+  ok(
+    "user mode reads the Workers-managed OAuth token",
+    (await userToken(REPO)) === "github-user-token"
+  )
+  ok(
+    "user mode registers GitHub App OAuth without legacy scopes",
+    userRegistration.key === GITHUB_OAUTH_CAPABILITY_KEY &&
+      userRegistration.config.clientId === "Iv1.client-id" &&
+      userRegistration.config.clientSecret === "client-secret" &&
+      userRegistration.config.scope === "" &&
+      userRegistration.config.authorizationEndpoint ===
+        "https://github.com/login/oauth/authorize" &&
+      userRegistration.config.tokenEndpoint ===
+        "https://github.com/login/oauth/access_token"
+  )
+
+  const privateKey = [
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "test-key",
+    "-----END RSA PRIVATE KEY-----",
+  ].join("\n")
+  let installationOptions:
+    { appId: string; privateKey: string; installationId: number } | undefined
+  let installationFactoryCalls = 0
+  let installationTokenRequests = 0
+  const installationOAuth = fakeOAuthWorker()
+  const installationToken = createGitHubAccessTokenProvider(
+    installationOAuth.worker,
+    {
+      env: {
+        GITHUB_AUTH_MODE: "installation",
+        GITHUB_APP_CLIENT_ID: "Iv1.client-id",
+        GITHUB_APP_PRIVATE_KEY_BASE64:
+          Buffer.from(privateKey).toString("base64"),
+        GITHUB_APP_INSTALLATION_ID: "123456",
+      },
+      createInstallationToken: (options) => {
+        installationFactoryCalls++
+        installationOptions = options
+        return async () => {
+          installationTokenRequests++
+          return "github-installation-token"
+        }
+      },
+    }
+  )
+  ok(
+    "installation secrets stay lazy so the first deployment can succeed",
+    installationOptions === undefined
+  )
+  const firstInstallationToken = await installationToken(REPO)
+  const secondInstallationToken = await installationToken(REPO)
+  ok(
+    "installation mode returns app tokens from one reusable strategy",
+    firstInstallationToken === "github-installation-token" &&
+      secondInstallationToken === "github-installation-token" &&
+      installationFactoryCalls === 1 &&
+      installationTokenRequests === 2
+  )
+  ok(
+    "installation mode decodes and validates its app configuration",
+    installationOptions?.appId === "Iv1.client-id" &&
+      installationOptions.privateKey === privateKey &&
+      installationOptions.installationId === 123456
+  )
+
+  let invalidInstallationThrew = false
+  try {
+    const invalidInstallationToken = createGitHubAccessTokenProvider(
+      fakeOAuthWorker().worker,
+      {
+        env: {
+          GITHUB_AUTH_MODE: "installation",
+          GITHUB_APP_CLIENT_ID: "Iv1.client-id",
+          GITHUB_APP_PRIVATE_KEY_BASE64:
+            Buffer.from(privateKey).toString("base64"),
+          GITHUB_APP_INSTALLATION_ID: "not-an-id",
+        },
+      }
+    )
+    await invalidInstallationToken(REPO)
+  } catch {
+    invalidInstallationThrew = true
+  }
+  ok("rejects an invalid installation ID", invalidInstallationThrew)
+}
+
+// ---------------------------------------------------------------------------
 // API client and Worker contracts — mocked HTTP only
 // ---------------------------------------------------------------------------
 
@@ -651,6 +806,15 @@ async function runApiClientTests() {
       })
   )
 
+  const oauthCapability = worker.manifest.capabilities.find(
+    (capability) => capability._tag === "oauth"
+  )
+  ok(
+    "the GitHub user OAuth capability is available before credentials exist",
+    oauthCapability?.key === GITHUB_OAUTH_CAPABILITY_KEY &&
+      (oauthCapability.config as { scope?: string }).scope === ""
+  )
+
   const originalFetch = globalThis.fetch
   const originalToken = process.env.GITHUB_TOKEN
   const originalRepos = process.env.GITHUB_REPOS
@@ -661,6 +825,16 @@ async function runApiClientTests() {
   try {
     const requests: Request[] = []
     let waits = 0
+    const tokenRepos: string[] = []
+    const github = createGitHubClient({
+      beforeRequest: async () => {
+        waits++
+      },
+      getAccessToken: async (repo) => {
+        tokenRepos.push(repo)
+        return "github-provider-token"
+      },
+    })
     globalThis.fetch = (async (input, init) => {
       const request = new Request(input, init)
       requests.push(request)
@@ -678,9 +852,7 @@ async function runApiClientTests() {
       )
     }) as typeof fetch
 
-    const issuePage = await fetchIssuesPage(REPO, 1, async () => {
-      waits++
-    })
+    const issuePage = await github.fetchIssuesPage(REPO, 1)
     const issueRequest = requests[0]
     const issueUrl = new URL(issueRequest.url)
     ok(
@@ -693,12 +865,14 @@ async function runApiClientTests() {
     )
     ok(
       "requests use current GitHub headers",
-      issueRequest.headers.get("Authorization") === "Bearer github_pat_test" &&
+      issueRequest.headers.get("Authorization") ===
+        "Bearer github-provider-token" &&
         issueRequest.headers.get("Accept") === "application/vnd.github+json" &&
         issueRequest.headers.get("X-GitHub-Api-Version") === "2026-03-10" &&
         issueRequest.headers.get("User-Agent") ===
           "notion-cookbook-github-sync" &&
-        waits === 1
+        waits === 1 &&
+        tokenRepos[0] === REPO
     )
 
     const paginatedRequests: Request[] = []
@@ -724,9 +898,7 @@ async function runApiClientTests() {
       })
     }) as typeof fetch
 
-    const allReviews = await fetchReviews(REPO, 123, async () => {
-      waits++
-    })
+    const allReviews = await github.fetchReviews(REPO, 123)
     ok(
       "fetchReviews follows every next link",
       allReviews.length === 2 &&
@@ -763,9 +935,7 @@ async function runApiClientTests() {
       )
     }) as typeof fetch
 
-    const allCheckRuns = await fetchCheckRuns(REPO, "abc123", async () => {
-      waits++
-    })
+    const allCheckRuns = await github.fetchCheckRuns(REPO, "abc123")
     ok(
       "fetchCheckRuns follows every next link and paces each request",
       allCheckRuns.length === 2 && paginatedRequests.length === 2 && waits === 2
@@ -780,11 +950,7 @@ async function runApiClientTests() {
         }),
         { status: 200 }
       )) as typeof fetch
-    const combinedStatus = await fetchCombinedStatus(
-      REPO,
-      "abc123",
-      async () => {}
-    )
+    const combinedStatus = await github.fetchCombinedStatus(REPO, "abc123")
     ok(
       "fetchCombinedStatus returns the aggregate classic status",
       combinedStatus.state === "failure" && combinedStatus.total_count === 2
@@ -797,7 +963,7 @@ async function runApiClientTests() {
       })) as typeof fetch
     let rateLimitError: unknown
     try {
-      await fetchIssuesPage(REPO, 1, async () => {})
+      await github.fetchIssuesPage(REPO, 1)
     } catch (error) {
       rateLimitError = error
     }
@@ -813,7 +979,7 @@ async function runApiClientTests() {
       })) as typeof fetch
     let secondaryRateLimitError: unknown
     try {
-      await fetchIssuesPage(REPO, 1, async () => {})
+      await github.fetchIssuesPage(REPO, 1)
     } catch (error) {
       secondaryRateLimitError = error
     }
@@ -830,7 +996,7 @@ async function runApiClientTests() {
       })) as typeof fetch
     let missingResetError: unknown
     try {
-      await fetchIssuesPage(REPO, 1, async () => {})
+      await github.fetchIssuesPage(REPO, 1)
     } catch (error) {
       missingResetError = error
     }
@@ -847,7 +1013,7 @@ async function runApiClientTests() {
       })) as typeof fetch
     let permissionError: unknown
     try {
-      await fetchIssuesPage(REPO, 1, async () => {})
+      await github.fetchIssuesPage(REPO, 1)
     } catch (error) {
       permissionError = error
     }
@@ -928,7 +1094,8 @@ async function runApiClientTests() {
   }
 }
 
-runApiClientTests()
+runAuthTests()
+  .then(runApiClientTests)
   .then(() => {
     console.log(`\n${passed} passed, ${failed} failed`)
     if (failed > 0) process.exit(1)

--- a/examples/workers/syncs/github/test.ts
+++ b/examples/workers/syncs/github/test.ts
@@ -1,7 +1,9 @@
 // Offline tests for the github sync worker.
-// No GitHub connection is made — all assertions run against pure functions.
+// No GitHub connection is made — API assertions use mocked fetch responses.
 // Run: npm test  (or: npx tsx test.ts)
 
+import { RateLimitError } from "@notionhq/workers"
+import worker from "./src/index.js"
 import { issueToChange } from "./src/issues.js"
 import { pullRequestToChange } from "./src/all-pull-requests.js"
 import {
@@ -10,8 +12,15 @@ import {
   ciStatus,
 } from "./src/open-pull-requests.js"
 import { dateOnly } from "./src/helpers.js"
-import { getRepos } from "./src/github.js"
+import {
+  fetchCheckRuns,
+  fetchCombinedStatus,
+  fetchIssuesPage,
+  fetchReviews,
+  getRepos,
+} from "./src/github.js"
 import type {
+  GitHubCombinedStatus,
   GitHubIssue,
   GitHubPullRequest,
   GitHubReview,
@@ -194,11 +203,23 @@ const minimalIssue: GitHubIssue = {
 const minimalChange = issueToChange(minimalIssue, REPO)
 
 ok("null user omits Author", minimalChange.properties.Author === undefined)
-ok("empty assignees omits Assignees", minimalChange.properties.Assignees === undefined)
+ok(
+  "empty assignees omits Assignees",
+  minimalChange.properties.Assignees === undefined
+)
 ok("empty labels omits Labels", minimalChange.properties.Labels === undefined)
-ok("null milestone omits Milestone", minimalChange.properties.Milestone === undefined)
-ok("null state_reason omits State Reason", minimalChange.properties["State Reason"] === undefined)
-ok("null body gives empty pageContentMarkdown", minimalChange.pageContentMarkdown === "")
+ok(
+  "null milestone omits Milestone",
+  minimalChange.properties.Milestone === undefined
+)
+ok(
+  "null state_reason omits State Reason",
+  minimalChange.properties["State Reason"] === undefined
+)
+ok(
+  "null body gives empty pageContentMarkdown",
+  minimalChange.pageContentMarkdown === ""
+)
 
 // ---------------------------------------------------------------------------
 // pullRequestToChange
@@ -219,7 +240,6 @@ const standardPR: GitHubPullRequest = {
   milestone: { title: "v2.0" },
   base: { ref: "main" },
   head: { ref: "feature/mobile", sha: "abc123" },
-  merged_by: null,
   html_url: "https://github.com/acme/widgets/pull/123",
   closed_at: null,
   merged_at: null,
@@ -251,7 +271,6 @@ ok(
 )
 ok("null closed_at omits Closed", prChange.properties.Closed === undefined)
 ok("null merged_at omits Merged", prChange.properties.Merged === undefined)
-ok("null merged_by omits Merged By", prChange.properties["Merged By"] === undefined)
 
 // ---------------------------------------------------------------------------
 // pullRequestToChange — merged PR
@@ -264,7 +283,6 @@ const mergedPR: GitHubPullRequest = {
   state: "closed",
   closed_at: "2024-06-17T12:00:00Z",
   merged_at: "2024-06-17T12:00:00Z",
-  merged_by: { login: "eve" },
 }
 
 const mergedChange = pullRequestToChange(mergedPR, REPO)
@@ -281,11 +299,6 @@ ok(
   "Merged date is set",
   JSON.stringify(mergedChange.properties.Merged).includes("2024-06-17")
 )
-ok(
-  "Merged By is set",
-  JSON.stringify(mergedChange.properties["Merged By"]).includes("eve")
-)
-
 // ---------------------------------------------------------------------------
 // pullRequestToChange — closed but not merged
 // ---------------------------------------------------------------------------
@@ -297,7 +310,6 @@ const closedPR: GitHubPullRequest = {
   state: "closed",
   closed_at: "2024-06-18T09:00:00Z",
   merged_at: null,
-  merged_by: null,
 }
 
 const closedPRChange = pullRequestToChange(closedPR, REPO)
@@ -310,8 +322,10 @@ ok(
   "Closed date is set",
   JSON.stringify(closedPRChange.properties.Closed).includes("2024-06-18")
 )
-ok("null merged_at omits Merged", closedPRChange.properties.Merged === undefined)
-ok("null merged_by omits Merged By", closedPRChange.properties["Merged By"] === undefined)
+ok(
+  "null merged_at omits Merged",
+  closedPRChange.properties.Merged === undefined
+)
 
 // ---------------------------------------------------------------------------
 // pullRequestToChange — minimal PR (all optional fields null/empty)
@@ -332,7 +346,6 @@ const minimalPR: GitHubPullRequest = {
   milestone: null,
   base: { ref: "main" },
   head: { ref: "fix", sha: "def456" },
-  merged_by: null,
   html_url: "https://github.com/acme/widgets/pull/1",
   closed_at: null,
   merged_at: null,
@@ -343,11 +356,23 @@ const minimalPR: GitHubPullRequest = {
 const minimalPRChange = pullRequestToChange(minimalPR, REPO)
 
 ok("null user omits Author", minimalPRChange.properties.Author === undefined)
-ok("empty assignees omits Assignees", minimalPRChange.properties.Assignees === undefined)
-ok("empty reviewers omits Reviewers", minimalPRChange.properties.Reviewers === undefined)
+ok(
+  "empty assignees omits Assignees",
+  minimalPRChange.properties.Assignees === undefined
+)
+ok(
+  "empty reviewers omits Reviewers",
+  minimalPRChange.properties.Reviewers === undefined
+)
 ok("empty labels omits Labels", minimalPRChange.properties.Labels === undefined)
-ok("null milestone omits Milestone", minimalPRChange.properties.Milestone === undefined)
-ok("null body gives empty pageContentMarkdown", minimalPRChange.pageContentMarkdown === "")
+ok(
+  "null milestone omits Milestone",
+  minimalPRChange.properties.Milestone === undefined
+)
+ok(
+  "null body gives empty pageContentMarkdown",
+  minimalPRChange.pageContentMarkdown === ""
+)
 
 // ---------------------------------------------------------------------------
 // reviewState — aggregates review decisions
@@ -368,14 +393,24 @@ ok(
   "changes requested wins over approval from different authors",
   reviewState([
     { id: 1, state: "APPROVED", user: { login: "alice" }, submitted_at: null },
-    { id: 2, state: "CHANGES_REQUESTED", user: { login: "bob" }, submitted_at: null },
+    {
+      id: 2,
+      state: "CHANGES_REQUESTED",
+      user: { login: "bob" },
+      submitted_at: null,
+    },
   ]) === "Changes Requested"
 )
 
 ok(
   "later approval from same author overrides changes requested",
   reviewState([
-    { id: 1, state: "CHANGES_REQUESTED", user: { login: "alice" }, submitted_at: null },
+    {
+      id: 1,
+      state: "CHANGES_REQUESTED",
+      user: { login: "alice" },
+      submitted_at: null,
+    },
     { id: 2, state: "APPROVED", user: { login: "alice" }, submitted_at: null },
   ]) === "Approved"
 )
@@ -401,30 +436,57 @@ ok(
 
 console.log("ciStatus:")
 
-ok("empty check runs returns undefined", ciStatus([]) === undefined)
+const NO_COMMIT_STATUSES: GitHubCombinedStatus = {
+  state: "pending",
+  total_count: 0,
+}
+
+ok(
+  "no checks or commit statuses returns undefined",
+  ciStatus([], NO_COMMIT_STATUSES) === undefined
+)
 
 ok(
   "all success",
-  ciStatus([
-    { name: "lint", status: "completed", conclusion: "success" },
-    { name: "test", status: "completed", conclusion: "success" },
-  ]) === "Success"
+  ciStatus(
+    [
+      { name: "lint", status: "completed", conclusion: "success" },
+      { name: "test", status: "completed", conclusion: "neutral" },
+    ],
+    NO_COMMIT_STATUSES
+  ) === "Success"
 )
 
 ok(
   "any failure",
-  ciStatus([
-    { name: "lint", status: "completed", conclusion: "success" },
-    { name: "test", status: "completed", conclusion: "failure" },
-  ]) === "Failure"
+  ciStatus(
+    [
+      { name: "lint", status: "completed", conclusion: "success" },
+      { name: "test", status: "completed", conclusion: "timed_out" },
+    ],
+    NO_COMMIT_STATUSES
+  ) === "Failure"
 )
 
 ok(
   "in-progress means pending",
-  ciStatus([
-    { name: "lint", status: "completed", conclusion: "success" },
-    { name: "test", status: "in_progress", conclusion: null },
-  ]) === "Pending"
+  ciStatus(
+    [
+      { name: "lint", status: "completed", conclusion: "success" },
+      { name: "test", status: "waiting", conclusion: null },
+    ],
+    NO_COMMIT_STATUSES
+  ) === "Pending"
+)
+
+ok(
+  "commit status failure is included",
+  ciStatus([], { state: "failure", total_count: 2 }) === "Failure"
+)
+
+ok(
+  "commit status success is included",
+  ciStatus([], { state: "success", total_count: 2 }) === "Success"
 )
 
 // ---------------------------------------------------------------------------
@@ -434,17 +496,28 @@ ok(
 console.log("openPullRequestToChange — with reviews and checks:")
 
 const reviews: GitHubReview[] = [
-  { id: 1, state: "APPROVED", user: { login: "carol" }, submitted_at: "2024-06-16T12:00:00Z" },
+  {
+    id: 1,
+    state: "APPROVED",
+    user: { login: "carol" },
+    submitted_at: "2024-06-16T12:00:00Z",
+  },
 ]
 const checks: GitHubCheckRun[] = [
   { name: "CI", status: "completed", conclusion: "success" },
 ]
 
-const openChange = openPullRequestToChange(standardPR, REPO, reviews, checks)
+const openChange = openPullRequestToChange(
+  standardPR,
+  REPO,
+  reviews,
+  checks,
+  NO_COMMIT_STATUSES
+)
 
 ok(
-  "Review State is Approved",
-  JSON.stringify(openChange.properties["Review State"]).includes("Approved")
+  "Review Activity is Approved",
+  JSON.stringify(openChange.properties["Review Activity"]).includes("Approved")
 )
 ok(
   "CI Status is Success",
@@ -457,10 +530,26 @@ ok(
 
 console.log("openPullRequestToChange — no reviews or checks:")
 
-const bareChange = openPullRequestToChange(standardPR, REPO, [], [])
+const bareChange = openPullRequestToChange(
+  standardPR,
+  REPO,
+  [],
+  [],
+  NO_COMMIT_STATUSES
+)
 
-ok("no reviews omits Review State", bareChange.properties["Review State"] === undefined)
-ok("no checks omits CI Status", bareChange.properties["CI Status"] === undefined)
+ok(
+  "no reviews omits Review Activity",
+  bareChange.properties["Review Activity"] === undefined
+)
+ok(
+  "no checks omits CI Status",
+  bareChange.properties["CI Status"] === undefined
+)
+ok(
+  "enriched change omits incomplete upstream timestamp",
+  !("upstreamUpdatedAt" in openChange)
+)
 
 // ---------------------------------------------------------------------------
 // dateOnly
@@ -468,7 +557,10 @@ ok("no checks omits CI Status", bareChange.properties["CI Status"] === undefined
 
 console.log("dateOnly:")
 
-ok("ISO timestamp returns date part", dateOnly("2024-03-15T12:00:00Z") === "2024-03-15")
+ok(
+  "ISO timestamp returns date part",
+  dateOnly("2024-03-15T12:00:00Z") === "2024-03-15"
+)
 ok("plain date passes through", dateOnly("2024-03-15") === "2024-03-15")
 ok("empty string returns empty", dateOnly("") === "")
 
@@ -485,8 +577,26 @@ const repos = getRepos()
 ok("parses comma-separated repos", repos.length === 3)
 ok("trims whitespace", repos[1] === "acme/api")
 
-process.env.GITHUB_REPOS = "single/repo"
-ok("single repo works", getRepos().length === 1)
+process.env.GITHUB_REPOS = "Acme/widgets,acme/WIDGETS,single/repo"
+ok("deduplicates repos case-insensitively", getRepos().length === 2)
+
+process.env.GITHUB_REPOS = ", ,"
+let emptyReposThrew = false
+try {
+  getRepos()
+} catch {
+  emptyReposThrew = true
+}
+ok("rejects an empty parsed repo list", emptyReposThrew)
+
+process.env.GITHUB_REPOS = "missing-slash"
+let invalidRepoThrew = false
+try {
+  getRepos()
+} catch {
+  invalidRepoThrew = true
+}
+ok("rejects invalid owner/repo values", invalidRepoThrew)
 
 delete process.env.GITHUB_REPOS
 let threw = false
@@ -500,5 +610,330 @@ ok("throws when GITHUB_REPOS not set", threw)
 if (origRepos) process.env.GITHUB_REPOS = origRepos
 else delete process.env.GITHUB_REPOS
 
-console.log(`\n${passed} passed, ${failed} failed`)
-if (failed > 0) process.exit(1)
+// ---------------------------------------------------------------------------
+// API client and Worker contracts — mocked HTTP only
+// ---------------------------------------------------------------------------
+
+type WorkerRunResult = {
+  changes: Array<{ key: string }>
+  hasMore: boolean
+  nextUserContext?: { repoIndex: number; page: number }
+}
+
+function githubPacerContext() {
+  return {
+    pacers: {
+      github: {
+        lastScheduledAtMs: 0,
+        allowedRequests: 1_000_000,
+        intervalMs: 1,
+      },
+    },
+  }
+}
+
+async function runApiClientTests() {
+  console.log("API client and Worker contracts:")
+
+  const syncCapabilities = worker.manifest.capabilities.filter(
+    (capability) => capability._tag === "sync"
+  )
+  ok(
+    "all sync schedules are the public 5-minute minimum",
+    syncCapabilities.length === 3 &&
+      syncCapabilities.every((capability) => {
+        const schedule = (
+          capability.config as {
+            schedule?: { type: string; intervalMs?: number }
+          }
+        ).schedule
+        return schedule?.type === "interval" && schedule.intervalMs === 300_000
+      })
+  )
+
+  const originalFetch = globalThis.fetch
+  const originalToken = process.env.GITHUB_TOKEN
+  const originalRepos = process.env.GITHUB_REPOS
+
+  process.env.GITHUB_TOKEN = "github_pat_test"
+  process.env.GITHUB_REPOS = REPO
+
+  try {
+    const requests: Request[] = []
+    let waits = 0
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+      requests.push(request)
+      return new Response(
+        JSON.stringify([
+          standardIssue,
+          { ...standardIssue, number: 43, pull_request: { url: "pr" } },
+        ]),
+        {
+          status: 200,
+          headers: {
+            Link: `<https://api.github.com/repos/${REPO}/issues?per_page=100&page=2>; rel="next"`,
+          },
+        }
+      )
+    }) as typeof fetch
+
+    const issuePage = await fetchIssuesPage(REPO, 1, async () => {
+      waits++
+    })
+    const issueRequest = requests[0]
+    const issueUrl = new URL(issueRequest.url)
+    ok(
+      "list requests use stable ordering and Link pagination",
+      issueUrl.searchParams.get("sort") === "created" &&
+        issueUrl.searchParams.get("direction") === "asc" &&
+        issueUrl.searchParams.get("per_page") === "100" &&
+        issuePage.nextPage === 2 &&
+        issuePage.issues.length === 1
+    )
+    ok(
+      "requests use current GitHub headers",
+      issueRequest.headers.get("Authorization") === "Bearer github_pat_test" &&
+        issueRequest.headers.get("Accept") === "application/vnd.github+json" &&
+        issueRequest.headers.get("X-GitHub-Api-Version") === "2026-03-10" &&
+        issueRequest.headers.get("User-Agent") ===
+          "notion-cookbook-github-sync" &&
+        waits === 1
+    )
+
+    const paginatedRequests: Request[] = []
+    waits = 0
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+      paginatedRequests.push(request)
+      const page = new URL(request.url).searchParams.get("page")
+      const review: GitHubReview = {
+        id: page === "1" ? 1 : 2,
+        state: page === "1" ? "CHANGES_REQUESTED" : "APPROVED",
+        user: { login: "alice" },
+        submitted_at: null,
+      }
+      return new Response(JSON.stringify([review]), {
+        status: 200,
+        headers:
+          page === "1"
+            ? {
+                Link: `<https://api.github.com/repos/${REPO}/pulls/123/reviews?per_page=100&page=2>; rel="next"`,
+              }
+            : undefined,
+      })
+    }) as typeof fetch
+
+    const allReviews = await fetchReviews(REPO, 123, async () => {
+      waits++
+    })
+    ok(
+      "fetchReviews follows every next link",
+      allReviews.length === 2 &&
+        allReviews[1].state === "APPROVED" &&
+        paginatedRequests.every(
+          (request) =>
+            new URL(request.url).searchParams.get("per_page") === "100"
+        ) &&
+        waits === 2
+    )
+
+    paginatedRequests.length = 0
+    waits = 0
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+      paginatedRequests.push(request)
+      const page = new URL(request.url).searchParams.get("page")
+      const checkRun: GitHubCheckRun = {
+        name: page === "1" ? "lint" : "test",
+        status: "completed",
+        conclusion: "success",
+      }
+      return new Response(
+        JSON.stringify({ total_count: 2, check_runs: [checkRun] }),
+        {
+          status: 200,
+          headers:
+            page === "1"
+              ? {
+                  Link: `<https://api.github.com/repos/${REPO}/commits/abc123/check-runs?per_page=100&page=2>; rel="next"`,
+                }
+              : undefined,
+        }
+      )
+    }) as typeof fetch
+
+    const allCheckRuns = await fetchCheckRuns(REPO, "abc123", async () => {
+      waits++
+    })
+    ok(
+      "fetchCheckRuns follows every next link and paces each request",
+      allCheckRuns.length === 2 && paginatedRequests.length === 2 && waits === 2
+    )
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          state: "failure",
+          total_count: 2,
+          statuses: [],
+        }),
+        { status: 200 }
+      )) as typeof fetch
+    const combinedStatus = await fetchCombinedStatus(
+      REPO,
+      "abc123",
+      async () => {}
+    )
+    ok(
+      "fetchCombinedStatus returns the aggregate classic status",
+      combinedStatus.state === "failure" && combinedStatus.total_count === 2
+    )
+
+    globalThis.fetch = (async () =>
+      new Response("rate limited", {
+        status: 429,
+        headers: { "Retry-After": "7" },
+      })) as typeof fetch
+    let rateLimitError: unknown
+    try {
+      await fetchIssuesPage(REPO, 1, async () => {})
+    } catch (error) {
+      rateLimitError = error
+    }
+    ok(
+      "surfaces Retry-After through RateLimitError",
+      rateLimitError instanceof RateLimitError &&
+        rateLimitError.retryAfter === 7
+    )
+
+    globalThis.fetch = (async () =>
+      new Response("You have exceeded a secondary rate limit.", {
+        status: 403,
+      })) as typeof fetch
+    let secondaryRateLimitError: unknown
+    try {
+      await fetchIssuesPage(REPO, 1, async () => {})
+    } catch (error) {
+      secondaryRateLimitError = error
+    }
+    ok(
+      "uses a 60-second fallback for secondary rate limits",
+      secondaryRateLimitError instanceof RateLimitError &&
+        secondaryRateLimitError.retryAfter === 60
+    )
+
+    globalThis.fetch = (async () =>
+      new Response("API rate limit exceeded", {
+        status: 403,
+        headers: { "X-RateLimit-Remaining": "0" },
+      })) as typeof fetch
+    let missingResetError: unknown
+    try {
+      await fetchIssuesPage(REPO, 1, async () => {})
+    } catch (error) {
+      missingResetError = error
+    }
+    ok(
+      "falls back safely when a primary-limit reset header is missing",
+      missingResetError instanceof RateLimitError &&
+        missingResetError.retryAfter === 60
+    )
+
+    globalThis.fetch = (async () =>
+      new Response("forbidden", {
+        status: 403,
+        headers: { "X-RateLimit-Remaining": "4999" },
+      })) as typeof fetch
+    let permissionError: unknown
+    try {
+      await fetchIssuesPage(REPO, 1, async () => {})
+    } catch (error) {
+      permissionError = error
+    }
+    ok(
+      "does not misclassify ordinary permission failures as rate limits",
+      permissionError instanceof Error &&
+        !(permissionError instanceof RateLimitError)
+    )
+
+    const openSyncRequests: Request[] = []
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+      openSyncRequests.push(request)
+      const url = new URL(request.url)
+
+      if (url.pathname.endsWith("/pulls")) {
+        return new Response(JSON.stringify([closedPR, standardPR]), {
+          status: 200,
+        })
+      }
+      if (url.pathname.endsWith("/reviews")) {
+        return new Response(JSON.stringify([]), { status: 200 })
+      }
+      if (url.pathname.endsWith("/check-runs")) {
+        return new Response(
+          JSON.stringify({ total_count: 0, check_runs: [] }),
+          { status: 200 }
+        )
+      }
+      if (url.pathname.endsWith("/status")) {
+        return new Response(
+          JSON.stringify({ state: "pending", total_count: 0, statuses: [] }),
+          { status: 200 }
+        )
+      }
+      return new Response("not found", { status: 404 })
+    }) as typeof fetch
+
+    const openSyncResult = (await worker.run(
+      "openPullRequestsSync",
+      githubPacerContext(),
+      { concreteOutput: true }
+    )) as WorkerRunResult
+    const openListUrl = new URL(openSyncRequests[0].url)
+    ok(
+      "open PR replacement scans all states in stable order",
+      openListUrl.searchParams.get("state") === "all" &&
+        openListUrl.searchParams.get("sort") === "created" &&
+        openListUrl.searchParams.get("direction") === "asc"
+    )
+    ok(
+      "open PR replacement filters closed PRs before enrichment",
+      openSyncResult.changes.length === 1 &&
+        openSyncResult.changes[0].key === `${REPO}#${standardPR.number}` &&
+        openSyncRequests.length === 4
+    )
+
+    process.env.GITHUB_REPOS = `${REPO},acme/api`
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify([]), { status: 200 })) as typeof fetch
+    const multiRepoResult = (await worker.run(
+      "issuesSync",
+      githubPacerContext(),
+      { concreteOutput: true }
+    )) as WorkerRunResult
+    ok(
+      "sync state advances to the next configured repository",
+      multiRepoResult.hasMore &&
+        multiRepoResult.nextUserContext?.repoIndex === 1 &&
+        multiRepoResult.nextUserContext.page === 1
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalToken === undefined) delete process.env.GITHUB_TOKEN
+    else process.env.GITHUB_TOKEN = originalToken
+    if (originalRepos === undefined) delete process.env.GITHUB_REPOS
+    else process.env.GITHUB_REPOS = originalRepos
+  }
+}
+
+runApiClientTests()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`)
+    if (failed > 0) process.exit(1)
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/examples/workers/syncs/github/tsconfig.test.json
+++ b/examples/workers/syncs/github/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- make replacement scans stable by ordering on creation time, following GitHub `Link` headers, and scanning all PR states before filtering the Open PR database
- paginate every review and check-run page, include classic commit status contexts, and handle all documented CI conclusions
- add GitHub-aware rate-limit backoff, per-request pacing, current API headers/version, and validated repository configuration
- use the documented 5-minute Worker schedule and remove the unsupported `Merged By` field
- support GitHub App installation auth (recommended), GitHub App user-to-server OAuth, and fine-grained PAT auth behind one token-provider boundary
- use `@octokit/auth-app` for short-lived installation tokens and Notion Workers OAuth for user-token storage and refresh
- document how to choose and configure each mode, including one-installation and one-authorized-user deployment boundaries
- add HTTP, Worker, pagination, and authentication contract coverage to the example's local tests

## Validation

- `npm run build`
- `npm run check`
- `npm test` — 98 passed
- focused Markdown lint and Prettier checks
- `git diff --check`

Follow-up to #34.
