### PR TITLE
feat(workers): add Linear sync example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ The [workers](workers/) directory includes examples built with the [Notion Worke
 
 - **[webhooks/zendesk](workers/webhooks/zendesk/)**: Verify Zendesk ticket webhooks and upsert them into a Notion database
 - **[syncs/salesforce](workers/syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
-- **[syncs/linear](workers/syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_
+- **[syncs/linear](workers/syncs/linear/)**: Sync Linear projects, issues, and initiatives into managed Notion databases
 - **[tools/snowflake-query](workers/tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results _(coming soon)_
 - **[tools/spotify-control](workers/tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_
 

--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -9,7 +9,7 @@ The [syncs](syncs/) directory includes one-way sync examples that bring data fro
 - **[duckdb-sync-demo](syncs/duckdb-sync-demo/)**: Sync a self-contained in-memory DuckDB into a managed Notion database — no setup required
 - **[snowflake-sync](syncs/snowflake-sync/)**: Sync rows from a Snowflake query into a managed Notion database
 - **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
-- **[linear](syncs/linear/)**: One-way sync from Linear issues into a Notion database _(coming soon)_
+- **[linear](syncs/linear/)**: Sync Linear projects, issues, and initiatives into managed Notion databases
 
 ## Tools
 

--- a/examples/workers/syncs/linear/.env.example
+++ b/examples/workers/syncs/linear/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed worker, set this with `ntn workers env set KEY=value` instead.
+
+# Required: Linear personal API key from Settings > Security & access > API keys.
+LINEAR_API_KEY=

--- a/examples/workers/syncs/linear/.gitignore
+++ b/examples/workers/syncs/linear/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/linear/README.md
+++ b/examples/workers/syncs/linear/README.md
@@ -1,18 +1,375 @@
-# Worker Sync: Linear
+# Worker sync: Linear
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+Syncs Linear projects, issues, and initiatives into Notion databases that stay
+up to date automatically. The operational issue mirror refreshes every five
+minutes, while projects and initiatives refresh on schedules suited to
+cross-functional planning.
 
-A Notion worker sync that pulls Linear issues into a Notion database, keeping the database up to date as issues are created and updated in Linear.
+You don't need to create the Notion databases yourself. The worker declares
+the schemas and Notion creates and manages each database for you (these are
+called "managed databases").
 
-## What this example will demonstrate
+## What you get
 
-- One-way sync from Linear issues into a Notion database
-- Webhook-driven updates from Linear into Notion using Linear's webhook events
-- Mapping Linear fields (state, priority, assignee, labels, project) to Notion properties
-- Querying Linear's GraphQL API from a Notion worker
+Three databases are maintained by four syncs:
+
+| Database               | Sync                       | Mode        | Schedule     |
+| ---------------------- | -------------------------- | ----------- | ------------ |
+| **Linear Projects**    | `projectsSync`             | replace     | Every 15 min |
+| **Linear Issues**      | `issuesSync`               | incremental | Every 5 min  |
+| **Linear Issues**      | `issuesReconciliationSync` | replace     | Daily        |
+| **Linear Initiatives** | `initiativesSync`          | replace     | Every hour   |
+
+The two issue syncs intentionally target the same managed database. The fast
+incremental sync keeps active work current; the daily replacement sweep repairs
+drift and removes records that Linear has permanently deleted.
+
+The databases are otherwise independent. Project, initiative, team, and cycle
+names are stored as readable values instead of Notion relations. This keeps
+the example reliable when resources have different visibility, are synced on
+different schedules, or are archived and deleted in a different order.
+
+### Linear Projects
+
+| Notion property   | Linear field                           | Type     |
+| ----------------- | -------------------------------------- | -------- |
+| Name              | `name`                                 | title    |
+| Status            | workspace-specific `status.name`       | select   |
+| Health            | `health`                               | select   |
+| Lead              | `lead.displayName` or `lead.name`      | richText |
+| Project Link      | `url`                                  | url      |
+| Progress %        | `progress` converted from 0–1 to 0–100 | number   |
+| Target Date       | `targetDate`                           | date     |
+| Updated           | `updatedAt`                            | date     |
+| Last Update At    | `lastUpdate.updatedAt`                 | date     |
+| Last Update Link  | `lastUpdate.url`                       | url      |
+| Status Category   | canonical category from `status.type`  | select   |
+| Priority          | `priorityLabel` or `priority`          | select   |
+| Start Date        | `startDate`                            | date     |
+| Started           | `startedAt`                            | date     |
+| Completed         | `completedAt`                          | date     |
+| Canceled          | `canceledAt`                           | date     |
+| Created           | `createdAt`                            | date     |
+| Archived          | whether `archivedAt` is set            | checkbox |
+| Slug ID           | `slugId`                               | richText |
+| Linear Project ID | `id`                                   | richText |
+
+Each project page body contains Linear's richer `content` field, falling back
+to `description` when no content is present. **Status** preserves the team's
+custom name, while **Status Category** provides a stable cross-project rollup.
+The latest status-update timestamp and link show how fresh the current health
+signal is without copying a potentially long update body into a table cell.
+Edits to that update also participate in the sync freshness watermark.
+
+**Linear Project ID**, the immutable UUID, is the primary key. **Slug ID**
+remains visible for recognition and cross-referencing but is not used for
+identity because human-readable identifiers can change.
+
+### Linear Issues
+
+| Notion property   | Linear field                         | Type        |
+| ----------------- | ------------------------------------ | ----------- |
+| Title             | `title`                              | title       |
+| Issue Key         | `identifier` (for example, ENG-123)  | richText    |
+| Status            | workspace-specific `state.name`      | select      |
+| Priority          | `priorityLabel` or `priority`        | select      |
+| Assignee          | `assignee.displayName` or `name`     | richText    |
+| Issue Link        | `url`                                | url         |
+| Updated           | `updatedAt`                          | date        |
+| Workflow Category | canonical category from `state.type` | select      |
+| Team              | `team.name` or `team.key`            | select      |
+| Project           | `project.name`                       | select      |
+| Cycle             | `cycle.name` or cycle number         | select      |
+| Labels            | all `labels.nodes[].name`            | multiSelect |
+| Estimate          | `estimate`                           | number      |
+| Due Date          | `dueDate`                            | date        |
+| Started           | `startedAt`                          | date        |
+| Completed         | `completedAt`                        | date        |
+| Canceled          | `canceledAt`                         | date        |
+| Created           | `createdAt`                          | date        |
+| Archived          | whether `archivedAt` is set          | checkbox    |
+| Linear Issue ID   | `id`                                 | richText    |
+
+Each issue page body contains its Markdown `description`. Workspace-specific
+workflow names remain visible in **Status**, while **Workflow Category** makes
+cross-team reporting consistent. Labels are paginated rather than silently
+stopping at the first nested page.
+
+**Linear Issue ID**, the immutable UUID, is the primary key. The familiar
+**Issue Key** stays prominent, but it can change when an issue moves between
+teams, so it is not safe as a sync key.
+
+### Linear Initiatives
+
+| Notion property      | Linear field                  | Type     |
+| -------------------- | ----------------------------- | -------- |
+| Name                 | `name`                        | title    |
+| Status               | `status`                      | select   |
+| Health               | `health`                      | select   |
+| Owner                | `owner.displayName` or `name` | richText |
+| Initiative Link      | `url`                         | url      |
+| Updated              | `updatedAt`                   | date     |
+| Last Update At       | `lastUpdate.updatedAt`        | date     |
+| Last Update Link     | `lastUpdate.url`              | url      |
+| Priority             | `priority`                    | select   |
+| Target Date          | `targetDate`                  | date     |
+| Started              | `startedAt`                   | date     |
+| Completed            | `completedAt`                 | date     |
+| Canceled             | `canceledAt`                  | date     |
+| Created              | `createdAt`                   | date     |
+| Archived             | whether `archivedAt` is set   | checkbox |
+| Slug ID              | `slugId`                      | richText |
+| Linear Initiative ID | `id`                          | richText |
+
+Each initiative page body contains `content`, falling back to `description`.
+**Linear Initiative ID**, the immutable UUID, is the primary key, while
+**Slug ID** is retained as the readable identifier.
+
+The full project and initiative update bodies are intentionally omitted from
+the base example: they can contain long Markdown, authenticated assets, and
+mentions. If your audience needs them, append `lastUpdate.body` to page content
+with an explicit asset and truncation policy.
+
+Initiatives are also subject to the authenticated user's Linear plan and
+permissions. If the API reports that the feature is unavailable, the
+initiative sync fails visibly instead of silently replacing the database with
+an empty snapshot. Initiatives must be enabled, and a guest user's key may not
+be able to read them.
+
+## Project structure
+
+```text
+src/
+├── index.ts       — registers three managed databases and four syncs
+├── linear.ts      — GraphQL client, cursor pagination, and rate-limit handling
+├── sync-state.ts  — serializable cursor and incremental-window transitions
+├── projects.ts    — project schema and transform
+├── issues.ts      — issue schema and transform
+├── initiatives.ts — initiative schema and transform
+└── helpers.ts     — shared labels, people, dates, and content helpers
+```
+
+## How it works
+
+1. **Projects** use a cursor-paginated replacement sweep every 15 minutes,
+   ordered by stable `createdAt` rather than a value that changes mid-sweep.
+2. **Issues** use an `updatedAt` filter and cursor every 5 minutes. Each run
+   pins an upper time boundary for every page, leaves a short consistency
+   buffer for Linear's indexes, and overlaps the previous watermark. Replaying
+   a small interval is safe because upserts are keyed by UUID; the overlap
+   protects against equal timestamps, indexing lag, and writes at a page
+   boundary.
+3. **Issue reconciliation** performs a complete daily replacement sweep in
+   stable `createdAt` order. The replacement run compares the complete key set
+   and removes hard-deleted issues that incremental polling cannot discover.
+4. **Initiatives** use a cursor-paginated replacement sweep every hour in
+   stable `createdAt` order.
+5. All top-level collections use Linear's Relay-style GraphQL pagination with
+   `first: 50`, `after`, `pageInfo.hasNextPage`, and `pageInfo.endCursor`. The
+   client rejects a missing cursor, and persisted cursor history detects both
+   immediate repeats and longer cursor cycles instead of looping forever.
+6. Issue labels are a nested connection. The first 50 arrive with the issue;
+   only issues with more labels make follow-up GraphQL requests. Those pages
+   share the same pacing and cursor safeguards, and duplicate label names are
+   removed. A top-level issue page may make at most 20 label follow-up requests;
+   exceeding the bound fails the page instead of committing truncated labels.
+
+All list queries pass `includeArchived: true`. Archived resources therefore
+remain available for history and are marked with the **Archived** checkbox.
+If Linear returns a recently deleted issue with `trashed: true`, the
+incremental sync emits an explicit delete. Linear does not document
+`includeArchived` as including trash, so prompt soft-delete delivery is not
+assumed. Replacement syncs exclude any trashed records they do receive, and
+the daily issue reconciliation is the guaranteed repair path once a deleted
+issue no longer appears in the full collection.
+
+### Suggested Notion views
+
+- **Active projects:** filter Archived off and Status Category to Backlog,
+  Planned, Started, or Paused; sort by Health and Target Date.
+- **Team issue tracker:** filter Archived off, then group by Team and Workflow
+  Category. Add a Cycle filter for a current-cycle view.
+- **Unassigned work:** filter Assignee empty and Workflow Category not Completed
+  or Canceled; sort by Priority.
+- **Leadership initiatives:** filter Archived off, group by Health, and sort by
+  Priority and Target Date.
+- **History:** filter Archived on in any database rather than mixing historical
+  records into its default active view.
+
+### Rate limits and query complexity
+
+Every GraphQL request from all four syncs, including follow-up label pages,
+shares one pacer set to **2,000 requests per hour**. Linear's current API-key
+request-limit table lists 2,500 requests per authenticated user per hour, so
+the pacer leaves meaningful headroom for incidental traffic. Multiple keys
+belonging to the same user share that quota.
+
+Linear also applies a separate hourly query-complexity budget and rejects an
+individual query above its maximum complexity. The example requests only the
+fields it maps, uses explicit 50-record connection limits, and paginates nested
+labels separately. This keeps connection multiplication predictable instead
+of hiding a large nested query in one request.
+
+The client treats both HTTP 429 responses and GraphQL `RATELIMITED` errors as
+rate limits. It reads `Retry-After` and Linear's request, endpoint, and
+complexity reset headers, then passes the longest applicable delay to the
+Workers runtime. It also rejects GraphQL partial responses so missing fields
+cannot silently become incomplete Notion pages.
+
+## Prerequisites
+
+- Node >= 22, npm >= 10.9.2
+- A Linear workspace and a user who can read the resources to sync
+- A Linear personal API key
+- The `ntn` CLI installed and authenticated (`ntn login`)
+
+### Getting a Linear personal API key
+
+1. Open Linear and go to **Settings > Security & access > API keys**.
+2. Create a new personal API key, give it a recognizable label, and copy it.
+3. Store it as `LINEAR_API_KEY`; Linear only shows the secret when it is
+   created.
+
+The worker sends this value directly in Linear's `Authorization` header, as
+required for personal API keys. Do not add a `Bearer` prefix. You do not need
+to build authentication headers or provide a `NOTION_API_TOKEN`; the worker
+handles Linear authorization and the Workers platform handles Notion
+credentials.
+
+## Environment variables
+
+### Required
+
+| Variable         | Description                                                |
+| ---------------- | ---------------------------------------------------------- |
+| `LINEAR_API_KEY` | Personal API key with access to the resources being synced |
+
+For local execution, copy `.env.example` to `.env` and add your key. `.env` is
+gitignored and must not be committed.
+
+## Setup and deploy
+
+1. Install the Notion Workers CLI:
+
+   ```sh
+   npm install --global ntn
+   ```
+
+2. Install the example's dependencies:
+
+   ```sh
+   cd examples/workers/syncs/linear
+   npm install
+   ```
+
+3. Typecheck the source and tests, then run the offline tests:
+
+   ```sh
+   npm run check
+   npm test
+   ```
+
+4. Log in to Notion:
+
+   ```sh
+   ntn login
+   ```
+
+5. Deploy the worker:
+
+   ```sh
+   ntn workers deploy
+   ```
+
+6. Set the personal API key on the deployed worker:
+
+   ```sh
+   ntn workers env set LINEAR_API_KEY=lin_api_your-key-here
+   ```
+
+7. Preview every sync without writing to Notion:
+
+   ```sh
+   ntn workers sync trigger projectsSync --preview
+   ntn workers sync trigger issuesSync --preview
+   ntn workers sync trigger issuesReconciliationSync --preview
+   ntn workers sync trigger initiativesSync --preview
+   ```
+
+8. Trigger real runs if you do not want to wait for their schedules:
+
+   ```sh
+   ntn workers sync trigger projectsSync
+   ntn workers sync trigger issuesSync
+   ntn workers sync trigger issuesReconciliationSync
+   ntn workers sync trigger initiativesSync
+   ```
+
+Once deployed, all four syncs run automatically. Three databases will appear
+in your Notion workspace after their first runs.
+
+## Local testing and live verification
+
+Run all offline tests without a Linear connection:
+
+```sh
+npm test
+```
+
+Run a sync locally against the Linear workspace accessible to the key in your
+`.env` file:
+
+```sh
+ntn workers exec projectsSync --local
+ntn workers exec issuesSync --local
+ntn workers exec issuesReconciliationSync --local
+ntn workers exec initiativesSync --local
+```
+
+A live API preview cannot be verified without a valid `LINEAR_API_KEY`. Offline
+tests can verify pagination, transforms, rate-limit behavior, and sync-state
+logic, but they cannot confirm which records a particular Linear user can see.
+After supplying a key, run all four `--preview` commands above and inspect the
+returned fields before triggering a write.
+
+Linear recommends webhooks instead of polling for production integrations that
+can receive events. Workers syncs currently use scheduled execution, so this
+example combines a five-minute incremental poll with daily reconciliation. A
+webhook-capable deployment can retain the reconciliation sweep as a repair path.
+
+Linear-hosted images embedded in Markdown may require Linear authentication;
+Notion readers who are not signed into Linear may not be able to render them.
+
+## Adapting the schema
+
+Each resource file contains both its managed-database schema and transform:
+
+| Resource    | File                 |
+| ----------- | -------------------- |
+| Projects    | `src/projects.ts`    |
+| Issues      | `src/issues.ts`      |
+| Initiatives | `src/initiatives.ts` |
+
+To add a Linear field:
+
+1. Add it to the resource's GraphQL selection and TypeScript type in
+   `src/linear.ts`.
+2. Add a property with the appropriate `Schema.*` type in the resource file.
+3. Add the matching `Builder.*` value in the resource transform, preserving
+   schema order.
+4. Add standard, minimal, and relevant edge-case assertions to `test.ts`.
+
+Keep the immutable UUID property as each database's primary key. Add related
+resources as resolved names unless you intentionally design and validate a
+cross-database relation lifecycle.
 
 ## Learn more
 
 - [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
-- [Contribute to this cookbook](../../../../CONTRIBUTING.md)
+- [Linear GraphQL API — Getting started](https://linear.app/developers/graphql)
+- [Linear GraphQL API — Pagination](https://linear.app/developers/pagination)
+- [Linear GraphQL API — Filtering](https://linear.app/developers/filtering)
+- [Linear GraphQL API — Rate limiting](https://linear.app/developers/rate-limiting)
+- [Linear documentation — Delete and archive issues](https://linear.app/docs/delete-archive-issues)
+- [Linear documentation — Initiatives](https://linear.app/docs/initiatives)
+- [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/linear/README.md
+++ b/examples/workers/syncs/linear/README.md
@@ -54,12 +54,11 @@ different schedules, or are archived and deleted in a different order.
 | Slug ID           | `slugId`                               | richText |
 | Linear Project ID | `id`                                   | richText |
 
-Each project page body contains Linear's richer `content` field, falling back
-to `description` when no content is present. **Status** preserves the team's
-custom name, while **Status Category** provides a stable cross-project rollup.
-The latest status-update timestamp and link show how fresh the current health
-signal is without copying a potentially long update body into a table cell.
-Edits to that update also participate in the sync freshness watermark.
+Each project page body starts with the latest status-update narrative, author,
+date, and source link, followed by Linear's richer `content` field (or
+`description` fallback). **Status** preserves the team's custom name, while
+**Status Category** provides a stable cross-project rollup. Update edits also
+participate in the sync freshness watermark.
 
 **Linear Project ID**, the immutable UUID, is the primary key. **Slug ID**
 remains visible for recognition and cross-referencing but is not used for
@@ -108,27 +107,31 @@ teams, so it is not safe as a sync key.
 | Health               | `health`                      | select   |
 | Owner                | `owner.displayName` or `name` | richText |
 | Initiative Link      | `url`                         | url      |
-| Updated              | `updatedAt`                   | date     |
+| Project Count        | all contributing `projects`   | number   |
+| Target Date          | `targetDate`                  | date     |
 | Last Update At       | `lastUpdate.updatedAt`        | date     |
 | Last Update Link     | `lastUpdate.url`              | url      |
-| Priority             | `priority`                    | select   |
-| Target Date          | `targetDate`                  | date     |
+| Updated              | `updatedAt`                   | date     |
 | Started              | `startedAt`                   | date     |
 | Completed            | `completedAt`                 | date     |
-| Canceled             | `canceledAt`                  | date     |
 | Created              | `createdAt`                   | date     |
 | Archived             | whether `archivedAt` is set   | checkbox |
 | Slug ID              | `slugId`                      | richText |
 | Linear Initiative ID | `id`                          | richText |
 
-Each initiative page body contains `content`, falling back to `description`.
+Each initiative page body starts with its latest update narrative and then
+lists the projects contributing directly or through sub-initiatives, followed
+by the Initiative overview. **Project Count** is exact for projects visible to
+the API key and includes inherited and archived projects. The body renders up
+to 100 alphabetized project links and directs readers to Linear when more
+exist. Archived projects are annotated, while trashed projects are excluded.
+
 **Linear Initiative ID**, the immutable UUID, is the primary key, while
 **Slug ID** is retained as the readable identifier.
 
-The full project and initiative update bodies are intentionally omitted from
-the base example: they can contain long Markdown, authenticated assets, and
-mentions. If your audience needs them, append `lastUpdate.body` to page content
-with an explicit asset and truncation policy.
+Latest-update and overview source-text excerpts are each limited to 20,000
+characters. When text is shortened, the page shows an explicit link to its
+complete version in Linear rather than truncating silently.
 
 Initiatives are also subject to the authenticated user's Linear plan and
 permissions. If the API reports that the feature is unavailable, the
@@ -163,16 +166,25 @@ src/
    stable `createdAt` order. The replacement run compares the complete key set
    and removes hard-deleted issues that incremental polling cannot discover.
 4. **Initiatives** use a cursor-paginated replacement sweep every hour in
-   stable `createdAt` order.
+   stable `createdAt` order. Their rows intentionally refresh each sweep
+   because contributing-project membership is derived data without a safe
+   monotonic timestamp for removals.
 5. All top-level collections use Linear's Relay-style GraphQL pagination with
-   `first: 50`, `after`, `pageInfo.hasNextPage`, and `pageInfo.endCursor`. The
-   client rejects a missing cursor, and persisted cursor history detects both
-   immediate repeats and longer cursor cycles instead of looping forever.
+   `after`, `pageInfo.hasNextPage`, and `pageInfo.endCursor`. Projects and
+   Issues request 50 records per page; Initiatives request 20 to leave
+   headroom in Linear's query-complexity budget for their nested project
+   summaries. The client rejects a missing cursor, and persisted cursor
+   history detects both immediate repeats and longer cursor cycles instead of
+   looping forever.
 6. Issue labels are a nested connection. The first 50 arrive with the issue;
    only issues with more labels make follow-up GraphQL requests. Those pages
    share the same pacing and cursor safeguards, and duplicate label names are
    removed. A top-level issue page may make at most 20 label follow-up requests;
    exceeding the bound fails the page instead of committing truncated labels.
+7. Initiative projects are also independently cursor-paginated, including
+   projects inherited through sub-initiatives. Their shared 20-request bound
+   fails the Initiative page instead of returning a false count or incomplete
+   project list.
 
 All list queries pass `includeArchived: true`. Archived resources therefore
 remain available for history and are marked with the **Archived** checkbox.
@@ -192,23 +204,25 @@ issue no longer appears in the full collection.
 - **Unassigned work:** filter Assignee empty and Workflow Category not Completed
   or Canceled; sort by Priority.
 - **Leadership initiatives:** filter Archived off, group by Health, and sort by
-  Priority and Target Date.
+  Target Date. Use Project Count to find strategic goals with no associated
+  projects visible to the API key.
 - **History:** filter Archived on in any database rather than mixing historical
   records into its default active view.
 
 ### Rate limits and query complexity
 
-Every GraphQL request from all four syncs, including follow-up label pages,
-shares one pacer set to **2,000 requests per hour**. Linear's current API-key
-request-limit table lists 2,500 requests per authenticated user per hour, so
-the pacer leaves meaningful headroom for incidental traffic. Multiple keys
-belonging to the same user share that quota.
+Every GraphQL request from all four syncs, including follow-up label and
+Initiative-project pages, shares one pacer set to **2,000 requests per hour**.
+Linear's current API-key request-limit table lists 2,500 requests per
+authenticated user per hour, so the pacer leaves meaningful headroom for
+incidental traffic. Multiple keys belonging to the same user share that quota.
 
 Linear also applies a separate hourly query-complexity budget and rejects an
 individual query above its maximum complexity. The example requests only the
-fields it maps, uses explicit 50-record connection limits, and paginates nested
-labels separately. This keeps connection multiplication predictable instead
-of hiding a large nested query in one request.
+fields it maps, uses explicit 20- or 50-record connection limits, and paginates
+nested labels and Initiative projects separately. This keeps connection
+multiplication predictable instead of hiding a large nested query in one
+request.
 
 The client treats both HTTP 429 responses and GraphQL `RATELIMITED` errors as
 rate limits. It reads `Retry-After` and Linear's request, endpoint, and
@@ -222,6 +236,10 @@ cannot silently become incomplete Notion pages.
 - A Linear workspace and a user who can read the resources to sync
 - A Linear personal API key
 - The `ntn` CLI installed and authenticated (`ntn login`)
+
+The key's Linear visibility defines what the worker can copy, including update
+narratives. Once synced, that content follows the destination Notion
+database's sharing permissions. Review both audiences before deployment.
 
 ### Getting a Linear personal API key
 
@@ -372,4 +390,6 @@ cross-database relation lifecycle.
 - [Linear GraphQL API — Rate limiting](https://linear.app/developers/rate-limiting)
 - [Linear documentation — Delete and archive issues](https://linear.app/docs/delete-archive-issues)
 - [Linear documentation — Initiatives](https://linear.app/docs/initiatives)
+- [Linear documentation — Initiative and Project updates](https://linear.app/docs/initiative-and-project-updates)
+- [Linear documentation — Sub-initiatives](https://linear.app/docs/sub-initiatives)
 - [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/linear/package.json
+++ b/examples/workers/syncs/linear/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "linear",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --project tsconfig.test.json",
+    "test": "node --import tsx --test test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": ">=0.0.0"
+  }
+}

--- a/examples/workers/syncs/linear/src/helpers.ts
+++ b/examples/workers/syncs/linear/src/helpers.ts
@@ -24,6 +24,9 @@ const PRIORITY_LABELS: Record<number, string> = {
   4: "Low",
 }
 
+export const MAX_PAGE_SECTION_CHARACTERS = 20_000
+export const MAX_RENDERED_CONTRIBUTING_PROJECTS = 100
+
 function normalizedKey(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]/g, "")
 }
@@ -129,17 +132,24 @@ export function dateTime(value: string | null | undefined): string | null {
 /** Include related status-update edits in the record freshness watermark. */
 export function latestTimestamp(
   primary: string,
-  candidate: string | null | undefined
+  ...candidates: Array<string | null | undefined>
 ): string {
-  const candidateValue = candidate?.trim()
-  if (!candidateValue) return primary
+  let latest = primary
+  let latestTime = Date.parse(primary)
 
-  const primaryTime = Date.parse(primary)
-  const candidateTime = Date.parse(candidateValue)
-  if (!Number.isFinite(candidateTime)) return primary
-  return !Number.isFinite(primaryTime) || candidateTime > primaryTime
-    ? candidateValue
-    : primary
+  for (const candidate of candidates) {
+    const candidateValue = candidate?.trim()
+    if (!candidateValue) continue
+
+    const candidateTime = Date.parse(candidateValue)
+    if (!Number.isFinite(candidateTime)) continue
+    if (!Number.isFinite(latestTime) || candidateTime > latestTime) {
+      latest = candidateValue
+      latestTime = candidateTime
+    }
+  }
+
+  return latest
 }
 
 export type LinearPersonDisplay = {
@@ -158,4 +168,158 @@ export function personDisplay(
     person?.email?.trim() ||
     null
   )
+}
+
+export type LinearStatusUpdateContent = {
+  body?: string | null
+  createdAt?: string | null
+  url?: string | null
+  user?: LinearPersonDisplay | null
+}
+
+export type LinearContributingProjectContent = {
+  id: string
+  name: string
+  url?: string | null
+  archivedAt?: string | null
+  trashed?: boolean | null
+}
+
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_[\]<>])/g, "\\$1")
+}
+
+function escapeMarkdownExcerpt(value: string): string {
+  return value.replace(/([\\`*_[\]{}()#+\-.!>|<>])/g, "\\$1")
+}
+
+function truncateMarkdownSection(
+  value: string,
+  fullContentUrl: string | null | undefined,
+  sectionLabel: string
+): string {
+  const content = value.trim()
+  const characters = Array.from(content)
+  if (characters.length <= MAX_PAGE_SECTION_CHARACTERS) return content
+
+  const initialExcerpt = characters
+    .slice(0, MAX_PAGE_SECTION_CHARACTERS)
+    .join("")
+  const earliestPreferredBreak = Math.floor(initialExcerpt.length * 0.6)
+  const breakCandidates = [
+    initialExcerpt.lastIndexOf("\n\n"),
+    initialExcerpt.lastIndexOf("\n"),
+    initialExcerpt.lastIndexOf(" "),
+  ]
+  const preferredBreak = breakCandidates.find(
+    (index) => index >= earliestPreferredBreak
+  )
+  const excerpt = initialExcerpt
+    .slice(0, preferredBreak ?? initialExcerpt.length)
+    .trimEnd()
+  const url = fullContentUrl?.trim()
+  const destination = url
+    ? ` [Read the full ${sectionLabel} in Linear](${url}).`
+    : " Open the source record in Linear to read the full text."
+
+  return `> This ${sectionLabel} was shortened in Notion.${destination}\n\n${escapeMarkdownExcerpt(excerpt)}`
+}
+
+function latestUpdateSection(
+  update: LinearStatusUpdateContent | null | undefined
+): string | null {
+  if (!update) return null
+
+  const author = personDisplay(update.user)
+  const postedOn = dateOnly(update.createdAt)
+  const url = update.url?.trim()
+  const metadata = [
+    author ? `Updated by ${escapeMarkdownText(author)}` : null,
+    postedOn,
+    url ? `[Open update in Linear](${url})` : null,
+  ].filter((value): value is string => Boolean(value))
+  const body = truncateMarkdownSection(update.body ?? "", url, "latest update")
+  const parts = [
+    "## Latest update",
+    metadata.length > 0 ? `_${metadata.join(" · ")}_` : null,
+    body || null,
+  ].filter((value): value is string => Boolean(value))
+
+  return parts.join("\n\n")
+}
+
+export function uniqueVisibleProjects<
+  T extends LinearContributingProjectContent,
+>(projects: T[]): T[] {
+  const seenIds = new Set<string>()
+  return projects.filter((project) => {
+    if (project.trashed || seenIds.has(project.id)) return false
+    seenIds.add(project.id)
+    return true
+  })
+}
+
+function contributingProjectsSection(
+  projects: LinearContributingProjectContent[],
+  initiativeUrl: string
+): string | null {
+  if (projects.length === 0) {
+    return "## Contributing projects (0)\n\nNo contributing projects visible to this Linear API key."
+  }
+
+  const sortedProjects = [...projects].sort(
+    (left, right) =>
+      left.name.localeCompare(right.name) || left.id.localeCompare(right.id)
+  )
+  const renderedProjects = sortedProjects.slice(
+    0,
+    MAX_RENDERED_CONTRIBUTING_PROJECTS
+  )
+  const bullets = renderedProjects.map((project) => {
+    const name = escapeMarkdownText(project.name.trim() || "Untitled project")
+    const url = project.url?.trim()
+    const label = url ? `[${name}](${url})` : name
+    return `- ${label}${project.archivedAt ? " _(archived)_" : ""}`
+  })
+  const remaining = sortedProjects.length - renderedProjects.length
+  if (remaining > 0) {
+    const url = initiativeUrl.trim()
+    const suffix = url
+      ? `[View all projects in Linear](${url}).`
+      : "Open the Initiative in Linear to view them."
+    bullets.push(`- _…and ${remaining} more. ${suffix}_`)
+  }
+
+  return `## Contributing projects (${projects.length})\n\n${bullets.join("\n")}`
+}
+
+export function resourcePageContent(options: {
+  overview: string
+  overviewHeading: "Project overview" | "Initiative overview"
+  resourceUrl: string
+  latestUpdate?: LinearStatusUpdateContent | null
+  contributingProjects?: LinearContributingProjectContent[]
+}): string {
+  const sections: string[] = []
+  const update = latestUpdateSection(options.latestUpdate)
+  if (update) sections.push(update)
+
+  if (options.contributingProjects) {
+    const projects = contributingProjectsSection(
+      options.contributingProjects,
+      options.resourceUrl
+    )
+    if (projects) sections.push(projects)
+  }
+
+  const overview = truncateMarkdownSection(
+    options.overview,
+    options.resourceUrl,
+    options.overviewHeading.toLowerCase()
+  )
+  if (overview) {
+    sections.push(`## ${options.overviewHeading}\n\n${overview}`)
+  }
+
+  return sections.join("\n\n")
 }

--- a/examples/workers/syncs/linear/src/helpers.ts
+++ b/examples/workers/syncs/linear/src/helpers.ts
@@ -1,0 +1,161 @@
+// Shared display helpers for Linear resource transforms.
+
+const PROJECT_STATUS_LABELS: Record<string, string> = {
+  backlog: "Backlog",
+  planned: "Planned",
+  started: "Started",
+  paused: "Paused",
+  completed: "Completed",
+  canceled: "Canceled",
+  cancelled: "Canceled",
+}
+
+const HEALTH_LABELS: Record<string, string> = {
+  ontrack: "On Track",
+  atrisk: "At Risk",
+  offtrack: "Off Track",
+}
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: "No Priority",
+  1: "Urgent",
+  2: "High",
+  3: "Medium",
+  4: "Low",
+}
+
+function normalizedKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "")
+}
+
+/** Turn an API enum or other machine label into readable title case. */
+export function formatLinearLabel(value: string): string {
+  const spaced = value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+
+  return spaced.replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+/** Map Linear's stable project status type, not a workspace-custom status name. */
+export function projectStatusLabel(
+  type: string | null | undefined
+): string | null {
+  const value = type?.trim()
+  if (!value) return null
+
+  return PROJECT_STATUS_LABELS[normalizedKey(value)] ?? formatLinearLabel(value)
+}
+
+export function healthLabel(health: string | null | undefined): string | null {
+  const value = health?.trim()
+  if (!value) return null
+
+  return HEALTH_LABELS[normalizedKey(value)] ?? formatLinearLabel(value)
+}
+
+export function workflowCategoryLabel(
+  type: string | null | undefined
+): string | null {
+  const value = type?.trim()
+  return value ? formatLinearLabel(value) : null
+}
+
+/**
+ * Prefer Linear's own display label, then fall back to its numeric priority.
+ * Unknown values remain visible instead of being silently misclassified.
+ */
+export function priorityLabel(
+  priority: number | string | null | undefined,
+  suppliedLabel?: string | null
+): string | null {
+  const displayLabel = suppliedLabel?.trim()
+  if (displayLabel) {
+    const key = normalizedKey(displayLabel)
+    if (key === "nopriority" || key === "none") return "No Priority"
+    return formatLinearLabel(displayLabel)
+  }
+
+  if (typeof priority === "number") {
+    return PRIORITY_LABELS[priority] ?? String(priority)
+  }
+
+  const raw = priority?.trim()
+  if (!raw) return null
+
+  const numericPriority = Number(raw)
+  if (Number.isInteger(numericPriority) && raw !== "") {
+    return PRIORITY_LABELS[numericPriority] ?? raw
+  }
+
+  const key = normalizedKey(raw)
+  if (key === "nopriority" || key === "none") return "No Priority"
+  return formatLinearLabel(raw)
+}
+
+export type LinearCycleDisplay = {
+  name?: string | null
+  number?: number | null
+}
+
+export function cycleDisplay(
+  cycle: LinearCycleDisplay | null | undefined
+): string | null {
+  const name = cycle?.name?.trim()
+  if (name) return name
+  return cycle?.number == null ? null : `Cycle ${cycle.number}`
+}
+
+/** Prefer Linear's richer document content and fall back to its description. */
+export function longFormContent(
+  content: unknown,
+  description: string | null | undefined
+): string {
+  if (typeof content === "string" && content.trim()) return content
+  return description?.trim() ? description : ""
+}
+
+export function dateOnly(value: string | null | undefined): string | null {
+  const date = value?.trim()
+  return date ? date.slice(0, 10) : null
+}
+
+export function dateTime(value: string | null | undefined): string | null {
+  const date = value?.trim()
+  return date || null
+}
+
+/** Include related status-update edits in the record freshness watermark. */
+export function latestTimestamp(
+  primary: string,
+  candidate: string | null | undefined
+): string {
+  const candidateValue = candidate?.trim()
+  if (!candidateValue) return primary
+
+  const primaryTime = Date.parse(primary)
+  const candidateTime = Date.parse(candidateValue)
+  if (!Number.isFinite(candidateTime)) return primary
+  return !Number.isFinite(primaryTime) || candidateTime > primaryTime
+    ? candidateValue
+    : primary
+}
+
+export type LinearPersonDisplay = {
+  displayName?: string | null
+  name?: string | null
+  email?: string | null
+}
+
+/** Resolve a related user to a human-readable value without exposing its ID. */
+export function personDisplay(
+  person: LinearPersonDisplay | null | undefined
+): string | null {
+  return (
+    person?.displayName?.trim() ||
+    person?.name?.trim() ||
+    person?.email?.trim() ||
+    null
+  )
+}

--- a/examples/workers/syncs/linear/src/index.ts
+++ b/examples/workers/syncs/linear/src/index.ts
@@ -1,0 +1,193 @@
+// Entry point — syncs Linear projects, issues, and initiatives into managed
+// Notion databases for cross-functional product and engineering visibility.
+//
+// Three databases are created:
+//   1. Projects     — strategic delivery view (every 15 min)
+//   2. Issues       — incremental workflow updates (every 5 min), plus a
+//                     daily full reconciliation for deletes and drift
+//   3. Initiatives  — company-level goals and health (hourly)
+
+// Every API request shares one pacer. All pagination and incremental cursors
+// are plain serializable state so executions never rely on module globals.
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  fetchInitiativesPage,
+  fetchIssuesPage,
+  fetchProjectsPage,
+} from "./linear.js"
+import {
+  INITIAL_TITLE as PROJECTS_TITLE,
+  PRIMARY_KEY as PROJECTS_PK,
+  projectSchema,
+  projectToChange,
+} from "./projects.js"
+import {
+  INITIAL_TITLE as ISSUES_TITLE,
+  PRIMARY_KEY as ISSUES_PK,
+  issueSchema,
+  issueToChange,
+  issueToSyncChange,
+} from "./issues.js"
+import {
+  INITIAL_TITLE as INITIATIVES_TITLE,
+  PRIMARY_KEY as INITIATIVES_PK,
+  initiativeSchema,
+  initiativeToChange,
+} from "./initiatives.js"
+import {
+  issueIncrementalWindow,
+  nextCursorState,
+  nextIssueWatermark,
+  type CursorSyncState,
+  type IssueIncrementalSyncState,
+} from "./sync-state.js"
+
+const worker = new Worker()
+
+// Linear currently documents a lower API-key limit of 2,500 requests/hour
+// alongside a separate query-complexity budget. Keep aggregate traffic below
+// the lower request limit and keep each GraphQL query deliberately shallow.
+const pacer = worker.pacer("linear", {
+  allowedRequests: 2_000,
+  intervalMs: 3_600_000,
+})
+const beforeLinearRequest = () => pacer.wait()
+
+// ---------------------------------------------------------------------------
+// Projects — strategic delivery view
+// ---------------------------------------------------------------------------
+
+const projects = worker.database("projects", {
+  type: "managed",
+  initialTitle: PROJECTS_TITLE,
+  primaryKeyProperty: PROJECTS_PK,
+  schema: projectSchema,
+})
+
+worker.sync("projectsSync", {
+  database: projects,
+  mode: "replace",
+  schedule: "15m",
+  execute: async (state: CursorSyncState | undefined) => {
+    const page = await fetchProjectsPage(beforeLinearRequest, state?.after)
+    const changes = page.resources
+      .filter((project) => !project.trashed)
+      .map(projectToChange)
+
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.hasMore
+        ? nextCursorState(state, page.nextCursor, "projects")
+        : undefined,
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Issues — fast incremental updates with an overlapping, pinned time window
+// ---------------------------------------------------------------------------
+
+const issues = worker.database("issues", {
+  type: "managed",
+  initialTitle: ISSUES_TITLE,
+  primaryKeyProperty: ISSUES_PK,
+  schema: issueSchema,
+})
+
+worker.sync("issuesSync", {
+  database: issues,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state: IssueIncrementalSyncState | undefined) => {
+    const { since, until } = issueIncrementalWindow(state)
+
+    const page = await fetchIssuesPage(beforeLinearRequest, {
+      after: state?.after,
+      updatedSince: since,
+      updatedBefore: until,
+    })
+    const changes = page.resources.map(issueToSyncChange)
+
+    if (page.hasMore) {
+      return {
+        changes,
+        hasMore: true,
+        nextState: {
+          since,
+          until,
+          ...nextCursorState(state, page.nextCursor, "issues"),
+        },
+      }
+    }
+
+    // Keep an overlap so equal timestamps, indexing lag, and writes near the
+    // window boundary are safely replayed. Upserts are idempotent by UUID.
+    return {
+      changes,
+      hasMore: false,
+      // Incremental sync state persists between scheduled runs even when the
+      // current page finishes the cycle.
+      nextState: { since: nextIssueWatermark(until) },
+    }
+  },
+})
+
+// A daily full sweep repairs missed updates and removes hard-deleted issues,
+// which an updatedAt watermark cannot discover by itself.
+worker.sync("issuesReconciliationSync", {
+  database: issues,
+  mode: "replace",
+  schedule: "1d",
+  execute: async (state: CursorSyncState | undefined) => {
+    const page = await fetchIssuesPage(beforeLinearRequest, {
+      after: state?.after,
+    })
+    const changes = page.resources
+      .filter((issue) => !issue.trashed)
+      .map(issueToChange)
+
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.hasMore
+        ? nextCursorState(state, page.nextCursor, "issues")
+        : undefined,
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Initiatives — leadership-level goals and health
+// ---------------------------------------------------------------------------
+
+const initiatives = worker.database("initiatives", {
+  type: "managed",
+  initialTitle: INITIATIVES_TITLE,
+  primaryKeyProperty: INITIATIVES_PK,
+  schema: initiativeSchema,
+})
+
+worker.sync("initiativesSync", {
+  database: initiatives,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state: CursorSyncState | undefined) => {
+    const page = await fetchInitiativesPage(beforeLinearRequest, state?.after)
+    const changes = page.resources
+      .filter((initiative) => !initiative.trashed)
+      .map(initiativeToChange)
+
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.hasMore
+        ? nextCursorState(state, page.nextCursor, "initiatives")
+        : undefined,
+    }
+  },
+})
+
+export default worker

--- a/examples/workers/syncs/linear/src/initiatives.ts
+++ b/examples/workers/syncs/linear/src/initiatives.ts
@@ -11,10 +11,10 @@ import {
   dateTime,
   formatLinearLabel,
   healthLabel,
-  latestTimestamp,
   longFormContent,
   personDisplay,
-  priorityLabel,
+  resourcePageContent,
+  uniqueVisibleProjects,
 } from "./helpers.js"
 
 export const INITIAL_TITLE = "Linear Initiatives"
@@ -43,27 +43,19 @@ export const initiativeSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Initiative Link": Schema.url(),
 
-    Updated: Schema.date(),
+    "Project Count": Schema.number(),
+
+    "Target Date": Schema.date(),
 
     "Last Update At": Schema.date(),
 
     "Last Update Link": Schema.url(),
 
-    Priority: Schema.select([
-      { name: "No Priority" },
-      { name: "Urgent" },
-      { name: "High" },
-      { name: "Medium" },
-      { name: "Low" },
-    ]),
-
-    "Target Date": Schema.date(),
+    Updated: Schema.date(),
 
     Started: Schema.date(),
 
     Completed: Schema.date(),
-
-    Canceled: Schema.date(),
 
     Created: Schema.date(),
 
@@ -84,44 +76,43 @@ export function initiativeToChange(initiative: LinearInitiative) {
   const updated = dateTime(initiative.updatedAt)
   const lastUpdateAt = dateTime(initiative.lastUpdate?.updatedAt)
   const lastUpdateLink = initiative.lastUpdate?.url?.trim()
-  const priority = priorityLabel(initiative.priority)
+  const projects = uniqueVisibleProjects(initiative.projects.nodes)
   const targetDate = dateOnly(initiative.targetDate)
   const started = dateTime(initiative.startedAt)
   const completed = dateTime(initiative.completedAt)
-  const canceled = dateTime(initiative.canceledAt)
   const created = dateTime(initiative.createdAt)
   const slugId = initiative.slugId?.trim()
-  const upstreamUpdatedAt = latestTimestamp(
-    initiative.updatedAt,
-    initiative.lastUpdate?.updatedAt
-  )
 
   return {
     type: "upsert" as const,
     key: initiative.id,
-    upstreamUpdatedAt,
-    pageContentMarkdown: longFormContent(
-      initiative.content,
-      initiative.description
-    ),
+    // This row includes a derived project set. Association removals can make a
+    // max-child timestamp move backward, so the hourly replacement deliberately
+    // refreshes Initiatives instead of supplying an unsafe freshness watermark.
+    pageContentMarkdown: resourcePageContent({
+      overview: longFormContent(initiative.content, initiative.description),
+      overviewHeading: "Initiative overview",
+      resourceUrl: url ?? "",
+      latestUpdate: initiative.lastUpdate,
+      contributingProjects: projects,
+    }),
     properties: {
       Name: Builder.title(initiative.name),
       ...(status ? { Status: Builder.select(status) } : {}),
       ...(health ? { Health: Builder.select(health) } : {}),
       ...(owner ? { Owner: Builder.richText(owner) } : {}),
       ...(url ? { "Initiative Link": Builder.url(url) } : {}),
-      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
+      "Project Count": Builder.number(projects.length),
+      ...(targetDate ? { "Target Date": Builder.date(targetDate) } : {}),
       ...(lastUpdateAt
         ? { "Last Update At": Builder.dateTime(lastUpdateAt) }
         : {}),
       ...(lastUpdateLink
         ? { "Last Update Link": Builder.url(lastUpdateLink) }
         : {}),
-      ...(priority ? { Priority: Builder.select(priority) } : {}),
-      ...(targetDate ? { "Target Date": Builder.date(targetDate) } : {}),
+      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
       ...(started ? { Started: Builder.dateTime(started) } : {}),
       ...(completed ? { Completed: Builder.dateTime(completed) } : {}),
-      ...(canceled ? { Canceled: Builder.dateTime(canceled) } : {}),
       ...(created ? { Created: Builder.dateTime(created) } : {}),
       Archived: Builder.checkbox(Boolean(initiative.archivedAt)),
       ...(slugId ? { "Slug ID": Builder.richText(slugId) } : {}),

--- a/examples/workers/syncs/linear/src/initiatives.ts
+++ b/examples/workers/syncs/linear/src/initiatives.ts
@@ -1,0 +1,131 @@
+// Linear initiatives — leadership-level goals above individual projects.
+// Keep the schema and transform property order in sync.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+
+import type { LinearInitiative } from "./linear.js"
+import {
+  dateOnly,
+  dateTime,
+  formatLinearLabel,
+  healthLabel,
+  latestTimestamp,
+  longFormContent,
+  personDisplay,
+  priorityLabel,
+} from "./helpers.js"
+
+export const INITIAL_TITLE = "Linear Initiatives"
+export const PRIMARY_KEY = "Linear Initiative ID"
+
+export const initiativeSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("trophy"),
+  properties: {
+    Name: Schema.title(),
+
+    Status: Schema.select([
+      { name: "Proposed" },
+      { name: "Planned" },
+      { name: "Active" },
+      { name: "Completed" },
+      { name: "Canceled" },
+    ]),
+
+    Health: Schema.select([
+      { name: "On Track" },
+      { name: "At Risk" },
+      { name: "Off Track" },
+    ]),
+
+    Owner: Schema.richText(),
+
+    "Initiative Link": Schema.url(),
+
+    Updated: Schema.date(),
+
+    "Last Update At": Schema.date(),
+
+    "Last Update Link": Schema.url(),
+
+    Priority: Schema.select([
+      { name: "No Priority" },
+      { name: "Urgent" },
+      { name: "High" },
+      { name: "Medium" },
+      { name: "Low" },
+    ]),
+
+    "Target Date": Schema.date(),
+
+    Started: Schema.date(),
+
+    Completed: Schema.date(),
+
+    Canceled: Schema.date(),
+
+    Created: Schema.date(),
+
+    Archived: Schema.checkbox(),
+
+    "Slug ID": Schema.richText(),
+
+    "Linear Initiative ID": Schema.richText(),
+  },
+}
+
+export function initiativeToChange(initiative: LinearInitiative) {
+  const rawStatus = initiative.status?.trim()
+  const status = rawStatus ? formatLinearLabel(rawStatus) : null
+  const health = healthLabel(initiative.health)
+  const owner = personDisplay(initiative.owner)
+  const url = initiative.url?.trim()
+  const updated = dateTime(initiative.updatedAt)
+  const lastUpdateAt = dateTime(initiative.lastUpdate?.updatedAt)
+  const lastUpdateLink = initiative.lastUpdate?.url?.trim()
+  const priority = priorityLabel(initiative.priority)
+  const targetDate = dateOnly(initiative.targetDate)
+  const started = dateTime(initiative.startedAt)
+  const completed = dateTime(initiative.completedAt)
+  const canceled = dateTime(initiative.canceledAt)
+  const created = dateTime(initiative.createdAt)
+  const slugId = initiative.slugId?.trim()
+  const upstreamUpdatedAt = latestTimestamp(
+    initiative.updatedAt,
+    initiative.lastUpdate?.updatedAt
+  )
+
+  return {
+    type: "upsert" as const,
+    key: initiative.id,
+    upstreamUpdatedAt,
+    pageContentMarkdown: longFormContent(
+      initiative.content,
+      initiative.description
+    ),
+    properties: {
+      Name: Builder.title(initiative.name),
+      ...(status ? { Status: Builder.select(status) } : {}),
+      ...(health ? { Health: Builder.select(health) } : {}),
+      ...(owner ? { Owner: Builder.richText(owner) } : {}),
+      ...(url ? { "Initiative Link": Builder.url(url) } : {}),
+      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
+      ...(lastUpdateAt
+        ? { "Last Update At": Builder.dateTime(lastUpdateAt) }
+        : {}),
+      ...(lastUpdateLink
+        ? { "Last Update Link": Builder.url(lastUpdateLink) }
+        : {}),
+      ...(priority ? { Priority: Builder.select(priority) } : {}),
+      ...(targetDate ? { "Target Date": Builder.date(targetDate) } : {}),
+      ...(started ? { Started: Builder.dateTime(started) } : {}),
+      ...(completed ? { Completed: Builder.dateTime(completed) } : {}),
+      ...(canceled ? { Canceled: Builder.dateTime(canceled) } : {}),
+      ...(created ? { Created: Builder.dateTime(created) } : {}),
+      Archived: Builder.checkbox(Boolean(initiative.archivedAt)),
+      ...(slugId ? { "Slug ID": Builder.richText(slugId) } : {}),
+      "Linear Initiative ID": Builder.richText(initiative.id),
+    },
+  }
+}

--- a/examples/workers/syncs/linear/src/issues.ts
+++ b/examples/workers/syncs/linear/src/issues.ts
@@ -1,0 +1,144 @@
+// Linear issues — the core engineering work visible to cross-functional teams.
+// Keep the schema and transform property order in sync.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+
+import type { LinearIssue } from "./linear.js"
+import {
+  cycleDisplay,
+  dateOnly,
+  dateTime,
+  personDisplay,
+  priorityLabel,
+  workflowCategoryLabel,
+} from "./helpers.js"
+
+export const INITIAL_TITLE = "Linear Issues"
+export const PRIMARY_KEY = "Linear Issue ID"
+
+export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("checkmark-square"),
+  properties: {
+    Title: Schema.title(),
+
+    "Issue Key": Schema.richText(),
+
+    // Workflow names are workspace-defined, so options are created dynamically.
+    Status: Schema.select([]),
+
+    Priority: Schema.select([
+      { name: "No Priority" },
+      { name: "Urgent" },
+      { name: "High" },
+      { name: "Medium" },
+      { name: "Low" },
+    ]),
+
+    Assignee: Schema.richText(),
+
+    "Issue Link": Schema.url(),
+
+    Updated: Schema.date(),
+
+    "Workflow Category": Schema.select([
+      { name: "Triage" },
+      { name: "Backlog" },
+      { name: "Unstarted" },
+      { name: "Started" },
+      { name: "Completed" },
+      { name: "Canceled" },
+    ]),
+
+    Team: Schema.select([]),
+
+    Project: Schema.select([]),
+
+    Cycle: Schema.select([]),
+
+    // Labels are also workspace-defined.
+    Labels: Schema.multiSelect([]),
+
+    Estimate: Schema.number(),
+
+    "Due Date": Schema.date(),
+
+    Started: Schema.date(),
+
+    Completed: Schema.date(),
+
+    Canceled: Schema.date(),
+
+    Created: Schema.date(),
+
+    Archived: Schema.checkbox(),
+
+    "Linear Issue ID": Schema.richText(),
+  },
+}
+
+export function issueToChange(issue: LinearIssue) {
+  const status = issue.state?.name?.trim()
+  const workflowCategory = workflowCategoryLabel(issue.state?.type)
+  const priority = priorityLabel(issue.priority, issue.priorityLabel)
+  const assignee = personDisplay(issue.assignee)
+  const url = issue.url?.trim()
+  const updated = dateTime(issue.updatedAt)
+  const team = issue.team?.name?.trim() || issue.team?.key?.trim()
+  const project = issue.project?.name?.trim()
+  const cycle = cycleDisplay(issue.cycle)
+  const labels = [
+    ...new Set(
+      issue.labels.nodes
+        .map((label) => label.name.trim())
+        .filter((name) => name.length > 0)
+    ),
+  ]
+  const dueDate = dateOnly(issue.dueDate)
+  const started = dateTime(issue.startedAt)
+  const completed = dateTime(issue.completedAt)
+  const canceled = dateTime(issue.canceledAt)
+  const created = dateTime(issue.createdAt)
+  const identifier = issue.identifier?.trim()
+
+  return {
+    type: "upsert" as const,
+    key: issue.id,
+    upstreamUpdatedAt: issue.updatedAt,
+    pageContentMarkdown: issue.description ?? "",
+    properties: {
+      Title: Builder.title(issue.title),
+      ...(identifier ? { "Issue Key": Builder.richText(identifier) } : {}),
+      ...(status ? { Status: Builder.select(status) } : {}),
+      ...(priority ? { Priority: Builder.select(priority) } : {}),
+      ...(assignee ? { Assignee: Builder.richText(assignee) } : {}),
+      ...(url ? { "Issue Link": Builder.url(url) } : {}),
+      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
+      ...(workflowCategory
+        ? { "Workflow Category": Builder.select(workflowCategory) }
+        : {}),
+      ...(team ? { Team: Builder.select(team) } : {}),
+      ...(project ? { Project: Builder.select(project) } : {}),
+      ...(cycle ? { Cycle: Builder.select(cycle) } : {}),
+      ...(labels.length > 0 ? { Labels: Builder.multiSelect(...labels) } : {}),
+      ...(issue.estimate != null && Number.isFinite(issue.estimate)
+        ? { Estimate: Builder.number(issue.estimate) }
+        : {}),
+      ...(dueDate ? { "Due Date": Builder.date(dueDate) } : {}),
+      ...(started ? { Started: Builder.dateTime(started) } : {}),
+      ...(completed ? { Completed: Builder.dateTime(completed) } : {}),
+      ...(canceled ? { Canceled: Builder.dateTime(canceled) } : {}),
+      ...(created ? { Created: Builder.dateTime(created) } : {}),
+      Archived: Builder.checkbox(Boolean(issue.archivedAt)),
+      "Linear Issue ID": Builder.richText(issue.id),
+    },
+  }
+}
+
+/** Incremental polling can observe soft-deleted issues before reconciliation. */
+export function issueToSyncChange(issue: LinearIssue) {
+  return issue.trashed
+    ? { type: "delete" as const, key: issue.id }
+    : issueToChange(issue)
+}

--- a/examples/workers/syncs/linear/src/linear.ts
+++ b/examples/workers/syncs/linear/src/linear.ts
@@ -6,7 +6,11 @@ import { RateLimitError } from "@notionhq/workers"
 
 const API_URL = "https://api.linear.app/graphql"
 const PAGE_SIZE = 50
+// Initiative rows embed the first 50 contributing projects. A smaller outer
+// page keeps the worst-case query comfortably below Linear's complexity cap.
+const INITIATIVE_PAGE_SIZE = 20
 const MAX_NESTED_LABEL_REQUESTS_PER_PAGE = 20
+export const MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE = 20
 
 export type BeforeRequest = () => Promise<void>
 
@@ -32,8 +36,11 @@ export type LinearUser = {
 }
 
 export type LinearStatusUpdate = {
+  body: string
+  createdAt: string
   updatedAt: string
   url: string
+  user: LinearUser | null
 }
 
 export type LinearProjectStatus = {
@@ -109,15 +116,23 @@ export type LinearInitiative = {
   health: string | null
   lastUpdate: LinearStatusUpdate | null
   owner: LinearUser | null
-  priority: number | null
+  projects: LinearConnection<LinearInitiativeProject>
   targetDate: string | null
   startedAt: string | null
   completedAt: string | null
-  canceledAt: string | null
   createdAt: string
   updatedAt: string
   description: string | null
   content: string | null
+  archivedAt: string | null
+  trashed: boolean | null
+}
+
+export type LinearInitiativeProject = {
+  id: string
+  name: string
+  url: string
+  updatedAt: string
   archivedAt: string | null
   trashed: boolean | null
 }
@@ -371,8 +386,14 @@ const PROJECTS_QUERY = /* GraphQL */ `
         }
         health
         lastUpdate {
+          body
+          createdAt
           updatedAt
           url
+          user {
+            name
+            displayName
+          }
         }
         lead {
           name
@@ -635,7 +656,7 @@ export async function fetchIssuesPage(
 const INITIATIVES_QUERY = /* GraphQL */ `
   query Initiatives($after: String) {
     initiatives(
-      first: ${PAGE_SIZE}
+      first: ${INITIATIVE_PAGE_SIZE}
       after: $after
       orderBy: createdAt
       includeArchived: true
@@ -648,18 +669,41 @@ const INITIATIVES_QUERY = /* GraphQL */ `
         status
         health
         lastUpdate {
+          body
+          createdAt
           updatedAt
           url
+          user {
+            name
+            displayName
+          }
         }
         owner {
           name
           displayName
         }
-        priority
+        projects(
+          first: ${PAGE_SIZE}
+          orderBy: createdAt
+          includeArchived: true
+          includeSubInitiatives: true
+        ) {
+          nodes {
+            id
+            name
+            url
+            updatedAt
+            archivedAt
+            trashed
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
         targetDate
         startedAt
         completedAt
-        canceledAt
         createdAt
         updatedAt
         description
@@ -675,6 +719,149 @@ const INITIATIVES_QUERY = /* GraphQL */ `
   }
 `
 
+const INITIATIVE_PROJECTS_QUERY = /* GraphQL */ `
+  query InitiativeProjects($initiativeId: String!, $after: String!) {
+    initiative(id: $initiativeId) {
+      projects(
+        first: ${PAGE_SIZE}
+        after: $after
+        orderBy: createdAt
+        includeArchived: true
+        includeSubInitiatives: true
+      ) {
+        nodes {
+          id
+          name
+          url
+          updatedAt
+          archivedAt
+          trashed
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`
+
+function assertInitiativeProjectsConnection(
+  projects: LinearConnection<LinearInitiativeProject>,
+  initiativeId: string
+): void {
+  if (!projects || !Array.isArray(projects.nodes) || !projects.pageInfo) {
+    throw new Error(
+      `Linear initiative ${initiativeId} has an invalid projects connection`
+    )
+  }
+  if (typeof projects.pageInfo.hasNextPage !== "boolean") {
+    throw new Error(
+      `Linear initiative ${initiativeId} projects response is missing hasNextPage`
+    )
+  }
+  if (projects.pageInfo.hasNextPage && !projects.pageInfo.endCursor) {
+    throw new Error(
+      `Linear initiative ${initiativeId} projects pagination is missing endCursor`
+    )
+  }
+}
+
+function dedupeInitiativeProjects(
+  projects: LinearInitiativeProject[]
+): LinearInitiativeProject[] {
+  const projectsById = new Map<string, LinearInitiativeProject>()
+  for (const project of projects) {
+    const existing = projectsById.get(project.id)
+    const projectUpdatedAt = Date.parse(project.updatedAt)
+    const existingUpdatedAt = existing
+      ? Date.parse(existing.updatedAt)
+      : Number.NaN
+    if (
+      !existing ||
+      (Number.isFinite(projectUpdatedAt) &&
+        (!Number.isFinite(existingUpdatedAt) ||
+          projectUpdatedAt > existingUpdatedAt)) ||
+      (projectUpdatedAt === existingUpdatedAt &&
+        Boolean(existing.trashed) &&
+        !project.trashed)
+    ) {
+      projectsById.set(project.id, project)
+    }
+  }
+  return [...projectsById.values()]
+}
+
+async function fetchAllInitiativeProjects(
+  initiative: LinearInitiative,
+  beforeRequest: BeforeRequest,
+  requestBudget: { remaining: number }
+): Promise<LinearInitiative> {
+  assertInitiativeProjectsConnection(initiative.projects, initiative.id)
+  if (!initiative.projects.pageInfo.hasNextPage) {
+    return {
+      ...initiative,
+      projects: {
+        ...initiative.projects,
+        nodes: dedupeInitiativeProjects(initiative.projects.nodes),
+      },
+    }
+  }
+
+  const projects = [...initiative.projects.nodes]
+  const seenCursors = new Set<string>()
+  let pageInfo = initiative.projects.pageInfo
+
+  while (pageInfo.hasNextPage) {
+    if (requestBudget.remaining <= 0) {
+      throw new Error(
+        `Linear initiative projects exceeded ${MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE} follow-up requests for one initiative page`
+      )
+    }
+
+    const after = pageInfo.endCursor
+    if (!after) {
+      throw new Error(
+        `Linear initiative ${initiative.id} projects pagination is missing endCursor`
+      )
+    }
+    if (seenCursors.has(after)) {
+      throw new Error(
+        `Linear initiative ${initiative.id} projects pagination repeated cursor`
+      )
+    }
+    seenCursors.add(after)
+    requestBudget.remaining -= 1
+
+    const data = await graphql<{
+      initiative: {
+        projects: LinearConnection<LinearInitiativeProject>
+      } | null
+    }>(
+      INITIATIVE_PROJECTS_QUERY,
+      { initiativeId: initiative.id, after },
+      beforeRequest
+    )
+    if (!data.initiative) {
+      throw new Error(
+        `Linear initiative ${initiative.id} disappeared while paginating projects`
+      )
+    }
+
+    assertInitiativeProjectsConnection(data.initiative.projects, initiative.id)
+    projects.push(...data.initiative.projects.nodes)
+    pageInfo = data.initiative.projects.pageInfo
+  }
+
+  return {
+    ...initiative,
+    projects: {
+      nodes: dedupeInitiativeProjects(projects),
+      pageInfo,
+    },
+  }
+}
+
 export async function fetchInitiativesPage(
   beforeRequest: BeforeRequest,
   after?: string
@@ -682,6 +869,20 @@ export async function fetchInitiativesPage(
   const data = await graphql<{
     initiatives: LinearConnection<LinearInitiative>
   }>(INITIATIVES_QUERY, after ? { after } : {}, beforeRequest)
+  const page = connectionToPage(data.initiatives, after, "initiatives")
+  const nestedRequestBudget = {
+    remaining: MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE,
+  }
+  const resources: LinearInitiative[] = []
+  for (const initiative of page.resources) {
+    resources.push(
+      await fetchAllInitiativeProjects(
+        initiative,
+        beforeRequest,
+        nestedRequestBudget
+      )
+    )
+  }
 
-  return connectionToPage(data.initiatives, after, "initiatives")
+  return { ...page, resources }
 }

--- a/examples/workers/syncs/linear/src/linear.ts
+++ b/examples/workers/syncs/linear/src/linear.ts
@@ -1,0 +1,687 @@
+// Linear GraphQL API client. This module deliberately uses the public GraphQL
+// API directly instead of the Linear SDK so that the example shows the full
+// pagination, pacing, and rate-limit behavior required by a production sync.
+
+import { RateLimitError } from "@notionhq/workers"
+
+const API_URL = "https://api.linear.app/graphql"
+const PAGE_SIZE = 50
+const MAX_NESTED_LABEL_REQUESTS_PER_PAGE = 20
+
+export type BeforeRequest = () => Promise<void>
+
+export type LinearPageInfo = {
+  hasNextPage: boolean
+  endCursor: string | null
+}
+
+export type LinearConnection<T> = {
+  nodes: T[]
+  pageInfo: LinearPageInfo
+}
+
+export type LinearPage<T> = {
+  resources: T[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}
+
+export type LinearUser = {
+  name: string | null
+  displayName: string | null
+}
+
+export type LinearStatusUpdate = {
+  updatedAt: string
+  url: string
+}
+
+export type LinearProjectStatus = {
+  name: string
+  type: string
+}
+
+export type LinearProject = {
+  id: string
+  name: string
+  slugId: string
+  url: string
+  status: LinearProjectStatus | null
+  health: string | null
+  lastUpdate: LinearStatusUpdate | null
+  lead: LinearUser | null
+  priority: number | null
+  priorityLabel: string | null
+  progress: number | null
+  startDate: string | null
+  targetDate: string | null
+  startedAt: string | null
+  completedAt: string | null
+  canceledAt: string | null
+  createdAt: string
+  updatedAt: string
+  description: string | null
+  content: string | null
+  archivedAt: string | null
+  trashed: boolean | null
+}
+
+export type LinearIssueState = {
+  name: string
+  type: string
+}
+
+export type LinearLabel = {
+  name: string
+}
+
+export type LinearIssue = {
+  id: string
+  identifier: string
+  title: string
+  url: string
+  description: string | null
+  state: LinearIssueState | null
+  priority: number
+  priorityLabel: string
+  assignee: LinearUser | null
+  team: { name: string; key: string } | null
+  project: { name: string } | null
+  cycle: { name: string; number: number } | null
+  labels: LinearConnection<LinearLabel>
+  estimate: number | null
+  dueDate: string | null
+  createdAt: string
+  updatedAt: string
+  startedAt: string | null
+  completedAt: string | null
+  canceledAt: string | null
+  archivedAt: string | null
+  trashed: boolean | null
+}
+
+export type LinearInitiative = {
+  id: string
+  name: string
+  slugId: string
+  url: string
+  status: string | null
+  health: string | null
+  lastUpdate: LinearStatusUpdate | null
+  owner: LinearUser | null
+  priority: number | null
+  targetDate: string | null
+  startedAt: string | null
+  completedAt: string | null
+  canceledAt: string | null
+  createdAt: string
+  updatedAt: string
+  description: string | null
+  content: string | null
+  archivedAt: string | null
+  trashed: boolean | null
+}
+
+export type FetchIssuesOptions = {
+  after?: string
+  updatedSince?: string
+  updatedBefore?: string
+}
+
+type GraphQLError = {
+  message?: string
+  type?: string
+  extensions?: {
+    code?: string
+    type?: string
+    [key: string]: unknown
+  }
+}
+
+type GraphQLResponse<T> = {
+  data?: T | null
+  errors?: GraphQLError[]
+}
+
+function getApiKey(): string {
+  const apiKey = process.env.LINEAR_API_KEY?.trim()
+  if (!apiKey) {
+    throw new Error("LINEAR_API_KEY is not set.")
+  }
+  return apiKey
+}
+
+/**
+ * Parse the standard Retry-After header. It can be either delta-seconds or an
+ * HTTP date. Workers' RateLimitError expects the resulting delay in seconds.
+ */
+export function parseRetryAfterSeconds(
+  value: string | null,
+  now = Date.now()
+): number | undefined {
+  if (!value?.trim()) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds)
+  }
+
+  const retryAt = Date.parse(value)
+  if (!Number.isFinite(retryAt)) return undefined
+  return Math.max(0, Math.ceil((retryAt - now) / 1_000))
+}
+
+type RateLimitHeaderPair = {
+  remaining: string
+  reset: string
+}
+
+// Linear has independent workspace request, endpoint request, and query
+// complexity budgets. Header names have evolved, so accept the documented
+// names plus the older endpoint aliases when calculating a retry delay.
+const RATE_LIMIT_HEADER_PAIRS: RateLimitHeaderPair[] = [
+  {
+    remaining: "x-ratelimit-requests-remaining",
+    reset: "x-ratelimit-requests-reset",
+  },
+  {
+    remaining: "x-ratelimit-endpoint-requests-remaining",
+    reset: "x-ratelimit-endpoint-requests-reset",
+  },
+  {
+    remaining: "x-ratelimit-endpoint-remaining",
+    reset: "x-ratelimit-endpoint-reset",
+  },
+  {
+    remaining: "x-ratelimit-complexity-remaining",
+    reset: "x-ratelimit-complexity-reset",
+  },
+  {
+    remaining: "x-ratelimit-endpoint-complexity-remaining",
+    reset: "x-ratelimit-endpoint-complexity-reset",
+  },
+]
+
+/** Return the longest applicable retry delay across all exhausted budgets. */
+export function rateLimitRetryAfterSeconds(
+  headers: Headers,
+  now = Date.now()
+): number | undefined {
+  const delays: number[] = []
+  const retryAfter = parseRetryAfterSeconds(headers.get("retry-after"), now)
+  if (retryAfter !== undefined) delays.push(retryAfter)
+
+  for (const pair of RATE_LIMIT_HEADER_PAIRS) {
+    const remainingValue = headers.get(pair.remaining)
+    if (remainingValue === null) continue
+
+    const remaining = Number(remainingValue)
+    if (!Number.isFinite(remaining) || remaining > 0) continue
+
+    // Linear documents reset timestamps as epoch milliseconds.
+    const resetAt = Number(headers.get(pair.reset))
+    if (!Number.isFinite(resetAt) || resetAt < 0) continue
+    delays.push(Math.max(0, Math.ceil((resetAt - now) / 1_000)))
+  }
+
+  return delays.length > 0 ? Math.max(...delays) : undefined
+}
+
+function isRateLimitError(error: GraphQLError): boolean {
+  const classifications = [
+    error.type,
+    error.extensions?.code,
+    error.extensions?.type,
+  ]
+
+  return classifications.some(
+    (value) =>
+      typeof value === "string" &&
+      value.replace(/[\s_-]/g, "").toUpperCase() === "RATELIMITED"
+  )
+}
+
+function graphQLErrorMessage(errors: GraphQLError[]): string {
+  const messages = errors
+    .map((error) => error.message?.trim())
+    .filter((message): message is string => Boolean(message))
+  return messages.length > 0 ? messages.join("; ") : "Unknown GraphQL error"
+}
+
+/**
+ * Execute one GraphQL operation. The pacing callback is deliberately called
+ * here, immediately before fetch, so it also covers follow-up label pages.
+ * GraphQL partial responses are rejected: accepting data alongside errors can
+ * silently create incomplete Notion rows.
+ */
+async function graphql<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  beforeRequest: BeforeRequest
+): Promise<T> {
+  const apiKey = getApiKey()
+
+  await beforeRequest()
+  const response = await fetch(API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: apiKey,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+    redirect: "error",
+  })
+
+  const text = await response.text()
+  let body: GraphQLResponse<T> | undefined
+  if (text) {
+    try {
+      body = JSON.parse(text) as GraphQLResponse<T>
+    } catch {
+      if (response.status === 429) {
+        throw new RateLimitError({
+          retryAfter: rateLimitRetryAfterSeconds(response.headers),
+        })
+      }
+      throw new Error(
+        `Linear API returned invalid JSON (${response.status}): ${text.slice(0, 500)}`
+      )
+    }
+  }
+
+  if (response.status === 429) {
+    throw new RateLimitError({
+      retryAfter: rateLimitRetryAfterSeconds(response.headers),
+    })
+  }
+
+  const errors = Array.isArray(body?.errors) ? body.errors : []
+  if (errors.some(isRateLimitError)) {
+    throw new RateLimitError({
+      retryAfter: rateLimitRetryAfterSeconds(response.headers),
+    })
+  }
+
+  if (!response.ok) {
+    const detail =
+      errors.length > 0
+        ? graphQLErrorMessage(errors)
+        : text || "No response body"
+    throw new Error(`Linear API error (${response.status}): ${detail}`)
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Linear GraphQL error: ${graphQLErrorMessage(errors)}`)
+  }
+  if (!body || body.data === undefined || body.data === null) {
+    throw new Error("Linear GraphQL response is missing data")
+  }
+
+  return body.data
+}
+
+function connectionToPage<T>(
+  connection: LinearConnection<T>,
+  after: string | undefined,
+  resourceName: string
+): LinearPage<T> {
+  if (!connection || !Array.isArray(connection.nodes) || !connection.pageInfo) {
+    throw new Error(`Linear ${resourceName} response has an invalid connection`)
+  }
+
+  const { hasNextPage, endCursor } = connection.pageInfo
+  if (typeof hasNextPage !== "boolean") {
+    throw new Error(
+      `Linear ${resourceName} response is missing pageInfo.hasNextPage`
+    )
+  }
+  if (hasNextPage && !endCursor) {
+    throw new Error(
+      `Linear ${resourceName} pagination response is missing endCursor`
+    )
+  }
+  if (hasNextPage && endCursor === after) {
+    throw new Error(`Linear ${resourceName} pagination repeated cursor`)
+  }
+
+  return {
+    resources: connection.nodes,
+    hasMore: hasNextPage,
+    nextCursor: hasNextPage ? endCursor ?? undefined : undefined,
+  }
+}
+
+const PROJECTS_QUERY = /* GraphQL */ `
+  query Projects($after: String) {
+    projects(
+      first: ${PAGE_SIZE}
+      after: $after
+      orderBy: createdAt
+      includeArchived: true
+    ) {
+      nodes {
+        id
+        name
+        slugId
+        url
+        status {
+          name
+          type
+        }
+        health
+        lastUpdate {
+          updatedAt
+          url
+        }
+        lead {
+          name
+          displayName
+        }
+        priority
+        priorityLabel
+        progress
+        startDate
+        targetDate
+        startedAt
+        completedAt
+        canceledAt
+        createdAt
+        updatedAt
+        description
+        content
+        archivedAt
+        trashed
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`
+
+export async function fetchProjectsPage(
+  beforeRequest: BeforeRequest,
+  after?: string
+): Promise<LinearPage<LinearProject>> {
+  const data = await graphql<{
+    projects: LinearConnection<LinearProject>
+  }>(PROJECTS_QUERY, after ? { after } : {}, beforeRequest)
+
+  return connectionToPage(data.projects, after, "projects")
+}
+
+const ISSUES_QUERY = /* GraphQL */ `
+  query Issues(
+    $after: String
+    $filter: IssueFilter
+    $orderBy: PaginationOrderBy!
+  ) {
+    issues(
+      first: ${PAGE_SIZE}
+      after: $after
+      orderBy: $orderBy
+      includeArchived: true
+      filter: $filter
+    ) {
+      nodes {
+        id
+        identifier
+        title
+        url
+        description
+        state {
+          name
+          type
+        }
+        priority
+        priorityLabel
+        assignee {
+          name
+          displayName
+        }
+        team {
+          name
+          key
+        }
+        project {
+          name
+        }
+        cycle {
+          name
+          number
+        }
+        labels(first: ${PAGE_SIZE}, includeArchived: true) {
+          nodes {
+            name
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+        estimate
+        dueDate
+        createdAt
+        updatedAt
+        startedAt
+        completedAt
+        canceledAt
+        archivedAt
+        trashed
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`
+
+const ISSUE_LABELS_QUERY = /* GraphQL */ `
+  query IssueLabels($issueId: String!, $after: String!) {
+    issue(id: $issueId) {
+      labels(
+        first: ${PAGE_SIZE}
+        after: $after
+        includeArchived: true
+      ) {
+        nodes {
+          name
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`
+
+function assertLabelsConnection(
+  labels: LinearConnection<LinearLabel>,
+  issueId: string
+): void {
+  if (!labels || !Array.isArray(labels.nodes) || !labels.pageInfo) {
+    throw new Error(`Linear issue ${issueId} has an invalid labels connection`)
+  }
+  if (typeof labels.pageInfo.hasNextPage !== "boolean") {
+    throw new Error(
+      `Linear issue ${issueId} labels response is missing hasNextPage`
+    )
+  }
+  if (labels.pageInfo.hasNextPage && !labels.pageInfo.endCursor) {
+    throw new Error(
+      `Linear issue ${issueId} labels pagination is missing endCursor`
+    )
+  }
+}
+
+async function fetchAllIssueLabels(
+  issue: LinearIssue,
+  beforeRequest: BeforeRequest,
+  requestBudget: { remaining: number }
+): Promise<LinearIssue> {
+  assertLabelsConnection(issue.labels, issue.id)
+  if (!issue.labels.pageInfo.hasNextPage) {
+    return {
+      ...issue,
+      labels: {
+        ...issue.labels,
+        nodes: dedupeLabels(issue.labels.nodes),
+      },
+    }
+  }
+
+  const labels = [...issue.labels.nodes]
+  const seenCursors = new Set<string>()
+  let pageInfo = issue.labels.pageInfo
+
+  while (pageInfo.hasNextPage) {
+    if (requestBudget.remaining <= 0) {
+      throw new Error(
+        `Linear issue labels exceeded ${MAX_NESTED_LABEL_REQUESTS_PER_PAGE} follow-up requests for one issue page`
+      )
+    }
+
+    const after = pageInfo.endCursor
+    if (!after) {
+      throw new Error(
+        `Linear issue ${issue.id} labels pagination is missing endCursor`
+      )
+    }
+    if (seenCursors.has(after)) {
+      throw new Error(
+        `Linear issue ${issue.id} labels pagination repeated cursor`
+      )
+    }
+    seenCursors.add(after)
+    requestBudget.remaining -= 1
+
+    const data = await graphql<{
+      issue: { labels: LinearConnection<LinearLabel> } | null
+    }>(ISSUE_LABELS_QUERY, { issueId: issue.id, after }, beforeRequest)
+    if (!data.issue) {
+      throw new Error(
+        `Linear issue ${issue.id} disappeared while paginating labels`
+      )
+    }
+
+    assertLabelsConnection(data.issue.labels, issue.id)
+    labels.push(...data.issue.labels.nodes)
+    pageInfo = data.issue.labels.pageInfo
+  }
+
+  return {
+    ...issue,
+    labels: {
+      nodes: dedupeLabels(labels),
+      pageInfo,
+    },
+  }
+}
+
+function dedupeLabels(labels: LinearLabel[]): LinearLabel[] {
+  const names = new Set<string>()
+  return labels.filter((label) => {
+    if (names.has(label.name)) return false
+    names.add(label.name)
+    return true
+  })
+}
+
+export async function fetchIssuesPage(
+  beforeRequest: BeforeRequest,
+  options: FetchIssuesOptions = {}
+): Promise<LinearPage<LinearIssue>> {
+  const hasUpdatedAtFilter =
+    options.updatedSince !== undefined || options.updatedBefore !== undefined
+  const variables: Record<string, unknown> = {
+    // Replacement sweeps use stable creation order; bounded incremental
+    // windows must use updated order so cursor traversal matches the filter.
+    orderBy: hasUpdatedAtFilter ? "updatedAt" : "createdAt",
+  }
+  if (options.after) variables.after = options.after
+
+  const updatedAt: { gte?: string; lt?: string } = {}
+  if (options.updatedSince !== undefined) updatedAt.gte = options.updatedSince
+  if (options.updatedBefore !== undefined) updatedAt.lt = options.updatedBefore
+  if (Object.keys(updatedAt).length > 0) {
+    variables.filter = { updatedAt }
+  }
+
+  const data = await graphql<{
+    issues: LinearConnection<LinearIssue>
+  }>(ISSUES_QUERY, variables, beforeRequest)
+  const page = connectionToPage(data.issues, options.after, "issues")
+
+  // A nested connection only incurs extra API requests when an issue actually
+  // has more than PAGE_SIZE labels. Bound all label follow-ups for this issue
+  // page so one pathological workspace cannot create an unbounded execution.
+  const resources: LinearIssue[] = []
+  const nestedRequestBudget = {
+    remaining: MAX_NESTED_LABEL_REQUESTS_PER_PAGE,
+  }
+  for (const issue of page.resources) {
+    resources.push(
+      await fetchAllIssueLabels(issue, beforeRequest, nestedRequestBudget)
+    )
+  }
+
+  return { ...page, resources }
+}
+
+const INITIATIVES_QUERY = /* GraphQL */ `
+  query Initiatives($after: String) {
+    initiatives(
+      first: ${PAGE_SIZE}
+      after: $after
+      orderBy: createdAt
+      includeArchived: true
+    ) {
+      nodes {
+        id
+        name
+        slugId
+        url
+        status
+        health
+        lastUpdate {
+          updatedAt
+          url
+        }
+        owner {
+          name
+          displayName
+        }
+        priority
+        targetDate
+        startedAt
+        completedAt
+        canceledAt
+        createdAt
+        updatedAt
+        description
+        content
+        archivedAt
+        trashed
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`
+
+export async function fetchInitiativesPage(
+  beforeRequest: BeforeRequest,
+  after?: string
+): Promise<LinearPage<LinearInitiative>> {
+  const data = await graphql<{
+    initiatives: LinearConnection<LinearInitiative>
+  }>(INITIATIVES_QUERY, after ? { after } : {}, beforeRequest)
+
+  return connectionToPage(data.initiatives, after, "initiatives")
+}

--- a/examples/workers/syncs/linear/src/projects.ts
+++ b/examples/workers/syncs/linear/src/projects.ts
@@ -1,0 +1,148 @@
+// Linear projects — the strategic delivery view for PMs and stakeholders.
+// Keep the schema and transform property order in sync.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+
+import type { LinearProject } from "./linear.js"
+import {
+  dateOnly,
+  dateTime,
+  healthLabel,
+  latestTimestamp,
+  longFormContent,
+  personDisplay,
+  priorityLabel,
+  projectStatusLabel,
+} from "./helpers.js"
+
+export const INITIAL_TITLE = "Linear Projects"
+export const PRIMARY_KEY = "Linear Project ID"
+
+export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("target"),
+  properties: {
+    Name: Schema.title(),
+
+    // Project status names are workspace-defined.
+    Status: Schema.select([]),
+
+    Health: Schema.select([
+      { name: "On Track" },
+      { name: "At Risk" },
+      { name: "Off Track" },
+    ]),
+
+    Lead: Schema.richText(),
+
+    "Project Link": Schema.url(),
+
+    "Progress %": Schema.number(),
+
+    "Target Date": Schema.date(),
+
+    Updated: Schema.date(),
+
+    "Last Update At": Schema.date(),
+
+    "Last Update Link": Schema.url(),
+
+    "Status Category": Schema.select([
+      { name: "Backlog" },
+      { name: "Planned" },
+      { name: "Started" },
+      { name: "Paused" },
+      { name: "Completed" },
+      { name: "Canceled" },
+    ]),
+
+    Priority: Schema.select([
+      { name: "No Priority" },
+      { name: "Urgent" },
+      { name: "High" },
+      { name: "Medium" },
+      { name: "Low" },
+    ]),
+
+    "Start Date": Schema.date(),
+
+    Started: Schema.date(),
+
+    Completed: Schema.date(),
+
+    Canceled: Schema.date(),
+
+    Created: Schema.date(),
+
+    Archived: Schema.checkbox(),
+
+    "Slug ID": Schema.richText(),
+
+    "Linear Project ID": Schema.richText(),
+  },
+}
+
+function progressPercent(progress: number | null | undefined): number | null {
+  if (progress == null || !Number.isFinite(progress)) return null
+  return Math.min(100, Math.max(0, progress * 100))
+}
+
+export function projectToChange(project: LinearProject) {
+  const status = project.status?.name?.trim()
+  const statusCategory = projectStatusLabel(project.status?.type)
+  const health = healthLabel(project.health)
+  const lead = personDisplay(project.lead)
+  const url = project.url?.trim()
+  const updated = dateTime(project.updatedAt)
+  const lastUpdateAt = dateTime(project.lastUpdate?.updatedAt)
+  const lastUpdateLink = project.lastUpdate?.url?.trim()
+  const priority = priorityLabel(project.priority, project.priorityLabel)
+  const progress = progressPercent(project.progress)
+  const startDate = dateOnly(project.startDate)
+  const targetDate = dateOnly(project.targetDate)
+  const started = dateTime(project.startedAt)
+  const completed = dateTime(project.completedAt)
+  const canceled = dateTime(project.canceledAt)
+  const created = dateTime(project.createdAt)
+  const slugId = project.slugId?.trim()
+  const upstreamUpdatedAt = latestTimestamp(
+    project.updatedAt,
+    project.lastUpdate?.updatedAt
+  )
+
+  return {
+    type: "upsert" as const,
+    key: project.id,
+    upstreamUpdatedAt,
+    pageContentMarkdown: longFormContent(project.content, project.description),
+    properties: {
+      Name: Builder.title(project.name),
+      ...(status ? { Status: Builder.select(status) } : {}),
+      ...(health ? { Health: Builder.select(health) } : {}),
+      ...(lead ? { Lead: Builder.richText(lead) } : {}),
+      ...(url ? { "Project Link": Builder.url(url) } : {}),
+      ...(progress != null ? { "Progress %": Builder.number(progress) } : {}),
+      ...(targetDate ? { "Target Date": Builder.date(targetDate) } : {}),
+      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
+      ...(lastUpdateAt
+        ? { "Last Update At": Builder.dateTime(lastUpdateAt) }
+        : {}),
+      ...(lastUpdateLink
+        ? { "Last Update Link": Builder.url(lastUpdateLink) }
+        : {}),
+      ...(statusCategory
+        ? { "Status Category": Builder.select(statusCategory) }
+        : {}),
+      ...(priority ? { Priority: Builder.select(priority) } : {}),
+      ...(startDate ? { "Start Date": Builder.date(startDate) } : {}),
+      ...(started ? { Started: Builder.dateTime(started) } : {}),
+      ...(completed ? { Completed: Builder.dateTime(completed) } : {}),
+      ...(canceled ? { Canceled: Builder.dateTime(canceled) } : {}),
+      ...(created ? { Created: Builder.dateTime(created) } : {}),
+      Archived: Builder.checkbox(Boolean(project.archivedAt)),
+      ...(slugId ? { "Slug ID": Builder.richText(slugId) } : {}),
+      "Linear Project ID": Builder.richText(project.id),
+    },
+  }
+}

--- a/examples/workers/syncs/linear/src/projects.ts
+++ b/examples/workers/syncs/linear/src/projects.ts
@@ -15,6 +15,7 @@ import {
   personDisplay,
   priorityLabel,
   projectStatusLabel,
+  resourcePageContent,
 } from "./helpers.js"
 
 export const INITIAL_TITLE = "Linear Projects"
@@ -115,7 +116,12 @@ export function projectToChange(project: LinearProject) {
     type: "upsert" as const,
     key: project.id,
     upstreamUpdatedAt,
-    pageContentMarkdown: longFormContent(project.content, project.description),
+    pageContentMarkdown: resourcePageContent({
+      overview: longFormContent(project.content, project.description),
+      overviewHeading: "Project overview",
+      resourceUrl: url ?? "",
+      latestUpdate: project.lastUpdate,
+    }),
     properties: {
       Name: Builder.title(project.name),
       ...(status ? { Status: Builder.select(status) } : {}),

--- a/examples/workers/syncs/linear/src/sync-state.ts
+++ b/examples/workers/syncs/linear/src/sync-state.ts
@@ -1,0 +1,66 @@
+// Pure, serializable sync-state helpers. Keeping these transitions separate
+// makes the safety properties of a multi-page sync straightforward to test.
+
+export type CursorSyncState = {
+  after: string
+  seenCursors: string[]
+}
+
+export type IssueIncrementalSyncState = {
+  since: string
+  until?: string
+  after?: string
+  seenCursors?: string[]
+}
+
+export const INITIAL_ISSUE_WATERMARK = new Date(0).toISOString()
+export const CONSISTENCY_BUFFER_MS = 15_000
+export const WATERMARK_OVERLAP_MS = 60_000
+
+/**
+ * Record every cursor in persisted state so a longer cycle such as A -> B -> A
+ * fails instead of keeping a replacement run alive forever.
+ */
+export function nextCursorState(
+  state: { after?: string; seenCursors?: string[] } | undefined,
+  nextCursor: string | undefined,
+  resourceName: string
+): CursorSyncState {
+  if (!nextCursor) {
+    throw new Error(`Linear ${resourceName} pagination is missing next cursor`)
+  }
+
+  const seenCursors = new Set(state?.seenCursors ?? [])
+  if (state?.after) seenCursors.add(state.after)
+  if (seenCursors.has(nextCursor)) {
+    throw new Error(`Linear ${resourceName} pagination repeated cursor`)
+  }
+
+  return {
+    after: nextCursor,
+    seenCursors: [...seenCursors, nextCursor],
+  }
+}
+
+/** Pin an incremental window until every cursor page has completed. */
+export function issueIncrementalWindow(
+  state: IssueIncrementalSyncState | undefined,
+  now = Date.now()
+): { since: string; until: string } {
+  return {
+    since: state?.since ?? INITIAL_ISSUE_WATERMARK,
+    until:
+      state?.until ??
+      new Date(Math.max(0, now - CONSISTENCY_BUFFER_MS)).toISOString(),
+  }
+}
+
+/** Advance the watermark with overlap after the final page succeeds. */
+export function nextIssueWatermark(until: string): string {
+  const parsedUntil = Date.parse(until)
+  if (!Number.isFinite(parsedUntil)) {
+    throw new Error("Linear issues incremental window has an invalid end time")
+  }
+
+  return new Date(Math.max(0, parsedUntil - WATERMARK_OVERLAP_MS)).toISOString()
+}

--- a/examples/workers/syncs/linear/test.ts
+++ b/examples/workers/syncs/linear/test.ts
@@ -1,0 +1,1100 @@
+// Offline tests for the Linear sync worker.
+// Run from this directory with `npm test`.
+
+import assert from "node:assert/strict"
+import { afterEach, test } from "node:test"
+
+import { RateLimitError } from "@notionhq/workers"
+
+import {
+  cycleDisplay,
+  dateOnly,
+  dateTime,
+  formatLinearLabel,
+  healthLabel,
+  latestTimestamp,
+  longFormContent,
+  personDisplay,
+  priorityLabel,
+  projectStatusLabel,
+  workflowCategoryLabel,
+} from "./src/helpers.js"
+import worker from "./src/index.js"
+import { initiativeToChange } from "./src/initiatives.js"
+import { issueToChange, issueToSyncChange } from "./src/issues.js"
+import {
+  fetchInitiativesPage,
+  fetchIssuesPage,
+  fetchProjectsPage,
+  parseRetryAfterSeconds,
+  rateLimitRetryAfterSeconds,
+} from "./src/linear.js"
+import type {
+  LinearInitiative,
+  LinearIssue,
+  LinearProject,
+} from "./src/linear.js"
+import { projectToChange } from "./src/projects.js"
+import {
+  CONSISTENCY_BUFFER_MS,
+  INITIAL_ISSUE_WATERMARK,
+  WATERMARK_OVERLAP_MS,
+  issueIncrementalWindow,
+  nextCursorState,
+  nextIssueWatermark,
+} from "./src/sync-state.js"
+
+const originalFetch = globalThis.fetch
+const originalApiKey = process.env.LINEAR_API_KEY
+const originalDateNow = Date.now
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  Date.now = originalDateNow
+  if (originalApiKey === undefined) {
+    delete process.env.LINEAR_API_KEY
+  } else {
+    process.env.LINEAR_API_KEY = originalApiKey
+  }
+})
+
+function propertyText(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function assertPropertyContains(value: unknown, expected: string): void {
+  assert.match(
+    propertyText(value),
+    new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  )
+}
+
+const fullProject: LinearProject = {
+  id: "f0d3f667-397d-4f29-a3bd-c34fcab57ffc",
+  name: "Launch Enterprise",
+  slugId: "launch-enterprise-42",
+  url: "https://linear.app/acme/project/launch-enterprise-42",
+  status: { name: "Custom delivery name", type: "started" },
+  health: "atRisk",
+  lastUpdate: {
+    updatedAt: "2026-07-01T16:17:18.654Z",
+    url: "https://linear.app/acme/project/launch-enterprise-42/updates/last",
+  },
+  lead: { name: "Ada Lovelace", displayName: "Ada" },
+  priority: 2,
+  priorityLabel: null,
+  progress: 1.25,
+  startDate: "2026-02-03",
+  targetDate: "2026-09-30",
+  startedAt: "2026-02-03T14:15:16.789Z",
+  completedAt: "2026-09-29T23:59:58.123Z",
+  canceledAt: null,
+  createdAt: "2025-12-01T08:09:10.456Z",
+  updatedAt: "2026-06-30T17:18:19.987Z",
+  description: "Fallback project description",
+  content: "# Launch Enterprise\n\nFull project brief.",
+  archivedAt: "2026-10-01T00:00:00Z",
+  trashed: false,
+}
+
+const minimalProject: LinearProject = {
+  id: "b3be6524-e989-410b-b0a4-98ed6b42dc40",
+  name: "Unscheduled project",
+  slugId: "",
+  url: "https://linear.app/acme/project/unscheduled",
+  status: null,
+  health: null,
+  lastUpdate: null,
+  lead: null,
+  priority: null,
+  priorityLabel: null,
+  progress: null,
+  startDate: null,
+  targetDate: null,
+  startedAt: null,
+  completedAt: null,
+  canceledAt: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-02T03:04:05Z",
+  description: null,
+  content: null,
+  archivedAt: null,
+  trashed: null,
+}
+
+const fullIssue: LinearIssue = {
+  id: "2ec63b7f-8b80-4d4b-b19a-34ca621ba901",
+  identifier: "ENG-321",
+  title: "Make import resumable",
+  url: "https://linear.app/acme/issue/ENG-321/make-import-resumable",
+  description: "## Acceptance criteria\n\n- Resume from the saved cursor.",
+  state: { name: "In Progress", type: "started" },
+  priority: 1,
+  priorityLabel: "",
+  assignee: { name: "Grace Hopper", displayName: "Grace" },
+  team: { name: "Engineering", key: "ENG" },
+  project: { name: "Launch Enterprise" },
+  cycle: { name: "Cycle 27", number: 27 },
+  labels: {
+    nodes: [{ name: "backend" }, { name: "api" }, { name: "backend" }],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  },
+  estimate: 0,
+  dueDate: "2026-07-15",
+  createdAt: "2026-06-01T01:02:03.456Z",
+  updatedAt: "2026-06-30T20:21:22.987Z",
+  startedAt: "2026-06-03T04:05:06.789Z",
+  completedAt: "2026-06-29T22:23:24.123Z",
+  canceledAt: null,
+  archivedAt: null,
+  trashed: false,
+}
+
+const minimalIssue: LinearIssue = {
+  id: "7ae26556-424d-488a-a8a5-5b38e9a28088",
+  identifier: "ENG-1",
+  title: "Triage me",
+  url: "https://linear.app/acme/issue/ENG-1/triage-me",
+  description: null,
+  state: null,
+  priority: 0,
+  priorityLabel: "",
+  assignee: null,
+  team: null,
+  project: null,
+  cycle: { name: "", number: 12 },
+  labels: {
+    nodes: [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  },
+  estimate: null,
+  dueDate: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-02T00:00:00Z",
+  startedAt: null,
+  completedAt: null,
+  canceledAt: null,
+  archivedAt: null,
+  trashed: null,
+}
+
+const fullInitiative: LinearInitiative = {
+  id: "a4614236-8020-4eb7-8f50-cf088cc5f075",
+  name: "Reach enterprise readiness",
+  slugId: "enterprise-readiness-2026",
+  url: "https://linear.app/acme/initiative/enterprise-readiness-2026",
+  status: "Active",
+  health: "offTrack",
+  lastUpdate: {
+    updatedAt: "2026-07-02T18:19:20.321Z",
+    url: "https://linear.app/acme/initiative/enterprise-readiness-2026/updates/last",
+  },
+  owner: { name: "Katherine Johnson", displayName: "Katherine" },
+  priority: 3,
+  targetDate: "2026-12-31",
+  startedAt: "2026-01-15T11:12:13.456Z",
+  completedAt: "2026-12-20T14:15:16.789Z",
+  canceledAt: "2026-12-21T10:11:12.345Z",
+  createdAt: "2025-11-01T17:18:19.123Z",
+  updatedAt: "2026-06-30T20:21:22.987Z",
+  description: "Fallback initiative description",
+  content: "# Enterprise readiness\n\nCompany-level goal.",
+  archivedAt: "2027-01-01T00:00:00Z",
+  trashed: false,
+}
+
+const minimalInitiative: LinearInitiative = {
+  id: "33ac57a9-f846-44e8-9889-91f061409343",
+  name: "Explore a new market",
+  slugId: "",
+  url: "https://linear.app/acme/initiative/explore-market",
+  status: null,
+  health: null,
+  lastUpdate: null,
+  owner: null,
+  priority: null,
+  targetDate: null,
+  startedAt: null,
+  completedAt: null,
+  canceledAt: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-02T00:00:00Z",
+  description: null,
+  content: null,
+  archivedAt: null,
+  trashed: null,
+}
+
+test("worker manifest preserves databases, sync schedules, and shared pacing", () => {
+  assert.deepEqual(
+    worker.manifest.databases.map((database) => ({
+      key: database.key,
+      title: database.config.initialTitle,
+      primaryKey: database.config.primaryKeyProperty,
+      icon: database.config.schema.databaseIcon,
+    })),
+    [
+      {
+        key: "projects",
+        title: "Linear Projects",
+        primaryKey: "Linear Project ID",
+        icon: { type: "notion", icon: "target", color: "gray" },
+      },
+      {
+        key: "issues",
+        title: "Linear Issues",
+        primaryKey: "Linear Issue ID",
+        icon: { type: "notion", icon: "checkmark-square", color: "gray" },
+      },
+      {
+        key: "initiatives",
+        title: "Linear Initiatives",
+        primaryKey: "Linear Initiative ID",
+        icon: { type: "notion", icon: "trophy", color: "gray" },
+      },
+    ]
+  )
+  assert.deepEqual(
+    worker.manifest.databases.map((database) => ({
+      key: database.key,
+      firstSixProperties: Object.keys(database.config.schema.properties).slice(
+        0,
+        6
+      ),
+    })),
+    [
+      {
+        key: "projects",
+        firstSixProperties: [
+          "Name",
+          "Status",
+          "Health",
+          "Lead",
+          "Project Link",
+          "Progress %",
+        ],
+      },
+      {
+        key: "issues",
+        firstSixProperties: [
+          "Title",
+          "Issue Key",
+          "Status",
+          "Priority",
+          "Assignee",
+          "Issue Link",
+        ],
+      },
+      {
+        key: "initiatives",
+        firstSixProperties: [
+          "Name",
+          "Status",
+          "Health",
+          "Owner",
+          "Initiative Link",
+          "Updated",
+        ],
+      },
+    ]
+  )
+
+  type SyncManifestConfig = {
+    databaseKey: string
+    mode: string
+    schedule: { type: string; intervalMs: number }
+  }
+  assert.deepEqual(
+    worker.manifest.capabilities.map((capability) => {
+      assert.equal(capability._tag, "sync")
+      const config = capability.config as SyncManifestConfig
+      return {
+        key: capability.key,
+        databaseKey: config.databaseKey,
+        mode: config.mode,
+        schedule: config.schedule,
+      }
+    }),
+    [
+      {
+        key: "projectsSync",
+        databaseKey: "projects",
+        mode: "replace",
+        schedule: { type: "interval", intervalMs: 15 * 60_000 },
+      },
+      {
+        key: "issuesSync",
+        databaseKey: "issues",
+        mode: "incremental",
+        schedule: { type: "interval", intervalMs: 5 * 60_000 },
+      },
+      {
+        key: "issuesReconciliationSync",
+        databaseKey: "issues",
+        mode: "replace",
+        schedule: { type: "interval", intervalMs: 24 * 60 * 60_000 },
+      },
+      {
+        key: "initiativesSync",
+        databaseKey: "initiatives",
+        mode: "replace",
+        schedule: { type: "interval", intervalMs: 60 * 60_000 },
+      },
+    ]
+  )
+
+  assert.deepEqual(worker.manifest.pacers, [
+    {
+      key: "linear",
+      config: { allowedRequests: 2_000, intervalMs: 60 * 60_000 },
+    },
+  ])
+})
+
+test("display helpers normalize Linear values without discarding unknowns", () => {
+  assert.equal(formatLinearLabel("in_progress-now"), "In Progress Now")
+  assert.equal(formatLinearLabel("offTrack"), "Off Track")
+
+  assert.equal(projectStatusLabel("started"), "Started")
+  assert.equal(projectStatusLabel("CANCELLED"), "Canceled")
+  assert.equal(projectStatusLabel("custom_status"), "Custom Status")
+  assert.equal(projectStatusLabel("  "), null)
+
+  assert.equal(healthLabel("onTrack"), "On Track")
+  assert.equal(healthLabel("at_risk"), "At Risk")
+  assert.equal(healthLabel("custom_health"), "Custom Health")
+  assert.equal(healthLabel(null), null)
+
+  assert.equal(workflowCategoryLabel("started"), "Started")
+  assert.equal(workflowCategoryLabel("auto_closed"), "Auto Closed")
+  assert.equal(workflowCategoryLabel(null), null)
+
+  assert.equal(priorityLabel(1, null), "Urgent")
+  assert.equal(priorityLabel(2, ""), "High")
+  assert.equal(priorityLabel(99, null), "99")
+  assert.equal(priorityLabel(null, "no_priority"), "No Priority")
+  assert.equal(priorityLabel("4"), "Low")
+  assert.equal(priorityLabel("special_case"), "Special Case")
+  assert.equal(priorityLabel(null), null)
+})
+
+test("content, person, cycle, and date helpers preserve useful values", () => {
+  assert.equal(
+    personDisplay({ displayName: "  Display Name " }),
+    "Display Name"
+  )
+  assert.equal(
+    personDisplay({ displayName: "", name: " API Name " }),
+    "API Name"
+  )
+  assert.equal(
+    personDisplay({ email: " person@example.com " }),
+    "person@example.com"
+  )
+  assert.equal(personDisplay(null), null)
+
+  assert.equal(cycleDisplay({ name: " Sprint 20 ", number: 20 }), "Sprint 20")
+  assert.equal(cycleDisplay({ name: "", number: 20 }), "Cycle 20")
+  assert.equal(cycleDisplay(null), null)
+
+  assert.equal(
+    longFormContent("# Rich document", "description"),
+    "# Rich document"
+  )
+  assert.equal(longFormContent(" ", "  description  "), "  description  ")
+  assert.equal(longFormContent(null, null), "")
+  assert.equal(dateOnly("2026-06-30T23:59:59Z"), "2026-06-30")
+  assert.equal(dateOnly("  "), null)
+  assert.equal(dateTime("2026-06-30T23:59:59.987Z"), "2026-06-30T23:59:59.987Z")
+  assert.equal(dateTime(null), null)
+
+  const primary = "2026-06-30T12:00:00.000Z"
+  assert.equal(
+    latestTimestamp(primary, "2026-07-01T12:00:00.000Z"),
+    "2026-07-01T12:00:00.000Z"
+  )
+  assert.equal(latestTimestamp(primary, "2026-06-01T12:00:00.000Z"), primary)
+  assert.equal(latestTimestamp(primary, null), primary)
+  assert.equal(latestTimestamp(primary, "not-a-timestamp"), primary)
+  assert.equal(
+    latestTimestamp("invalid-primary", "2026-07-01T12:00:00.000Z"),
+    "2026-07-01T12:00:00.000Z"
+  )
+})
+
+test("retry helpers handle delta seconds, dates, and exhausted Linear budgets", () => {
+  const now = Date.parse("2026-06-30T12:00:00Z")
+  assert.equal(parseRetryAfterSeconds("3.2", now), 4)
+  assert.equal(parseRetryAfterSeconds("Tue, 30 Jun 2026 12:00:07 GMT", now), 7)
+  assert.equal(parseRetryAfterSeconds("invalid", now), undefined)
+  assert.equal(parseRetryAfterSeconds(null, now), undefined)
+
+  const headers = new Headers({
+    "retry-after": "2",
+    "x-ratelimit-requests-remaining": "0",
+    "x-ratelimit-requests-reset": String(now + 8_001),
+    "x-ratelimit-complexity-remaining": "4",
+    "x-ratelimit-complexity-reset": String(now + 60_000),
+  })
+  assert.equal(rateLimitRetryAfterSeconds(headers, now), 9)
+  assert.equal(rateLimitRetryAfterSeconds(new Headers(), now), undefined)
+})
+
+test("project transform emits a complete strategic record", () => {
+  const change = projectToChange(fullProject)
+
+  assert.equal(change.type, "upsert")
+  assert.equal(
+    change.key,
+    fullProject.id,
+    "the immutable Linear UUID is the key"
+  )
+  assert.equal(change.upstreamUpdatedAt, fullProject.lastUpdate?.updatedAt)
+  assert.equal(change.pageContentMarkdown, fullProject.content)
+  assertPropertyContains(change.properties.Name, fullProject.name)
+  assertPropertyContains(change.properties.Status, "Custom delivery name")
+  assertPropertyContains(change.properties["Status Category"], "Started")
+  assertPropertyContains(change.properties.Health, "At Risk")
+  assertPropertyContains(change.properties.Lead, "Ada")
+  assertPropertyContains(change.properties["Project Link"], fullProject.url)
+  assertPropertyContains(change.properties.Priority, "High")
+  assertPropertyContains(change.properties["Progress %"], "100")
+  assertPropertyContains(change.properties.Updated, "2026-06-30")
+  assertPropertyContains(change.properties.Updated, "17:18")
+  assertPropertyContains(change.properties["Last Update At"], "2026-07-01")
+  assertPropertyContains(change.properties["Last Update At"], "16:17")
+  assertPropertyContains(
+    change.properties["Last Update Link"],
+    fullProject.lastUpdate?.url ?? ""
+  )
+  assertPropertyContains(change.properties.Started, "14:15")
+  assertPropertyContains(change.properties.Completed, "23:59")
+  assertPropertyContains(change.properties["Start Date"], "2026-02-03")
+  assertPropertyContains(change.properties["Target Date"], "2026-09-30")
+  assertPropertyContains(change.properties.Archived, "Yes")
+  assertPropertyContains(change.properties["Slug ID"], fullProject.slugId)
+  assertPropertyContains(change.properties["Linear Project ID"], fullProject.id)
+})
+
+test("project transform omits absent optional values and keeps zero progress", () => {
+  const minimal = projectToChange(minimalProject)
+  assert.equal(minimal.key, minimalProject.id)
+  assert.equal(minimal.upstreamUpdatedAt, minimalProject.updatedAt)
+  assert.equal(minimal.pageContentMarkdown, "")
+  assert.equal(minimal.properties.Status, undefined)
+  assert.equal(minimal.properties["Status Category"], undefined)
+  assert.equal(minimal.properties.Health, undefined)
+  assert.equal(minimal.properties.Lead, undefined)
+  assert.equal(minimal.properties.Priority, undefined)
+  assert.equal(minimal.properties["Progress %"], undefined)
+  assert.equal(minimal.properties["Last Update At"], undefined)
+  assert.equal(minimal.properties["Last Update Link"], undefined)
+  assert.equal(minimal.properties["Start Date"], undefined)
+  assert.equal(minimal.properties["Target Date"], undefined)
+  assert.equal(minimal.properties.Started, undefined)
+  assert.equal(minimal.properties.Completed, undefined)
+  assert.equal(minimal.properties.Canceled, undefined)
+  assert.equal(minimal.properties["Slug ID"], undefined)
+  assertPropertyContains(minimal.properties.Archived, "No")
+
+  const zero = projectToChange({ ...minimalProject, progress: 0 })
+  assertPropertyContains(zero.properties["Progress %"], "0")
+  const belowZero = projectToChange({ ...minimalProject, progress: -0.4 })
+  assertPropertyContains(belowZero.properties["Progress %"], "0")
+  const aboveOne = projectToChange({ ...minimalProject, progress: 3 })
+  assertPropertyContains(aboveOne.properties["Progress %"], "100")
+})
+
+test("issue transform emits a full record, dedupes labels, and retains estimate zero", () => {
+  const change = issueToChange(fullIssue)
+
+  assert.equal(change.type, "upsert")
+  assert.equal(change.key, fullIssue.id, "the immutable Linear UUID is the key")
+  assert.equal(change.upstreamUpdatedAt, fullIssue.updatedAt)
+  assert.equal(change.pageContentMarkdown, fullIssue.description)
+  assertPropertyContains(change.properties.Title, fullIssue.title)
+  assertPropertyContains(change.properties["Issue Key"], "ENG-321")
+  assertPropertyContains(change.properties.Status, "In Progress")
+  assertPropertyContains(change.properties["Workflow Category"], "Started")
+  assertPropertyContains(change.properties.Priority, "Urgent")
+  assertPropertyContains(change.properties.Assignee, "Grace")
+  assertPropertyContains(change.properties["Issue Link"], fullIssue.url)
+  assertPropertyContains(change.properties.Team, "Engineering")
+  assertPropertyContains(change.properties.Project, "Launch Enterprise")
+  assertPropertyContains(change.properties.Cycle, "Cycle 27")
+  assert.equal(
+    propertyText(change.properties.Labels).match(/backend/g)?.length,
+    1
+  )
+  assertPropertyContains(change.properties.Labels, "api")
+  assertPropertyContains(change.properties.Estimate, "0")
+  assertPropertyContains(change.properties.Updated, "20:21")
+  assertPropertyContains(change.properties.Started, "04:05")
+  assertPropertyContains(change.properties.Completed, "22:23")
+  assertPropertyContains(change.properties["Due Date"], "2026-07-15")
+  assertPropertyContains(change.properties["Linear Issue ID"], fullIssue.id)
+})
+
+test("issue transform handles a minimal record and cycle-number fallback", () => {
+  const change = issueToChange(minimalIssue)
+
+  assert.equal(change.key, minimalIssue.id)
+  assert.equal(change.upstreamUpdatedAt, minimalIssue.updatedAt)
+  assert.equal(change.pageContentMarkdown, "")
+  assert.equal(change.properties.Status, undefined)
+  assert.equal(change.properties["Workflow Category"], undefined)
+  assertPropertyContains(change.properties.Priority, "No Priority")
+  assert.equal(change.properties.Assignee, undefined)
+  assert.equal(change.properties.Team, undefined)
+  assert.equal(change.properties.Project, undefined)
+  assertPropertyContains(change.properties.Cycle, "Cycle 12")
+  assert.equal(change.properties.Labels, undefined)
+  assert.equal(change.properties.Estimate, undefined)
+  assert.equal(change.properties["Due Date"], undefined)
+  assert.equal(change.properties.Started, undefined)
+  assert.equal(change.properties.Completed, undefined)
+  assert.equal(change.properties.Canceled, undefined)
+  assertPropertyContains(change.properties.Archived, "No")
+})
+
+test("issue sync changes turn soft-deleted records into immutable-key deletes", () => {
+  assert.deepEqual(issueToSyncChange({ ...minimalIssue, trashed: true }), {
+    type: "delete",
+    key: minimalIssue.id,
+  })
+
+  const upsert = issueToSyncChange({ ...minimalIssue, trashed: false })
+  assert.equal(upsert.type, "upsert")
+  assert.equal(upsert.key, minimalIssue.id)
+  assert.equal(upsert.upstreamUpdatedAt, minimalIssue.updatedAt)
+})
+
+test("first issue window starts at the epoch and leaves a consistency buffer", () => {
+  const now = Date.parse("2026-06-30T12:00:00.000Z")
+
+  assert.deepEqual(issueIncrementalWindow(undefined, now), {
+    since: INITIAL_ISSUE_WATERMARK,
+    until: new Date(now - CONSISTENCY_BUFFER_MS).toISOString(),
+  })
+})
+
+test("issue window remains pinned across every cursor page", () => {
+  const state = {
+    since: "2026-06-01T00:00:00.000Z",
+    until: "2026-06-30T11:59:45.000Z",
+    after: "issue-page-2",
+    seenCursors: ["issue-page-2"],
+  }
+
+  assert.deepEqual(
+    issueIncrementalWindow(state, Date.parse("2027-01-01T00:00:00.000Z")),
+    {
+      since: state.since,
+      until: state.until,
+    }
+  )
+})
+
+test("terminal issue watermark overlaps the completed window and validates it", () => {
+  const until = "2026-06-30T12:00:00.000Z"
+  assert.equal(
+    nextIssueWatermark(until),
+    new Date(Date.parse(until) - WATERMARK_OVERLAP_MS).toISOString()
+  )
+  assert.equal(
+    nextIssueWatermark("1970-01-01T00:00:30.000Z"),
+    INITIAL_ISSUE_WATERMARK,
+    "the overlap clamps at the epoch"
+  )
+  assert.throws(() => nextIssueWatermark("not-a-timestamp"), /invalid end time/)
+})
+
+test("cursor state rejects missing, immediate, and longer repeated cursors", () => {
+  assert.throws(
+    () => nextCursorState(undefined, undefined, "projects"),
+    /Linear projects pagination is missing next cursor/
+  )
+
+  const first = nextCursorState(undefined, "cursor-a", "projects")
+  assert.deepEqual(first, {
+    after: "cursor-a",
+    seenCursors: ["cursor-a"],
+  })
+
+  assert.throws(
+    () => nextCursorState(first, "cursor-a", "projects"),
+    /Linear projects pagination repeated cursor/
+  )
+
+  const second = nextCursorState(first, "cursor-b", "projects")
+  assert.deepEqual(second, {
+    after: "cursor-b",
+    seenCursors: ["cursor-a", "cursor-b"],
+  })
+  assert.throws(
+    () => nextCursorState(second, "cursor-a", "projects"),
+    /Linear projects pagination repeated cursor/,
+    "serialized cursor history catches A -> B -> A loops"
+  )
+})
+
+test("initiative transform emits status, health, slug, content, and timestamps", () => {
+  const change = initiativeToChange(fullInitiative)
+
+  assert.equal(change.type, "upsert")
+  assert.equal(
+    change.key,
+    fullInitiative.id,
+    "the immutable Linear UUID is the key"
+  )
+  assert.equal(change.upstreamUpdatedAt, fullInitiative.lastUpdate?.updatedAt)
+  assert.equal(change.pageContentMarkdown, fullInitiative.content)
+  assertPropertyContains(change.properties.Name, fullInitiative.name)
+  assertPropertyContains(change.properties.Status, "Active")
+  assertPropertyContains(change.properties.Health, "Off Track")
+  assertPropertyContains(change.properties.Owner, "Katherine")
+  assertPropertyContains(
+    change.properties["Initiative Link"],
+    fullInitiative.url
+  )
+  assertPropertyContains(change.properties.Updated, "20:21")
+  assertPropertyContains(change.properties["Last Update At"], "2026-07-02")
+  assertPropertyContains(change.properties["Last Update At"], "18:19")
+  assertPropertyContains(
+    change.properties["Last Update Link"],
+    fullInitiative.lastUpdate?.url ?? ""
+  )
+  assertPropertyContains(change.properties.Priority, "Medium")
+  assertPropertyContains(change.properties.Started, "11:12")
+  assertPropertyContains(change.properties.Completed, "14:15")
+  assertPropertyContains(change.properties.Canceled, "10:11")
+  assertPropertyContains(change.properties["Target Date"], "2026-12-31")
+  assertPropertyContains(change.properties["Slug ID"], fullInitiative.slugId)
+  assertPropertyContains(
+    change.properties["Linear Initiative ID"],
+    fullInitiative.id
+  )
+  assertPropertyContains(change.properties.Archived, "Yes")
+})
+
+test("initiative transform omits absent optional values", () => {
+  const change = initiativeToChange(minimalInitiative)
+
+  assert.equal(change.key, minimalInitiative.id)
+  assert.equal(change.upstreamUpdatedAt, minimalInitiative.updatedAt)
+  assert.equal(change.pageContentMarkdown, "")
+  assert.equal(change.properties.Status, undefined)
+  assert.equal(change.properties.Health, undefined)
+  assert.equal(change.properties.Owner, undefined)
+  assert.equal(change.properties.Priority, undefined)
+  assert.equal(change.properties["Last Update At"], undefined)
+  assert.equal(change.properties["Last Update Link"], undefined)
+  assert.equal(change.properties["Target Date"], undefined)
+  assert.equal(change.properties.Started, undefined)
+  assert.equal(change.properties.Completed, undefined)
+  assert.equal(change.properties.Canceled, undefined)
+  assert.equal(change.properties["Slug ID"], undefined)
+  assertPropertyContains(change.properties.Archived, "No")
+})
+
+type GraphQLRequest = {
+  query: string
+  variables: Record<string, unknown>
+}
+
+type FetchCall = {
+  url: string
+  method: string | undefined
+  authorization: string | null
+  accept: string | null
+  contentType: string | null
+  redirect: RequestRedirect | undefined
+  request: GraphQLRequest
+}
+
+function installQueuedGraphQLFetch(
+  responses: Array<Response | (() => Response)>,
+  calls: FetchCall[]
+): void {
+  globalThis.fetch = (async (input, init) => {
+    const headers = new Headers(init?.headers)
+    const request = JSON.parse(String(init?.body)) as GraphQLRequest
+    calls.push({
+      url: String(input),
+      method: init?.method,
+      authorization: headers.get("authorization"),
+      accept: headers.get("accept"),
+      contentType: headers.get("content-type"),
+      redirect: init?.redirect,
+      request,
+    })
+
+    const next = responses.shift()
+    assert.ok(next, `unexpected GraphQL request: ${request.query}`)
+    return typeof next === "function" ? next() : next
+  }) as typeof fetch
+}
+
+const noPacing = async (): Promise<void> => {}
+
+function projectConnection(
+  nodes: LinearProject[],
+  hasNextPage: boolean,
+  endCursor: string | null
+): Response {
+  return Response.json({
+    data: { projects: { nodes, pageInfo: { hasNextPage, endCursor } } },
+  })
+}
+
+function initiativeConnection(
+  nodes: LinearInitiative[],
+  hasNextPage: boolean,
+  endCursor: string | null
+): Response {
+  return Response.json({
+    data: { initiatives: { nodes, pageInfo: { hasNextPage, endCursor } } },
+  })
+}
+
+function issueConnection(
+  nodes: LinearIssue[],
+  hasNextPage: boolean,
+  endCursor: string | null
+): Response {
+  return Response.json({
+    data: { issues: { nodes, pageInfo: { hasNextPage, endCursor } } },
+  })
+}
+
+test("GraphQL client uses the endpoint, POST body, and direct API-key authorization", async () => {
+  process.env.LINEAR_API_KEY = "lin_api_test-secret"
+  const calls: FetchCall[] = []
+  installQueuedGraphQLFetch(
+    [projectConnection([fullProject], false, null)],
+    calls
+  )
+
+  const page = await fetchProjectsPage(noPacing)
+
+  assert.equal(page.resources[0]?.id, fullProject.id)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]?.url, "https://api.linear.app/graphql")
+  assert.equal(calls[0]?.method, "POST")
+  assert.equal(calls[0]?.authorization, "lin_api_test-secret")
+  assert.doesNotMatch(calls[0]?.authorization ?? "", /^Bearer\s/i)
+  assert.equal(calls[0]?.accept, "application/json")
+  assert.equal(calls[0]?.contentType, "application/json")
+  assert.equal(calls[0]?.redirect, "error")
+  assert.match(calls[0]?.request.query ?? "", /query Projects/)
+  assert.match(calls[0]?.request.query ?? "", /orderBy: createdAt/)
+  assert.deepEqual(calls[0]?.request.variables, {})
+})
+
+test("project and initiative connections expose durable cursor pages", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  const calls: FetchCall[] = []
+  installQueuedGraphQLFetch(
+    [
+      projectConnection([fullProject], true, "project-page-2"),
+      projectConnection([minimalProject], false, null),
+      initiativeConnection([fullInitiative], true, "initiative-page-2"),
+      initiativeConnection([minimalInitiative], false, null),
+    ],
+    calls
+  )
+
+  const firstProjects = await fetchProjectsPage(noPacing)
+  const finalProjects = await fetchProjectsPage(
+    noPacing,
+    firstProjects.nextCursor
+  )
+  const firstInitiatives = await fetchInitiativesPage(noPacing)
+  const finalInitiatives = await fetchInitiativesPage(
+    noPacing,
+    firstInitiatives.nextCursor
+  )
+
+  assert.deepEqual(firstProjects, {
+    resources: [fullProject],
+    hasMore: true,
+    nextCursor: "project-page-2",
+  })
+  assert.deepEqual(finalProjects, {
+    resources: [minimalProject],
+    hasMore: false,
+    nextCursor: undefined,
+  })
+  assert.deepEqual(firstInitiatives, {
+    resources: [fullInitiative],
+    hasMore: true,
+    nextCursor: "initiative-page-2",
+  })
+  assert.deepEqual(finalInitiatives, {
+    resources: [minimalInitiative],
+    hasMore: false,
+    nextCursor: undefined,
+  })
+  assert.deepEqual(
+    calls.map((call) => call.request.variables),
+    [{}, { after: "project-page-2" }, {}, { after: "initiative-page-2" }]
+  )
+  assert.match(calls[0]?.request.query ?? "", /orderBy: createdAt/)
+  assert.match(calls[2]?.request.query ?? "", /orderBy: createdAt/)
+})
+
+test("issue requests pin the incremental updatedAt window in GraphQL variables", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  const calls: FetchCall[] = []
+  installQueuedGraphQLFetch(
+    [issueConnection([minimalIssue], false, null)],
+    calls
+  )
+
+  const page = await fetchIssuesPage(noPacing, {
+    after: "issue-page-3",
+    updatedSince: "2026-06-01T00:00:00.000Z",
+    updatedBefore: "2026-07-01T00:00:00.000Z",
+  })
+
+  assert.equal(page.resources[0]?.id, minimalIssue.id)
+  assert.deepEqual(calls[0]?.request.variables, {
+    orderBy: "updatedAt",
+    after: "issue-page-3",
+    filter: {
+      updatedAt: {
+        gte: "2026-06-01T00:00:00.000Z",
+        lt: "2026-07-01T00:00:00.000Z",
+      },
+    },
+  })
+})
+
+test("connection pagination rejects a missing next cursor", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  installQueuedGraphQLFetch([projectConnection([], true, null)], [])
+
+  await assert.rejects(
+    () => fetchProjectsPage(noPacing),
+    /Linear projects pagination response is missing endCursor/
+  )
+})
+
+test("connection pagination rejects a repeated cursor", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  installQueuedGraphQLFetch([projectConnection([], true, "project-page-2")], [])
+
+  await assert.rejects(
+    () => fetchProjectsPage(noPacing, "project-page-2"),
+    /Linear projects pagination repeated cursor/
+  )
+})
+
+test("GraphQL errors are rejected", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  installQueuedGraphQLFetch(
+    [
+      Response.json({
+        errors: [{ message: "Projects are unavailable", type: "INTERNAL" }],
+      }),
+    ],
+    []
+  )
+
+  await assert.rejects(
+    () => fetchProjectsPage(noPacing),
+    /Linear GraphQL error: Projects are unavailable/
+  )
+})
+
+test("GraphQL partial data is rejected instead of silently syncing it", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  installQueuedGraphQLFetch(
+    [
+      Response.json({
+        data: {
+          projects: {
+            nodes: [fullProject],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+        errors: [{ message: "One project could not be resolved" }],
+      }),
+    ],
+    []
+  )
+
+  await assert.rejects(
+    () => fetchProjectsPage(noPacing),
+    /Linear GraphQL error: One project could not be resolved/
+  )
+})
+
+test("HTTP 429 preserves Retry-After in Workers RateLimitError", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  installQueuedGraphQLFetch(
+    [new Response("", { status: 429, headers: { "Retry-After": "7" } })],
+    []
+  )
+
+  await assert.rejects(
+    () => fetchProjectsPage(noPacing),
+    (error: unknown) => {
+      assert.ok(error instanceof RateLimitError)
+      assert.equal(error.retryAfter, 7)
+      return true
+    }
+  )
+})
+
+test("HTTP 400 GraphQL RATELIMITED uses Linear reset headers", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  const now = Date.parse("2026-06-30T12:00:00Z")
+  Date.now = () => now
+  installQueuedGraphQLFetch(
+    [
+      Response.json(
+        {
+          errors: [
+            {
+              message: "Request budget exhausted",
+              extensions: { code: "RATE_LIMITED" },
+            },
+          ],
+        },
+        {
+          status: 400,
+          headers: {
+            "x-ratelimit-requests-remaining": "0",
+            "x-ratelimit-requests-reset": String(now + 11_000),
+          },
+        }
+      ),
+    ],
+    []
+  )
+
+  await assert.rejects(
+    () => fetchProjectsPage(noPacing),
+    (error: unknown) => {
+      assert.ok(error instanceof RateLimitError)
+      assert.equal(error.retryAfter, 11)
+      return true
+    }
+  )
+})
+
+test("nested issue labels are fully paginated, deduped, and paced per request", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  const calls: FetchCall[] = []
+  let pacingCount = 0
+  const issueWithManyLabels: LinearIssue = {
+    ...minimalIssue,
+    labels: {
+      nodes: [{ name: "bug" }, { name: "api" }, { name: "bug" }],
+      pageInfo: { hasNextPage: true, endCursor: "label-page-2" },
+    },
+  }
+
+  installQueuedGraphQLFetch(
+    [
+      issueConnection([issueWithManyLabels], false, null),
+      Response.json({
+        data: {
+          issue: {
+            labels: {
+              nodes: [{ name: "api" }, { name: "backend" }],
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "label-page-3",
+              },
+            },
+          },
+        },
+      }),
+      Response.json({
+        data: {
+          issue: {
+            labels: {
+              nodes: [{ name: "backend" }, { name: "customer" }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      }),
+    ],
+    calls
+  )
+
+  const page = await fetchIssuesPage(async () => {
+    pacingCount++
+  })
+
+  assert.equal(pacingCount, 3, "the issue page and both label pages are paced")
+  assert.deepEqual(
+    page.resources[0]?.labels.nodes.map((label) => label.name),
+    ["bug", "api", "backend", "customer"]
+  )
+  assert.equal(calls.length, 3)
+  assert.match(calls[0]?.request.query ?? "", /query Issues/)
+  assert.match(
+    calls[0]?.request.query ?? "",
+    /labels\(first: 50, includeArchived: true\)/
+  )
+  assert.deepEqual(calls[0]?.request.variables, { orderBy: "createdAt" })
+  assert.match(calls[1]?.request.query ?? "", /query IssueLabels/)
+  assert.match(calls[1]?.request.query ?? "", /includeArchived: true/)
+  assert.match(calls[2]?.request.query ?? "", /query IssueLabels/)
+  assert.deepEqual(calls[1]?.request.variables, {
+    issueId: issueWithManyLabels.id,
+    after: "label-page-2",
+  })
+  assert.deepEqual(calls[2]?.request.variables, {
+    issueId: issueWithManyLabels.id,
+    after: "label-page-3",
+  })
+})
+
+test("nested label safety bound rejects instead of returning truncated labels", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  let pacingCount = 0
+  const issue: LinearIssue = {
+    ...minimalIssue,
+    labels: {
+      nodes: [],
+      pageInfo: { hasNextPage: true, endCursor: "label-page-1" },
+    },
+  }
+  const followUpPages = Array.from({ length: 20 }, (_, index) =>
+    Response.json({
+      data: {
+        issue: {
+          labels: {
+            nodes: [{ name: `label-${index + 1}` }],
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: `label-page-${index + 2}`,
+            },
+          },
+        },
+      },
+    })
+  )
+  installQueuedGraphQLFetch(
+    [issueConnection([issue], false, null), ...followUpPages],
+    []
+  )
+
+  await assert.rejects(
+    () =>
+      fetchIssuesPage(async () => {
+        pacingCount++
+      }),
+    /exceeded 20 follow-up requests/
+  )
+  assert.equal(
+    pacingCount,
+    21,
+    "one issue request plus exactly 20 label requests"
+  )
+})

--- a/examples/workers/syncs/linear/test.ts
+++ b/examples/workers/syncs/linear/test.ts
@@ -7,6 +7,8 @@ import { afterEach, test } from "node:test"
 import { RateLimitError } from "@notionhq/workers"
 
 import {
+  MAX_PAGE_SECTION_CHARACTERS,
+  MAX_RENDERED_CONTRIBUTING_PROJECTS,
   cycleDisplay,
   dateOnly,
   dateTime,
@@ -17,12 +19,14 @@ import {
   personDisplay,
   priorityLabel,
   projectStatusLabel,
+  resourcePageContent,
   workflowCategoryLabel,
 } from "./src/helpers.js"
 import worker from "./src/index.js"
 import { initiativeToChange } from "./src/initiatives.js"
 import { issueToChange, issueToSyncChange } from "./src/issues.js"
 import {
+  MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE,
   fetchInitiativesPage,
   fetchIssuesPage,
   fetchProjectsPage,
@@ -31,6 +35,7 @@ import {
 } from "./src/linear.js"
 import type {
   LinearInitiative,
+  LinearInitiativeProject,
   LinearIssue,
   LinearProject,
 } from "./src/linear.js"
@@ -77,8 +82,11 @@ const fullProject: LinearProject = {
   status: { name: "Custom delivery name", type: "started" },
   health: "atRisk",
   lastUpdate: {
+    body: "Enterprise launch remains on track after the security review.",
+    createdAt: "2026-07-01T15:16:17.654Z",
     updatedAt: "2026-07-01T16:17:18.654Z",
     url: "https://linear.app/acme/project/launch-enterprise-42/updates/last",
+    user: { name: "Ada Lovelace", displayName: "Ada" },
   },
   lead: { name: "Ada Lovelace", displayName: "Ada" },
   priority: 2,
@@ -186,15 +194,53 @@ const fullInitiative: LinearInitiative = {
   status: "Active",
   health: "offTrack",
   lastUpdate: {
+    body: "The remaining enterprise blockers now have committed owners.",
+    createdAt: "2026-07-02T17:18:19.321Z",
     updatedAt: "2026-07-02T18:19:20.321Z",
     url: "https://linear.app/acme/initiative/enterprise-readiness-2026/updates/last",
+    user: { name: "Nan Yu", displayName: "Nan" },
   },
   owner: { name: "Katherine Johnson", displayName: "Katherine" },
-  priority: 3,
+  projects: {
+    nodes: [
+      {
+        id: "project-mobile",
+        name: "Mobile Reliability",
+        url: "https://linear.app/acme/project/mobile-reliability",
+        updatedAt: "2026-06-29T10:00:00Z",
+        archivedAt: null,
+        trashed: false,
+      },
+      {
+        id: "project-api",
+        name: "API Foundations",
+        url: "https://linear.app/acme/project/api-foundations",
+        updatedAt: "2026-06-28T10:00:00Z",
+        archivedAt: "2026-06-30T00:00:00Z",
+        trashed: false,
+      },
+      {
+        id: "project-api",
+        name: "Duplicate API Foundations",
+        url: "https://linear.app/acme/project/api-foundations",
+        updatedAt: "2026-06-28T10:00:00Z",
+        archivedAt: null,
+        trashed: false,
+      },
+      {
+        id: "project-trashed",
+        name: "Discarded experiment",
+        url: "https://linear.app/acme/project/discarded",
+        updatedAt: "2026-07-03T10:00:00Z",
+        archivedAt: null,
+        trashed: true,
+      },
+    ],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  },
   targetDate: "2026-12-31",
   startedAt: "2026-01-15T11:12:13.456Z",
   completedAt: "2026-12-20T14:15:16.789Z",
-  canceledAt: "2026-12-21T10:11:12.345Z",
   createdAt: "2025-11-01T17:18:19.123Z",
   updatedAt: "2026-06-30T20:21:22.987Z",
   description: "Fallback initiative description",
@@ -212,11 +258,13 @@ const minimalInitiative: LinearInitiative = {
   health: null,
   lastUpdate: null,
   owner: null,
-  priority: null,
+  projects: {
+    nodes: [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  },
   targetDate: null,
   startedAt: null,
   completedAt: null,
-  canceledAt: null,
   createdAt: "2026-01-01T00:00:00Z",
   updatedAt: "2026-01-02T00:00:00Z",
   description: null,
@@ -293,11 +341,17 @@ test("worker manifest preserves databases, sync schedules, and shared pacing", (
           "Health",
           "Owner",
           "Initiative Link",
-          "Updated",
+          "Project Count",
         ],
       },
     ]
   )
+
+  const initiativeProperties =
+    worker.manifest.databases.find((database) => database.key === "initiatives")
+      ?.config.schema.properties ?? {}
+  assert.equal("Priority" in initiativeProperties, false)
+  assert.equal("Canceled" in initiativeProperties, false)
 
   type SyncManifestConfig = {
     databaseKey: string
@@ -422,6 +476,70 @@ test("content, person, cycle, and date helpers preserve useful values", () => {
   )
 })
 
+test("page content keeps Unicode update excerpts bounded without splitting characters", () => {
+  const rocket = "🚀"
+  const content = resourcePageContent({
+    overview: "",
+    overviewHeading: "Project overview",
+    resourceUrl: "https://linear.app/acme/project/unicode",
+    latestUpdate: {
+      body: rocket.repeat(MAX_PAGE_SECTION_CHARACTERS + 1),
+    },
+  })
+  const [heading, notice, excerpt] = content.split("\n\n")
+
+  assert.equal(heading, "## Latest update")
+  assert.equal(Array.from(excerpt ?? "").length, MAX_PAGE_SECTION_CHARACTERS)
+  assert.ok(
+    Array.from(excerpt ?? "").every((character) => character === rocket)
+  )
+  assert.match(notice ?? "", /shortened in Notion/)
+})
+
+test("truncated Markdown cannot swallow later page-content sections", () => {
+  const content = resourcePageContent({
+    overview: "The overview remains visible.",
+    overviewHeading: "Initiative overview",
+    resourceUrl: "https://linear.app/acme/initiative/safe-markdown",
+    latestUpdate: {
+      body: `\`\`\`ts\n${"const value = 1\n".repeat(MAX_PAGE_SECTION_CHARACTERS)}`,
+      url: "https://linear.app/acme/update/safe-markdown",
+    },
+    contributingProjects: [],
+  })
+
+  assert.match(content, /This latest update was shortened in Notion/)
+  assert.doesNotMatch(content, /```/)
+  assert.match(content, /## Contributing projects \(0\)/)
+  assert.match(content, /## Initiative overview/)
+  assert.match(content, /The overview remains visible\./)
+})
+
+test("page content bounds long contributing-project lists with an explicit link", () => {
+  const projects = Array.from(
+    { length: MAX_RENDERED_CONTRIBUTING_PROJECTS + 2 },
+    (_, index) => ({
+      id: `project-${index}`,
+      name: `Project ${String(index).padStart(3, "0")}`,
+      url: `https://linear.app/acme/project/${index}`,
+    })
+  )
+  const content = resourcePageContent({
+    overview: "",
+    overviewHeading: "Initiative overview",
+    resourceUrl: "https://linear.app/acme/initiative/roadmap",
+    contributingProjects: projects,
+  })
+
+  assert.match(content, /## Contributing projects \(102\)/)
+  assert.equal(
+    content.match(/^- \[Project /gm)?.length,
+    MAX_RENDERED_CONTRIBUTING_PROJECTS
+  )
+  assert.match(content, /…and 2 more/)
+  assert.match(content, /View all projects in Linear/)
+})
+
 test("retry helpers handle delta seconds, dates, and exhausted Linear budgets", () => {
   const now = Date.parse("2026-06-30T12:00:00Z")
   assert.equal(parseRetryAfterSeconds("3.2", now), 4)
@@ -440,7 +558,7 @@ test("retry helpers handle delta seconds, dates, and exhausted Linear budgets", 
   assert.equal(rateLimitRetryAfterSeconds(new Headers(), now), undefined)
 })
 
-test("project transform emits a complete strategic record", () => {
+test("project transform leads with its latest update and retains the overview", () => {
   const change = projectToChange(fullProject)
 
   assert.equal(change.type, "upsert")
@@ -450,7 +568,19 @@ test("project transform emits a complete strategic record", () => {
     "the immutable Linear UUID is the key"
   )
   assert.equal(change.upstreamUpdatedAt, fullProject.lastUpdate?.updatedAt)
-  assert.equal(change.pageContentMarkdown, fullProject.content)
+  assert.match(change.pageContentMarkdown, /^## Latest update/)
+  assert.match(change.pageContentMarkdown, /Updated by Ada · 2026-07-01/)
+  assert.match(
+    change.pageContentMarkdown,
+    /Enterprise launch remains on track after the security review\./
+  )
+  assert.match(change.pageContentMarkdown, /Open update in Linear/)
+  assert.match(change.pageContentMarkdown, /## Project overview/)
+  assert.match(change.pageContentMarkdown, /Full project brief\./)
+  assert.ok(
+    change.pageContentMarkdown.indexOf("## Latest update") <
+      change.pageContentMarkdown.indexOf("## Project overview")
+  )
   assertPropertyContains(change.properties.Name, fullProject.name)
   assertPropertyContains(change.properties.Status, "Custom delivery name")
   assertPropertyContains(change.properties["Status Category"], "Started")
@@ -638,7 +768,7 @@ test("cursor state rejects missing, immediate, and longer repeated cursors", () 
   )
 })
 
-test("initiative transform emits status, health, slug, content, and timestamps", () => {
+test("initiative transform surfaces its update and contributing projects", () => {
   const change = initiativeToChange(fullInitiative)
 
   assert.equal(change.type, "upsert")
@@ -647,8 +777,29 @@ test("initiative transform emits status, health, slug, content, and timestamps",
     fullInitiative.id,
     "the immutable Linear UUID is the key"
   )
-  assert.equal(change.upstreamUpdatedAt, fullInitiative.lastUpdate?.updatedAt)
-  assert.equal(change.pageContentMarkdown, fullInitiative.content)
+  assert.equal(
+    "upstreamUpdatedAt" in change,
+    false,
+    "derived project membership is always refreshed by the hourly replacement"
+  )
+  assert.match(change.pageContentMarkdown, /^## Latest update/)
+  assert.match(change.pageContentMarkdown, /Updated by Nan · 2026-07-02/)
+  assert.match(
+    change.pageContentMarkdown,
+    /The remaining enterprise blockers now have committed owners\./
+  )
+  assert.match(change.pageContentMarkdown, /## Contributing projects \(2\)/)
+  assert.match(change.pageContentMarkdown, /API Foundations.*\(archived\)/)
+  assert.match(change.pageContentMarkdown, /Mobile Reliability/)
+  assert.doesNotMatch(change.pageContentMarkdown, /Duplicate API Foundations/)
+  assert.doesNotMatch(change.pageContentMarkdown, /Discarded experiment/)
+  assert.match(change.pageContentMarkdown, /## Initiative overview/)
+  assert.ok(
+    change.pageContentMarkdown.indexOf("## Latest update") <
+      change.pageContentMarkdown.indexOf("## Contributing projects") &&
+      change.pageContentMarkdown.indexOf("## Contributing projects") <
+        change.pageContentMarkdown.indexOf("## Initiative overview")
+  )
   assertPropertyContains(change.properties.Name, fullInitiative.name)
   assertPropertyContains(change.properties.Status, "Active")
   assertPropertyContains(change.properties.Health, "Off Track")
@@ -664,10 +815,9 @@ test("initiative transform emits status, health, slug, content, and timestamps",
     change.properties["Last Update Link"],
     fullInitiative.lastUpdate?.url ?? ""
   )
-  assertPropertyContains(change.properties.Priority, "Medium")
+  assertPropertyContains(change.properties["Project Count"], "2")
   assertPropertyContains(change.properties.Started, "11:12")
   assertPropertyContains(change.properties.Completed, "14:15")
-  assertPropertyContains(change.properties.Canceled, "10:11")
   assertPropertyContains(change.properties["Target Date"], "2026-12-31")
   assertPropertyContains(change.properties["Slug ID"], fullInitiative.slugId)
   assertPropertyContains(
@@ -681,18 +831,21 @@ test("initiative transform omits absent optional values", () => {
   const change = initiativeToChange(minimalInitiative)
 
   assert.equal(change.key, minimalInitiative.id)
-  assert.equal(change.upstreamUpdatedAt, minimalInitiative.updatedAt)
-  assert.equal(change.pageContentMarkdown, "")
+  assert.equal("upstreamUpdatedAt" in change, false)
+  assert.match(change.pageContentMarkdown, /^## Contributing projects \(0\)/)
+  assert.match(
+    change.pageContentMarkdown,
+    /No contributing projects visible to this Linear API key\./
+  )
   assert.equal(change.properties.Status, undefined)
   assert.equal(change.properties.Health, undefined)
   assert.equal(change.properties.Owner, undefined)
-  assert.equal(change.properties.Priority, undefined)
+  assertPropertyContains(change.properties["Project Count"], "0")
   assert.equal(change.properties["Last Update At"], undefined)
   assert.equal(change.properties["Last Update Link"], undefined)
   assert.equal(change.properties["Target Date"], undefined)
   assert.equal(change.properties.Started, undefined)
   assert.equal(change.properties.Completed, undefined)
-  assert.equal(change.properties.Canceled, undefined)
   assert.equal(change.properties["Slug ID"], undefined)
   assertPropertyContains(change.properties.Archived, "No")
 })
@@ -757,6 +910,36 @@ function initiativeConnection(
   })
 }
 
+function initiativeProjectsConnection(
+  nodes: LinearInitiativeProject[],
+  hasNextPage: boolean,
+  endCursor: string | null
+): Response {
+  return Response.json({
+    data: {
+      initiative: {
+        projects: { nodes, pageInfo: { hasNextPage, endCursor } },
+      },
+    },
+  })
+}
+
+function initiativeProject(
+  id: string,
+  name: string,
+  overrides: Partial<LinearInitiativeProject> = {}
+): LinearInitiativeProject {
+  return {
+    id,
+    name,
+    url: `https://linear.app/acme/project/${id}`,
+    updatedAt: "2026-06-30T00:00:00Z",
+    archivedAt: null,
+    trashed: false,
+    ...overrides,
+  }
+}
+
 function issueConnection(
   nodes: LinearIssue[],
   hasNextPage: boolean,
@@ -786,8 +969,13 @@ test("GraphQL client uses the endpoint, POST body, and direct API-key authorizat
   assert.equal(calls[0]?.accept, "application/json")
   assert.equal(calls[0]?.contentType, "application/json")
   assert.equal(calls[0]?.redirect, "error")
-  assert.match(calls[0]?.request.query ?? "", /query Projects/)
-  assert.match(calls[0]?.request.query ?? "", /orderBy: createdAt/)
+  const projectQuery = calls[0]?.request.query ?? ""
+  assert.match(projectQuery, /query Projects/)
+  assert.match(projectQuery, /orderBy: createdAt/)
+  assert.match(
+    projectQuery,
+    /lastUpdate\s*{[\s\S]*?body[\s\S]*?createdAt[\s\S]*?updatedAt[\s\S]*?url[\s\S]*?user\s*{[\s\S]*?name[\s\S]*?displayName/
+  )
   assert.deepEqual(calls[0]?.request.variables, {})
 })
 
@@ -825,11 +1013,13 @@ test("project and initiative connections expose durable cursor pages", async () 
     hasMore: false,
     nextCursor: undefined,
   })
-  assert.deepEqual(firstInitiatives, {
-    resources: [fullInitiative],
-    hasMore: true,
-    nextCursor: "initiative-page-2",
-  })
+  assert.equal(firstInitiatives.resources[0]?.id, fullInitiative.id)
+  assert.deepEqual(
+    firstInitiatives.resources[0]?.projects.nodes.map((project) => project.id),
+    ["project-mobile", "project-api", "project-trashed"]
+  )
+  assert.equal(firstInitiatives.hasMore, true)
+  assert.equal(firstInitiatives.nextCursor, "initiative-page-2")
   assert.deepEqual(finalInitiatives, {
     resources: [minimalInitiative],
     hasMore: false,
@@ -840,7 +1030,160 @@ test("project and initiative connections expose durable cursor pages", async () 
     [{}, { after: "project-page-2" }, {}, { after: "initiative-page-2" }]
   )
   assert.match(calls[0]?.request.query ?? "", /orderBy: createdAt/)
-  assert.match(calls[2]?.request.query ?? "", /orderBy: createdAt/)
+  const initiativeQuery = calls[2]?.request.query ?? ""
+  assert.match(initiativeQuery, /orderBy: createdAt/)
+  assert.match(initiativeQuery, /initiatives\([\s\S]*?first: 20/)
+  assert.match(
+    initiativeQuery,
+    /lastUpdate\s*{[\s\S]*?body[\s\S]*?user\s*{[\s\S]*?name[\s\S]*?displayName/
+  )
+  assert.match(
+    initiativeQuery,
+    /projects\([\s\S]*?first: 50[\s\S]*?includeArchived: true[\s\S]*?includeSubInitiatives: true/
+  )
+  assert.doesNotMatch(initiativeQuery, /\bpriority\b/)
+  assert.doesNotMatch(initiativeQuery, /\bcanceledAt\b/)
+})
+
+test("initiative projects paginate completely, dedupe by ID, and pace every request", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  const calls: FetchCall[] = []
+  let pacingCount = 0
+  const alpha = initiativeProject("alpha", "Alpha")
+  const beta = initiativeProject("beta", "Beta")
+  const gamma = initiativeProject("gamma", "Gamma")
+  const initiative: LinearInitiative = {
+    ...minimalInitiative,
+    projects: {
+      nodes: [alpha],
+      pageInfo: { hasNextPage: true, endCursor: "project-page-2" },
+    },
+  }
+
+  installQueuedGraphQLFetch(
+    [
+      initiativeConnection([initiative], false, null),
+      initiativeProjectsConnection(
+        [beta, { ...alpha, name: "Duplicate Alpha" }],
+        true,
+        "project-page-3"
+      ),
+      initiativeProjectsConnection([gamma], false, null),
+    ],
+    calls
+  )
+
+  const page = await fetchInitiativesPage(async () => {
+    pacingCount++
+  })
+
+  assert.equal(pacingCount, 3)
+  assert.deepEqual(
+    page.resources[0]?.projects.nodes.map((project) => project.id),
+    ["alpha", "beta", "gamma"]
+  )
+  assert.deepEqual(
+    calls.map((call) => call.request.variables),
+    [
+      {},
+      { initiativeId: initiative.id, after: "project-page-2" },
+      { initiativeId: initiative.id, after: "project-page-3" },
+    ]
+  )
+  assert.match(calls[1]?.request.query ?? "", /query InitiativeProjects/)
+  assert.match(
+    calls[1]?.request.query ?? "",
+    /includeArchived: true[\s\S]*includeSubInitiatives: true/
+  )
+})
+
+test("initiative project pagination rejects missing and repeated cursors", async (t) => {
+  process.env.LINEAR_API_KEY = "test-key"
+  const project = initiativeProject("alpha", "Alpha")
+
+  await t.test("missing cursor", async () => {
+    process.env.LINEAR_API_KEY = "test-key"
+    const initiative: LinearInitiative = {
+      ...minimalInitiative,
+      projects: {
+        nodes: [project],
+        pageInfo: { hasNextPage: true, endCursor: null },
+      },
+    }
+    installQueuedGraphQLFetch(
+      [initiativeConnection([initiative], false, null)],
+      []
+    )
+
+    await assert.rejects(
+      () => fetchInitiativesPage(noPacing),
+      /projects pagination is missing endCursor/
+    )
+  })
+
+  await t.test("repeated cursor", async () => {
+    process.env.LINEAR_API_KEY = "test-key"
+    let pacingCount = 0
+    const initiative: LinearInitiative = {
+      ...minimalInitiative,
+      projects: {
+        nodes: [project],
+        pageInfo: { hasNextPage: true, endCursor: "project-page-2" },
+      },
+    }
+    installQueuedGraphQLFetch(
+      [
+        initiativeConnection([initiative], false, null),
+        initiativeProjectsConnection([], true, "project-page-2"),
+      ],
+      []
+    )
+
+    await assert.rejects(
+      () =>
+        fetchInitiativesPage(async () => {
+          pacingCount++
+        }),
+      /projects pagination repeated cursor/
+    )
+    assert.equal(pacingCount, 2)
+  })
+})
+
+test("nested initiative project safety bound rejects incomplete snapshots", async () => {
+  process.env.LINEAR_API_KEY = "test-key"
+  let pacingCount = 0
+  const initiative: LinearInitiative = {
+    ...minimalInitiative,
+    projects: {
+      nodes: [],
+      pageInfo: { hasNextPage: true, endCursor: "project-page-1" },
+    },
+  }
+  const followUpPages = Array.from(
+    { length: MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE },
+    (_, index) =>
+      initiativeProjectsConnection(
+        [initiativeProject(`project-${index + 1}`, `Project ${index + 1}`)],
+        true,
+        `project-page-${index + 2}`
+      )
+  )
+  installQueuedGraphQLFetch(
+    [initiativeConnection([initiative], false, null), ...followUpPages],
+    []
+  )
+
+  await assert.rejects(
+    () =>
+      fetchInitiativesPage(async () => {
+        pacingCount++
+      }),
+    new RegExp(
+      `exceeded ${MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE} follow-up requests`
+    )
+  )
+  assert.equal(pacingCount, 1 + MAX_NESTED_INITIATIVE_PROJECT_REQUESTS_PER_PAGE)
 })
 
 test("issue requests pin the incremental updatedAt window in GraphQL variables", async () => {

--- a/examples/workers/syncs/linear/tsconfig.json
+++ b/examples/workers/syncs/linear/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/workers/syncs/linear/tsconfig.test.json
+++ b/examples/workers/syncs/linear/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Add managed-database sync examples for Linear projects, issues, and initiatives.
- Keep issues fresh with 5-minute incremental syncs plus daily reconciliation; refresh projects every 15 minutes and initiatives hourly.
- Add useful planning context, including latest project and initiative updates and contributing projects for initiatives.
- Handle cursor pagination, shared rate limiting, Retry-After responses, bounded nested pagination, immutable IDs, and safe content truncation.
- Avoid alpha Initiative.priority and canceledAt fields until the API is ready.

## Validation

- TypeScript checks
- Worker build
- Prettier
- Markdown lint
- 34 tests
- git diff --check

A live API preview was not run because LINEAR_API_KEY is not available in this environment.