### PR TITLE
feat(workers): add Salesforce sync example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ The [javascript](javascript/) directory includes examples built with Notion's of
 The [workers](workers/) directory includes examples built with the [Notion Workers](https://developers.notion.com/docs/workers) platform:
 
 - **[webhooks/zendesk](workers/webhooks/zendesk/)**: Verify Zendesk ticket webhooks and upsert them into a Notion database
-- **[syncs/salesforce](workers/syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
+- **[syncs/salesforce](workers/syncs/salesforce/)**: Sync Salesforce Accounts and Opportunities into related managed Notion databases
 - **[syncs/linear](workers/syncs/linear/)**: Sync Linear projects, issues, and initiatives into managed Notion databases
 - **[tools/snowflake-query](workers/tools/snowflake-query/)**: Query Snowflake from a Notion agent and return results _(coming soon)_
 - **[tools/spotify-control](workers/tools/spotify-control/)**: Start and control Spotify playback from a Notion agent _(coming soon)_

--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -8,7 +8,7 @@ The [syncs](syncs/) directory includes one-way sync examples that bring data fro
 
 - **[duckdb-sync-demo](syncs/duckdb-sync-demo/)**: Sync a self-contained in-memory DuckDB into a managed Notion database — no setup required
 - **[snowflake-sync](syncs/snowflake-sync/)**: Sync rows from a Snowflake query into a managed Notion database
-- **[salesforce](syncs/salesforce/)**: One-way sync from Salesforce records into a Notion database _(coming soon)_
+- **[salesforce](syncs/salesforce/)**: Sync Salesforce Accounts and Opportunities into related managed Notion databases
 - **[linear](syncs/linear/)**: Sync Linear projects, issues, and initiatives into managed Notion databases
 
 ## Tools

--- a/examples/workers/syncs/salesforce/.env.example
+++ b/examples/workers/syncs/salesforce/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to `.env` for local testing. `.env` is gitignored.
+# For a deployed worker, use `ntn workers env set KEY=value` instead.
+
+# OAuth credentials from your Salesforce External Client App.
+SALESFORCE_CLIENT_ID=
+SALESFORCE_CLIENT_SECRET=
+
+# Your org's base URL, such as https://acme.my.salesforce.com.
+SALESFORCE_INSTANCE_URL=
+
+# OAuth host. Use https://test.salesforce.com for a sandbox, or your My Domain
+# login URL when your org requires it. Defaults to production when omitted.
+SALESFORCE_LOGIN_URL=https://login.salesforce.com

--- a/examples/workers/syncs/salesforce/.env.example
+++ b/examples/workers/syncs/salesforce/.env.example
@@ -1,13 +1,9 @@
 # Copy this file to `.env` for local testing. `.env` is gitignored.
 # For a deployed worker, use `ntn workers env set KEY=value` instead.
 
-# OAuth credentials from your Salesforce External Client App.
+# Client Credentials settings from your Salesforce External Client App.
 SALESFORCE_CLIENT_ID=
 SALESFORCE_CLIENT_SECRET=
 
-# Your org's base URL, such as https://acme.my.salesforce.com.
-SALESFORCE_INSTANCE_URL=
-
-# OAuth host. Use https://test.salesforce.com for a sandbox, or your My Domain
-# login URL when your org requires it. Defaults to production when omitted.
-SALESFORCE_LOGIN_URL=https://login.salesforce.com
+# Your production or sandbox org's My Domain URL.
+SALESFORCE_ORG_URL=https://acme.my.salesforce.com

--- a/examples/workers/syncs/salesforce/.gitignore
+++ b/examples/workers/syncs/salesforce/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/examples/workers/syncs/salesforce/README.md
+++ b/examples/workers/syncs/salesforce/README.md
@@ -1,18 +1,415 @@
-# Worker Sync: Salesforce
+# Worker sync: Salesforce
 
-> **Coming soon** — this example is in development. Check back for the full implementation.
+Syncs Salesforce Accounts and Opportunities into related Notion databases that
+stay up to date automatically. The worker performs fast incremental updates
+every 5 minutes and a complete daily reconciliation for each object.
 
-A Notion worker sync that pulls Salesforce records into a Notion database, keeping the database up to date as records are created and updated in Salesforce.
+You don't need to create the Notion databases yourself. The worker declares the
+schemas and Notion creates and manages each database for you (these are called
+"managed databases").
 
-## What this example will demonstrate
+## Supported configuration
 
-- One-way sync from Salesforce records into a Notion database
-- Webhook- or polling-driven updates from Salesforce into Notion
-- Mapping Salesforce standard and custom fields to Notion properties
-- Authenticating to Salesforce via OAuth from a Notion worker
+This example supports Salesforce production orgs and sandboxes with API access.
+It reads the standard **Account** and **Opportunity** objects and the standard
+fields listed below, using a Salesforce **External Client App** and OAuth. New
+deployments should not create a legacy Connected App.
+
+Custom objects, custom fields, Person Account-specific fields, and additional
+standard objects are not included by default. You can add them by extending the
+schemas, field lists, and sync registrations as described in
+[Adapting the sync](#adapting-the-sync).
+
+## What you get
+
+| Database                    | Salesforce object | Incremental updates | Full reconciliation |
+| --------------------------- | ----------------- | ------------------- | ------------------- |
+| **Salesforce Accounts**     | Account           | Every 5 min         | Daily               |
+| **Salesforce Opportunities** | Opportunity       | Every 5 min         | Daily               |
+
+### Salesforce Accounts
+
+| Notion property | Salesforce field     | Type        |
+| --------------- | -------------------- | ----------- |
+| Name            | `Name`               | title       |
+| Industry        | `Industry`           | select      |
+| Type            | `Type`               | select      |
+| Website         | `Website`            | url         |
+| Phone           | `Phone`              | phoneNumber |
+| Billing City    | `BillingCity`        | richText    |
+| Billing Country | `BillingCountry`     | richText    |
+| Annual Revenue  | `AnnualRevenue`      | number      |
+| Employees       | `NumberOfEmployees`  | number      |
+| Owner           | `Owner.Name`         | richText    |
+| Created         | `CreatedDate`        | date        |
+| Updated         | `LastModifiedDate`   | date        |
+| Account Link    | Salesforce record URL | url         |
+| Account ID      | `Id`                 | richText    |
+
+Each Account page body contains the Salesforce `Description` as markdown.
+`SystemModstamp` drives incremental sync checkpoints, while `Account ID` is the
+stable Notion sync key.
+
+### Salesforce Opportunities
+
+| Notion property  | Salesforce field       | Type     |
+| ---------------- | ---------------------- | -------- |
+| Name             | `Name`                 | title    |
+| Stage            | `StageName`            | select   |
+| Amount           | `Amount`               | number   |
+| Probability      | `Probability`          | number (percent) |
+| Close Date       | `CloseDate`            | date     |
+| Type             | `Type`                 | select   |
+| Lead Source      | `LeadSource`           | select   |
+| Forecast Category | `ForecastCategoryName` | select   |
+| Is Closed        | `IsClosed`             | checkbox |
+| Is Won           | `IsWon`                | checkbox |
+| Owner            | `Owner.Name`           | richText |
+| Account          | `AccountId`            | relation |
+| Created          | `CreatedDate`          | date     |
+| Updated          | `LastModifiedDate`     | date     |
+| Opportunity Link | Salesforce record URL  | url      |
+| Opportunity ID   | `Id`                   | richText |
+
+Each Opportunity page body contains the Salesforce `Description` as markdown.
+Salesforce percentages are converted to Notion's decimal percent format.
+`Amount` and `AnnualRevenue` are stored as plain numbers without a currency
+symbol. Multi-currency orgs can add `CurrencyIsoCode` by following
+[Adapting the sync](#adapting-the-sync).
+
+**Account** is a two-way relation to the Salesforce Accounts database. The
+relation uses `AccountId`, the same stable Salesforce ID used as the Account
+sync key. Notion adds the reciprocal **Opportunities** property to each related
+Account.
+
+## Project structure
+
+```text
+src/
+├── index.ts         — registers OAuth, databases, and all four syncs
+├── salesforce.ts    — REST client, authentication headers, and pagination
+├── sync.ts          — incremental and replacement sync lifecycle
+├── accounts.ts      — Account field list, schema, and transform
+└── opportunities.ts — Opportunity field list, schema, and transform
+```
+
+## How it works
+
+1. `accountsSync` and `opportunitiesSync` run every 5 minutes. Each one queries
+   Salesforce's `queryAll` REST resource for a fixed `SystemModstamp` window,
+   so current and soft-deleted records are returned together.
+2. A two-minute overlap between completed windows makes boundary retries safe.
+   Stable ordering, Salesforce query locators, and a batch-size hint of 2,000
+   let each window continue across as many pages as necessary.
+3. Live records become Notion `upsert` changes. Records marked `IsDeleted`
+   become explicit Notion `delete` changes.
+4. `accountsReconciliation` and `opportunitiesReconciliation` run daily in
+   `replace` mode. They sweep every currently visible record and remove Notion
+   pages that are absent after the complete sweep. This catches purged records,
+   permission changes, and changes missed while the worker was unavailable.
+5. All data requests use Salesforce REST API **v67.0**. OAuth access tokens are
+   stored and refreshed by the Notion Workers runtime. Because Salesforce can
+   omit `expires_in`, the OAuth capability supplies a one-hour fallback expiry.
+6. The four syncs share a conservative request pacer. Salesforce API limits
+   still depend on your org's edition and license count; limit responses are
+   passed to the Workers runtime for retry and backoff.
+
+### Freshness and deletion behavior
+
+The 5-minute schedule is the normal update target, not a hard delivery
+guarantee. API throttling, an unavailable worker, or a long initial backfill can
+increase latency.
+
+- A soft-deleted record still returned by `queryAll` is normally removed after
+  the next successful incremental run: about 5 minutes plus execution time.
+- A purged record, a record that becomes invisible to the integration user, or
+  a deletion missed during an outage is removed after the next successful daily
+  reconciliation: up to about 24 hours plus the time required to finish that
+  sweep.
+- Failed or rate-limited runs extend those windows until a run completes.
+
+## Prerequisites
+
+- Node >= 22 and npm >= 10.9.2
+- A Salesforce production org or sandbox with REST API access
+- Permission to create and manage a local External Client App
+- A dedicated Salesforce integration user that can authorize the app
+- The `ntn` CLI installed and authenticated (`ntn login`)
+
+### Configure least-privilege access
+
+Use one dedicated integration user for this worker instead of authorizing a
+human administrator's account. Where available, Salesforce recommends the
+Salesforce Integration user license with the **Minimum Access - API Only
+Integrations** profile.
+
+Grant that user only the access this read-only sync needs, preferably through a
+dedicated permission set:
+
+- **API Enabled** system permission
+- **Read** object permission on Account and Opportunity
+- Read field-level access to every field listed in the property maps, including
+  `Description`, `SystemModstamp`, `IsDeleted`, and the Owner name used by each
+  query
+- **View All Records** on Account and Opportunity if the Notion databases must
+  represent every record in the org
+- Access to the External Client App, if its policy requires admin
+  pre-authorization
+
+`View All Records` is object-specific and does not bypass field-level security.
+Grant it separately for both objects. Do not grant `Modify All Records`, `View
+All Data`, or write permissions to this read-only worker.
+
+You can omit `View All Records` when the sync is intentionally limited by the
+integration user's Salesforce sharing rules. In that configuration, the daily
+replacement sync treats records the user can no longer see as absent and
+removes them from Notion.
+
+## Environment variables
+
+| Variable                   | Required | Description |
+| -------------------------- | -------- | ----------- |
+| `SALESFORCE_CLIENT_ID`     | Yes      | External Client App consumer key (`client_id`) |
+| `SALESFORCE_CLIENT_SECRET` | Yes      | External Client App consumer secret |
+| `SALESFORCE_INSTANCE_URL`  | Yes      | Salesforce org origin, such as `https://acme.my.salesforce.com` |
+| `SALESFORCE_LOGIN_URL`     | No       | OAuth origin; defaults to `https://login.salesforce.com` |
+
+Use `https://test.salesforce.com` for `SALESFORCE_LOGIN_URL` when connecting to
+a sandbox. If your org requires a My Domain login, use that HTTPS origin
+instead. Both URL variables must be origins only: don't include credentials,
+paths, query strings, or fragments.
+
+No `NOTION_API_TOKEN` is needed. The platform handles Notion credentials
+automatically.
+
+## Setup and deploy
+
+The first deployment intentionally happens before Salesforce credentials are
+configured. It registers the worker and allocates the callback URL needed to
+create the External Client App. Sync execution still requires the environment
+variables and completed OAuth authorization.
+
+1. Install the Notion Workers CLI:
+
+   ```sh
+   curl -fsSL https://ntn.dev | bash
+   ```
+
+2. Clone and install:
+
+   ```sh
+   cd examples/workers/syncs/salesforce
+   npm install
+   ```
+
+3. Typecheck and test:
+
+   ```sh
+   npm run check
+   npm test
+   ```
+
+4. Log in to Notion:
+
+   ```sh
+   ntn login
+   ```
+
+5. Register the worker with a name, then print its OAuth callback URL:
+
+   ```sh
+   ntn workers deploy --name salesforce-sync
+   ntn workers oauth show-redirect-url
+   ```
+
+   Use `--name` only for the first deployment. Later deployments update the
+   registered worker and use `ntn workers deploy` without `--name`.
+
+### Create the Salesforce External Client App
+
+1. In Salesforce **Setup**, enter `External Client App` in Quick Find, open
+   **External Client App Manager**, and select **New External Client App**.
+2. Enter the basic app information. Select **Local** for the distribution state
+   because this app is used by one Salesforce org.
+3. Under **API (Enable OAuth Settings)**, enable OAuth.
+4. Paste the exact URL printed by
+   `ntn workers oauth show-redirect-url` into **Callback URL**.
+5. Under **Flow Enablement**, enable **Authorization Code and Credentials
+   Flow**. Do not enable Client Credentials Flow.
+6. Add only these OAuth scopes:
+   - **Manage user data via APIs** (`api`)
+   - **Perform requests at any time** (`refresh_token`, `offline_access`)
+7. Treat the worker as a confidential server-side client. Require the consumer
+   secret for the web server and refresh-token exchanges when those controls
+   are available in your org.
+8. Create the app. In its OAuth policies, select **Admin approved users are
+   pre-authorized**, then select a permission set assigned only to the dedicated
+   integration user.
+9. From the app's **Settings** tab, open **Consumer Key and Secret** and copy the
+   consumer key and consumer secret. Store both as secrets.
+
+This example uses an External Client App, Salesforce's current app framework.
+Do not enable client credentials flow and do not create a legacy Connected App
+for this authorization-code flow. A newly created app can take several minutes
+to become available.
+
+### Configure and authorize the worker
+
+1. Set the deployed worker's environment variables. For a production org:
+
+   ```sh
+   ntn workers env set SALESFORCE_CLIENT_ID=your-consumer-key
+   ntn workers env set SALESFORCE_CLIENT_SECRET=your-consumer-secret
+   ntn workers env set SALESFORCE_INSTANCE_URL=https://acme.my.salesforce.com
+   ntn workers env set SALESFORCE_LOGIN_URL=https://login.salesforce.com
+   ```
+
+   For a sandbox, use the sandbox My Domain for `SALESFORCE_INSTANCE_URL` and
+   `https://test.salesforce.com` for `SALESFORCE_LOGIN_URL`.
+
+2. Redeploy without `--name` so the OAuth capability receives the credentials:
+
+   ```sh
+   ntn workers deploy
+   ```
+
+3. Start OAuth and sign in as the dedicated integration user:
+
+   ```sh
+   ntn workers oauth start salesforceAuth
+   ```
+
+## Run the sync
+
+Preview the incremental syncs without writing to Notion:
+
+```sh
+ntn workers sync trigger accountsSync --preview
+ntn workers sync trigger opportunitiesSync --preview
+```
+
+Then start the real initial syncs:
+
+```sh
+ntn workers sync trigger accountsSync
+ntn workers sync trigger opportunitiesSync
+```
+
+The first incremental run starts at the Unix epoch and can take longer than a
+normal scheduled update. After it completes, both syncs run automatically every
+5 minutes.
+
+You can also preview or trigger the daily replacement reconciliations:
+
+```sh
+ntn workers sync trigger accountsReconciliation --preview
+ntn workers sync trigger opportunitiesReconciliation --preview
+ntn workers sync trigger accountsReconciliation
+ntn workers sync trigger opportunitiesReconciliation
+```
+
+## Adapting the sync
+
+Each resource owns its field list, TypeScript type, managed database schema, and
+transform:
+
+| Resource      | File                       |
+| ------------- | -------------------------- |
+| Accounts      | `src/accounts.ts`          |
+| Opportunities | `src/opportunities.ts`     |
+
+To add a field:
+
+1. Give the integration user read field-level access.
+2. Add its API name to `ACCOUNT_FIELDS` or `OPPORTUNITY_FIELDS`.
+3. Add the value to the corresponding Salesforce TypeScript type.
+4. Add a Notion property to the resource schema.
+5. Map the value in `accountToChange` or `opportunityToChange`.
+
+Salesforce returns only fields included in the SOQL `SELECT` list. Adding a
+type or Notion property without updating the field list does not fetch data.
+
+To add a custom object, create a resource module following the Account and
+Opportunity pattern, extend the `SalesforceResource` object-name type in
+`src/sync.ts`, then register both an incremental and daily reconciliation sync
+in `src/index.ts`. Keep the same stable Salesforce ID as the key for both syncs.
+
+The REST API version is pinned in `src/salesforce.ts`. Review Salesforce release
+notes and test production and sandbox orgs before changing `v67.0`.
+
+## Local testing
+
+Run offline tests without a Salesforce connection:
+
+```sh
+npm run check
+npm test
+```
+
+To execute against the authorized Salesforce org locally, first complete the
+deployed OAuth flow, pull the worker's environment, and run one sync:
+
+```sh
+ntn workers env pull
+ntn workers exec accountsSync --local
+ntn workers exec opportunitiesSync --local
+```
+
+Use a sandbox rather than production while testing schema or query changes.
+
+## Troubleshooting
+
+### OAuth callback mismatch
+
+Run `ntn workers oauth show-redirect-url` again and make sure the entire value
+exactly matches a callback URL on the External Client App. Confirm that
+`SALESFORCE_LOGIN_URL` points to the same production org, sandbox, or My Domain
+where the app was created.
+
+### `invalid_client_id` or OAuth authorization fails
+
+Confirm that the consumer key and secret came from **Consumer Key and Secret**
+for the External Client App, then run `ntn workers deploy` after setting them.
+New apps can take several minutes to propagate. Also verify that the dedicated
+user has been approved for the app's permission-set policy.
+
+### `INVALID_FIELD` or insufficient access
+
+Verify that every field in `ACCOUNT_FIELDS` and `OPPORTUNITY_FIELDS` exists in
+the org and is readable by the integration user. Confirm **API Enabled**, object
+**Read**, and the required field-level permissions. Customizations can make a
+field unavailable even when it is standard elsewhere.
+
+### Records are missing or disappear after reconciliation
+
+Salesforce REST queries use the authorizing user's permissions and sharing
+rules. Grant **View All Records** separately on Account and Opportunity when the
+sync must cover the whole org. A completed daily replace sweep removes records
+that are no longer visible to that user.
+
+### Opportunity Account relations are empty
+
+Confirm the Opportunity has an `AccountId`, that the integration user can read
+the related Account, and that the initial Account sync completed. The relation
+keys must match the Salesforce Account IDs synced into the Accounts database.
+
+### API limits delay a run
+
+Salesforce quotas vary by org. The client paces requests and reports limit
+responses to the Workers runtime, but a throttled run still completes later.
+Daily reconciliation removes absent pages only after every Salesforce page has
+been processed successfully.
 
 ## Learn more
 
-- [Notion Workers documentation](https://developers.notion.com/docs/workers)
-- [Notion API reference](https://developers.notion.com/reference)
-- [Contribute to this cookbook](../../../../CONTRIBUTING.md)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Notion Workers OAuth](https://developers.notion.com/workers/guides/oauth)
+- [Salesforce External Client Apps](https://help.salesforce.com/s/articleView?id=sf.external_client_apps.htm&language=en_US&type=5)
+- [Configure External Client App OAuth settings](https://help.salesforce.com/s/articleView?id=sf.configure_external_client_app_oauth_settings.htm&language=en_US&type=5)
+- [Salesforce OAuth scope values](https://developer.salesforce.com/docs/platform/mobile-sdk/guide/oauth-scope-parameter-values.html)
+- [Give integration users API-only access](https://help.salesforce.com/s/articleView?id=User-Permission-for-API-Integration-User&language=en_US&type=1)
+- [View All Records permission](https://help.salesforce.com/s/articleView?id=platform.users_profiles_view_all_mod_all.htm&language=en_US&type=5)
+- [Salesforce REST API Query](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm)
+- [Salesforce REST API QueryAll](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_queryall.htm)
+- [Salesforce REST API limits](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm)
+- [Contributing guide](../../../../CONTRIBUTING.md)

--- a/examples/workers/syncs/salesforce/README.md
+++ b/examples/workers/syncs/salesforce/README.md
@@ -16,6 +16,10 @@ fields listed below. Authentication uses the OAuth client-credentials flow from
 a Salesforce **External Client App**, with a dedicated integration user as its
 **Run As** user. New deployments should not create a legacy Connected App.
 
+The default mapping is intended for **single-currency orgs**. It stores
+`Amount` and `AnnualRevenue` as numbers without `CurrencyIsoCode`; multi-currency
+orgs should add that field before deploying so values remain distinguishable.
+
 Custom objects, custom fields, Person Account-specific fields, and additional
 standard objects are not included by default. You can add them by extending the
 schemas, field lists, and sync registrations as described in
@@ -74,9 +78,6 @@ stable Notion sync key.
 
 Each Opportunity page body contains the Salesforce `Description` as markdown.
 Salesforce percentages are converted to Notion's decimal percent format.
-`Amount` and `AnnualRevenue` are stored as plain numbers without a currency
-symbol. Multi-currency orgs can add `CurrencyIsoCode` by following
-[Adapting the sync](#adapting-the-sync).
 
 **Account** is a two-way relation to the Salesforce Accounts database. The
 relation uses `AccountId`, the same stable Salesforce ID used as the Account

--- a/examples/workers/syncs/salesforce/README.md
+++ b/examples/workers/syncs/salesforce/README.md
@@ -12,8 +12,9 @@ schemas and Notion creates and manages each database for you (these are called
 
 This example supports Salesforce production orgs and sandboxes with API access.
 It reads the standard **Account** and **Opportunity** objects and the standard
-fields listed below, using a Salesforce **External Client App** and OAuth. New
-deployments should not create a legacy Connected App.
+fields listed below. Authentication uses the OAuth client-credentials flow from
+a Salesforce **External Client App**, with a dedicated integration user as its
+**Run As** user. New deployments should not create a legacy Connected App.
 
 Custom objects, custom fields, Person Account-specific fields, and additional
 standard objects are not included by default. You can add them by extending the
@@ -22,29 +23,29 @@ schemas, field lists, and sync registrations as described in
 
 ## What you get
 
-| Database                    | Salesforce object | Incremental updates | Full reconciliation |
-| --------------------------- | ----------------- | ------------------- | ------------------- |
-| **Salesforce Accounts**     | Account           | Every 5 min         | Daily               |
+| Database                     | Salesforce object | Incremental updates | Full reconciliation |
+| ---------------------------- | ----------------- | ------------------- | ------------------- |
+| **Salesforce Accounts**      | Account           | Every 5 min         | Daily               |
 | **Salesforce Opportunities** | Opportunity       | Every 5 min         | Daily               |
 
 ### Salesforce Accounts
 
-| Notion property | Salesforce field     | Type        |
-| --------------- | -------------------- | ----------- |
-| Name            | `Name`               | title       |
-| Industry        | `Industry`           | select      |
-| Type            | `Type`               | select      |
-| Website         | `Website`            | url         |
-| Phone           | `Phone`              | phoneNumber |
-| Billing City    | `BillingCity`        | richText    |
-| Billing Country | `BillingCountry`     | richText    |
-| Annual Revenue  | `AnnualRevenue`      | number      |
-| Employees       | `NumberOfEmployees`  | number      |
-| Owner           | `Owner.Name`         | richText    |
-| Created         | `CreatedDate`        | date        |
-| Updated         | `LastModifiedDate`   | date        |
+| Notion property | Salesforce field      | Type        |
+| --------------- | --------------------- | ----------- |
+| Name            | `Name`                | title       |
+| Industry        | `Industry`            | select      |
+| Type            | `Type`                | select      |
+| Website         | `Website`             | url         |
+| Phone           | `Phone`               | phoneNumber |
+| Billing City    | `BillingCity`         | richText    |
+| Billing Country | `BillingCountry`      | richText    |
+| Annual Revenue  | `AnnualRevenue`       | number      |
+| Employees       | `NumberOfEmployees`   | number      |
+| Owner           | `Owner.Name`          | richText    |
+| Created         | `CreatedDate`         | date        |
+| Updated         | `LastModifiedDate`    | date        |
 | Account Link    | Salesforce record URL | url         |
-| Account ID      | `Id`                 | richText    |
+| Account ID      | `Id`                  | richText    |
 
 Each Account page body contains the Salesforce `Description` as markdown.
 `SystemModstamp` drives incremental sync checkpoints, while `Account ID` is the
@@ -52,24 +53,24 @@ stable Notion sync key.
 
 ### Salesforce Opportunities
 
-| Notion property  | Salesforce field       | Type     |
-| ---------------- | ---------------------- | -------- |
-| Name             | `Name`                 | title    |
-| Stage            | `StageName`            | select   |
-| Amount           | `Amount`               | number   |
-| Probability      | `Probability`          | number (percent) |
-| Close Date       | `CloseDate`            | date     |
-| Type             | `Type`                 | select   |
-| Lead Source      | `LeadSource`           | select   |
-| Forecast Category | `ForecastCategoryName` | select   |
-| Is Closed        | `IsClosed`             | checkbox |
-| Is Won           | `IsWon`                | checkbox |
-| Owner            | `Owner.Name`           | richText |
-| Account          | `AccountId`            | relation |
-| Created          | `CreatedDate`          | date     |
-| Updated          | `LastModifiedDate`     | date     |
-| Opportunity Link | Salesforce record URL  | url      |
-| Opportunity ID   | `Id`                   | richText |
+| Notion property   | Salesforce field       | Type             |
+| ----------------- | ---------------------- | ---------------- |
+| Name              | `Name`                 | title            |
+| Stage             | `StageName`            | select           |
+| Amount            | `Amount`               | number           |
+| Probability       | `Probability`          | number (percent) |
+| Close Date        | `CloseDate`            | date             |
+| Type              | `Type`                 | select           |
+| Lead Source       | `LeadSource`           | select           |
+| Forecast Category | `ForecastCategoryName` | select           |
+| Is Closed         | `IsClosed`             | checkbox         |
+| Is Won            | `IsWon`                | checkbox         |
+| Owner             | `Owner.Name`           | richText         |
+| Account           | `AccountId`            | relation         |
+| Created           | `CreatedDate`          | date             |
+| Updated           | `LastModifiedDate`     | date             |
+| Opportunity Link  | Salesforce record URL  | url              |
+| Opportunity ID    | `Id`                   | richText         |
 
 Each Opportunity page body contains the Salesforce `Description` as markdown.
 Salesforce percentages are converted to Notion's decimal percent format.
@@ -86,8 +87,8 @@ Account.
 
 ```text
 src/
-├── index.ts         — registers OAuth, databases, and all four syncs
-├── salesforce.ts    — REST client, authentication headers, and pagination
+├── index.ts         — registers the databases and all four syncs
+├── salesforce.ts    — client credentials, REST requests, and pagination
 ├── sync.ts          — incremental and replacement sync lifecycle
 ├── accounts.ts      — Account field list, schema, and transform
 └── opportunities.ts — Opportunity field list, schema, and transform
@@ -107,9 +108,10 @@ src/
    `replace` mode. They sweep every currently visible record and remove Notion
    pages that are absent after the complete sweep. This catches purged records,
    permission changes, and changes missed while the worker was unavailable.
-5. All data requests use Salesforce REST API **v67.0**. OAuth access tokens are
-   stored and refreshed by the Notion Workers runtime. Because Salesforce can
-   omit `expires_in`, the OAuth capability supplies a one-hour fallback expiry.
+5. All data requests use Salesforce REST API **v67.0**. The client exchanges
+   the External Client App credentials for one cached access token. If
+   Salesforce returns HTTP 401, it obtains a new token and retries once; the
+   client-credentials flow does not use a refresh token.
 6. The four syncs share a conservative request pacer. Salesforce API limits
    still depend on your org's edition and license count; limit responses are
    passed to the Workers runtime for retry and backoff.
@@ -133,13 +135,14 @@ increase latency.
 - Node >= 22 and npm >= 10.9.2
 - A Salesforce production org or sandbox with REST API access
 - Permission to create and manage a local External Client App
-- A dedicated Salesforce integration user that can authorize the app
+- A dedicated Salesforce integration user configured as the app's **Run As**
+  user
 - The `ntn` CLI installed and authenticated (`ntn login`)
 
 ### Configure least-privilege access
 
-Use one dedicated integration user for this worker instead of authorizing a
-human administrator's account. Where available, Salesforce recommends the
+Use one dedicated integration user for this worker instead of running the sync
+as a human administrator. Where available, Salesforce recommends the
 Salesforce Integration user license with the **Minimum Access - API Only
 Integrations** profile.
 
@@ -167,27 +170,24 @@ removes them from Notion.
 
 ## Environment variables
 
-| Variable                   | Required | Description |
-| -------------------------- | -------- | ----------- |
-| `SALESFORCE_CLIENT_ID`     | Yes      | External Client App consumer key (`client_id`) |
-| `SALESFORCE_CLIENT_SECRET` | Yes      | External Client App consumer secret |
-| `SALESFORCE_INSTANCE_URL`  | Yes      | Salesforce org origin, such as `https://acme.my.salesforce.com` |
-| `SALESFORCE_LOGIN_URL`     | No       | OAuth origin; defaults to `https://login.salesforce.com` |
+| Variable                   | Required | Description                                                                      |
+| -------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `SALESFORCE_CLIENT_ID`     | Yes      | External Client App consumer key (`client_id`)                                   |
+| `SALESFORCE_CLIENT_SECRET` | Yes      | External Client App consumer secret                                              |
+| `SALESFORCE_ORG_URL`       | Yes      | Production or sandbox My Domain origin, such as `https://acme.my.salesforce.com` |
 
-Use `https://test.salesforce.com` for `SALESFORCE_LOGIN_URL` when connecting to
-a sandbox. If your org requires a My Domain login, use that HTTPS origin
-instead. Both URL variables must be origins only: don't include credentials,
-paths, query strings, or fragments.
+Use the specific org's My Domain URL, including for sandboxes—not the generic
+`login.salesforce.com` or `test.salesforce.com` host. The value must be an HTTPS
+origin without credentials, paths, query strings, or fragments.
 
 No `NOTION_API_TOKEN` is needed. The platform handles Notion credentials
 automatically.
 
 ## Setup and deploy
 
-The first deployment intentionally happens before Salesforce credentials are
-configured. It registers the worker and allocates the callback URL needed to
-create the External Client App. Sync execution still requires the environment
-variables and completed OAuth authorization.
+This server-to-server flow has no callback URL or interactive sign-in. The
+External Client App runs every request as the dedicated integration user chosen
+in its policy.
 
 1. Install the Notion Workers CLI:
 
@@ -209,22 +209,6 @@ variables and completed OAuth authorization.
    npm test
    ```
 
-4. Log in to Notion:
-
-   ```sh
-   ntn login
-   ```
-
-5. Register the worker with a name, then print its OAuth callback URL:
-
-   ```sh
-   ntn workers deploy --name salesforce-sync
-   ntn workers oauth show-redirect-url
-   ```
-
-   Use `--name` only for the first deployment. Later deployments update the
-   registered worker and use `ntn workers deploy` without `--name`.
-
 ### Create the Salesforce External Client App
 
 1. In Salesforce **Setup**, enter `External Client App` in Quick Find, open
@@ -232,52 +216,52 @@ variables and completed OAuth authorization.
 2. Enter the basic app information. Select **Local** for the distribution state
    because this app is used by one Salesforce org.
 3. Under **API (Enable OAuth Settings)**, enable OAuth.
-4. Paste the exact URL printed by
-   `ntn workers oauth show-redirect-url` into **Callback URL**.
-5. Under **Flow Enablement**, enable **Authorization Code and Credentials
-   Flow**. Do not enable Client Credentials Flow.
-6. Add only these OAuth scopes:
-   - **Manage user data via APIs** (`api`)
-   - **Perform requests at any time** (`refresh_token`, `offline_access`)
-7. Treat the worker as a confidential server-side client. Require the consumer
-   secret for the web server and refresh-token exchanges when those controls
-   are available in your org.
-8. Create the app. In its OAuth policies, select **Admin approved users are
-   pre-authorized**, then select a permission set assigned only to the dedicated
-   integration user.
+4. Enter `https://login.salesforce.com/services/oauth2/success` as the
+   **Callback URL**. Salesforce requires a value when OAuth is enabled, but the
+   client-credentials flow never redirects to or calls this URL.
+5. Under **Flow Enablement**, enable **Client Credentials Flow**. Leave
+   **Authorization Code and Credentials Flow** disabled for this example.
+6. Add only **Manage user data via APIs** (`api`) as an OAuth scope. Do not add
+   `refresh_token` or `offline_access`; client credentials obtains a new access
+   token instead of a refresh token.
+7. Create the app. In its policies, configure **Client Credentials** and select
+   the dedicated integration user as **Run As**.
+8. Set **Permitted Users** to **Admin approved users are pre-authorized** and
+   associate the dedicated permission set assigned to the integration user.
 9. From the app's **Settings** tab, open **Consumer Key and Secret** and copy the
-   consumer key and consumer secret. Store both as secrets.
+   consumer key and consumer secret.
 
-This example uses an External Client App, Salesforce's current app framework.
-Do not enable client credentials flow and do not create a legacy Connected App
-for this authorization-code flow. A newly created app can take several minutes
-to become available.
+This uses Salesforce's current External Client App framework, not a legacy
+Connected App. A newly created app can take several minutes to become
+available.
 
-### Configure and authorize the worker
+### Deploy and configure the worker
 
-1. Set the deployed worker's environment variables. For a production org:
+1. Log in to Notion:
+
+   ```sh
+   ntn login
+   ```
+
+2. Deploy the worker:
+
+   ```sh
+   ntn workers deploy --name salesforce-sync
+   ```
+
+   Use `--name` only when creating the worker. Later deployments update it with
+   `ntn workers deploy`.
+
+3. Store the External Client App credentials and your production or sandbox My
+   Domain URL on the deployed worker:
 
    ```sh
    ntn workers env set SALESFORCE_CLIENT_ID=your-consumer-key
    ntn workers env set SALESFORCE_CLIENT_SECRET=your-consumer-secret
-   ntn workers env set SALESFORCE_INSTANCE_URL=https://acme.my.salesforce.com
-   ntn workers env set SALESFORCE_LOGIN_URL=https://login.salesforce.com
+   ntn workers env set SALESFORCE_ORG_URL=https://acme.my.salesforce.com
    ```
 
-   For a sandbox, use the sandbox My Domain for `SALESFORCE_INSTANCE_URL` and
-   `https://test.salesforce.com` for `SALESFORCE_LOGIN_URL`.
-
-2. Redeploy without `--name` so the OAuth capability receives the credentials:
-
-   ```sh
-   ntn workers deploy
-   ```
-
-3. Start OAuth and sign in as the dedicated integration user:
-
-   ```sh
-   ntn workers oauth start salesforceAuth
-   ```
+   For a sandbox, use that sandbox's My Domain URL.
 
 ## Run the sync
 
@@ -313,10 +297,10 @@ ntn workers sync trigger opportunitiesReconciliation
 Each resource owns its field list, TypeScript type, managed database schema, and
 transform:
 
-| Resource      | File                       |
-| ------------- | -------------------------- |
-| Accounts      | `src/accounts.ts`          |
-| Opportunities | `src/opportunities.ts`     |
+| Resource      | File                   |
+| ------------- | ---------------------- |
+| Accounts      | `src/accounts.ts`      |
+| Opportunities | `src/opportunities.ts` |
 
 To add a field:
 
@@ -328,6 +312,9 @@ To add a field:
 
 Salesforce returns only fields included in the SOQL `SELECT` list. Adding a
 type or Notion property without updating the field list does not fetch data.
+Every upsert includes every declared Notion property. Map nullable Salesforce
+values to an empty property value (`[]`) so clearing a field upstream also
+clears its previous value in Notion.
 
 To add a custom object, create a resource module following the Account and
 Opportunity pattern, extend the `SalesforceResource` object-name type in
@@ -346,8 +333,8 @@ npm run check
 npm test
 ```
 
-To execute against the authorized Salesforce org locally, first complete the
-deployed OAuth flow, pull the worker's environment, and run one sync:
+To execute against the configured Salesforce org locally, pull the worker's
+environment and run one sync:
 
 ```sh
 ntn workers env pull
@@ -359,19 +346,18 @@ Use a sandbox rather than production while testing schema or query changes.
 
 ## Troubleshooting
 
-### OAuth callback mismatch
-
-Run `ntn workers oauth show-redirect-url` again and make sure the entire value
-exactly matches a callback URL on the External Client App. Confirm that
-`SALESFORCE_LOGIN_URL` points to the same production org, sandbox, or My Domain
-where the app was created.
-
-### `invalid_client_id` or OAuth authorization fails
+### `invalid_client`, `invalid_client_id`, or authentication fails
 
 Confirm that the consumer key and secret came from **Consumer Key and Secret**
-for the External Client App, then run `ntn workers deploy` after setting them.
-New apps can take several minutes to propagate. Also verify that the dedicated
-user has been approved for the app's permission-set policy.
+for the External Client App. Verify that **Client Credentials Flow** is enabled,
+the dedicated integration user is selected as **Run As**, and
+`SALESFORCE_ORG_URL` is that org's exact My Domain origin. New apps can take
+several minutes to propagate.
+
+The client caches the access token because Salesforce does not issue a refresh
+token for this flow. An HTTP 401 clears the cached token and retries once. If
+authentication still fails, verify that the Run As user remains active and has
+access to the app's permission set.
 
 ### `INVALID_FIELD` or insufficient access
 
@@ -382,10 +368,10 @@ field unavailable even when it is standard elsewhere.
 
 ### Records are missing or disappear after reconciliation
 
-Salesforce REST queries use the authorizing user's permissions and sharing
-rules. Grant **View All Records** separately on Account and Opportunity when the
-sync must cover the whole org. A completed daily replace sweep removes records
-that are no longer visible to that user.
+Salesforce REST queries use the **Run As** integration user's permissions and
+sharing rules. Grant **View All Records** separately on Account and Opportunity
+when the sync must cover the whole org. A completed daily replace sweep removes
+records that are no longer visible to that user.
 
 ### Opportunity Account relations are empty
 
@@ -403,9 +389,11 @@ been processed successfully.
 ## Learn more
 
 - [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
-- [Notion Workers OAuth](https://developers.notion.com/workers/guides/oauth)
+- [Notion Workers secrets](https://developers.notion.com/workers/guides/secrets)
 - [Salesforce External Client Apps](https://help.salesforce.com/s/articleView?id=sf.external_client_apps.htm&language=en_US&type=5)
 - [Configure External Client App OAuth settings](https://help.salesforce.com/s/articleView?id=sf.configure_external_client_app_oauth_settings.htm&language=en_US&type=5)
+- [Salesforce OAuth client credentials flow](https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5)
+- [Salesforce Integration user and client credentials](https://developer.salesforce.com/blogs/2024/02/invoke-rest-apis-with-the-salesforce-integration-user-and-oauth-client-credentials)
 - [Salesforce OAuth scope values](https://developer.salesforce.com/docs/platform/mobile-sdk/guide/oauth-scope-parameter-values.html)
 - [Give integration users API-only access](https://help.salesforce.com/s/articleView?id=User-Permission-for-API-Integration-User&language=en_US&type=1)
 - [View All Records permission](https://help.salesforce.com/s/articleView?id=platform.users_profiles_view_all_mod_all.htm&language=en_US&type=5)

--- a/examples/workers/syncs/salesforce/package.json
+++ b/examples/workers/syncs/salesforce/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "salesforce-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --project tsconfig.test.json",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": "^0.4.0"
+  }
+}

--- a/examples/workers/syncs/salesforce/src/accounts.ts
+++ b/examples/workers/syncs/salesforce/src/accounts.ts
@@ -1,4 +1,4 @@
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import * as Builder from "@notionhq/workers/builder"
 import * as Schema from "@notionhq/workers/schema"
 
@@ -43,7 +43,7 @@ export type SalesforceAccount = {
   Description: string | null
 }
 
-export const accountSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const accountSchema = {
   databaseIcon: notionIcon("briefcase"),
   properties: {
     Name: Schema.title(),
@@ -74,12 +74,12 @@ export const accountSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Account ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 export function accountToChange(
   account: SalesforceAccount,
   instanceUrl: string
-) {
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof accountSchema.properties> {
   const website = normalizeWebsite(account.Website)
 
   return {
@@ -89,31 +89,30 @@ export function accountToChange(
     pageContentMarkdown: account.Description ?? "",
     properties: {
       Name: Builder.title(account.Name),
-      ...(account.Industry != null
-        ? { Industry: Builder.select(account.Industry) }
-        : {}),
-      ...(account.Type != null ? { Type: Builder.select(account.Type) } : {}),
-      ...(website ? { Website: Builder.url(website) } : {}),
-      ...(account.Phone != null
-        ? { Phone: Builder.phoneNumber(account.Phone) }
-        : {}),
-      ...(account.BillingCity != null
-        ? { "Billing City": Builder.richText(account.BillingCity) }
-        : {}),
-      ...(account.BillingCountry != null
-        ? { "Billing Country": Builder.richText(account.BillingCountry) }
-        : {}),
-      ...(account.AnnualRevenue != null &&
-      Number.isFinite(account.AnnualRevenue)
-        ? { "Annual Revenue": Builder.number(account.AnnualRevenue) }
-        : {}),
-      ...(account.NumberOfEmployees != null &&
-      Number.isFinite(account.NumberOfEmployees)
-        ? { Employees: Builder.number(account.NumberOfEmployees) }
-        : {}),
-      ...(account.Owner?.Name != null
-        ? { Owner: Builder.richText(account.Owner.Name) }
-        : {}),
+      Industry:
+        account.Industry != null ? Builder.select(account.Industry) : [],
+      Type: account.Type != null ? Builder.select(account.Type) : [],
+      Website: website ? Builder.url(website) : [],
+      Phone: account.Phone != null ? Builder.phoneNumber(account.Phone) : [],
+      "Billing City":
+        account.BillingCity != null
+          ? Builder.richText(account.BillingCity)
+          : [],
+      "Billing Country":
+        account.BillingCountry != null
+          ? Builder.richText(account.BillingCountry)
+          : [],
+      "Annual Revenue":
+        account.AnnualRevenue != null && Number.isFinite(account.AnnualRevenue)
+          ? Builder.number(account.AnnualRevenue)
+          : [],
+      Employees:
+        account.NumberOfEmployees != null &&
+        Number.isFinite(account.NumberOfEmployees)
+          ? Builder.number(account.NumberOfEmployees)
+          : [],
+      Owner:
+        account.Owner?.Name != null ? Builder.richText(account.Owner.Name) : [],
       Created: Builder.dateTime(account.CreatedDate),
       Updated: Builder.dateTime(account.LastModifiedDate),
       "Account Link": Builder.url(

--- a/examples/workers/syncs/salesforce/src/accounts.ts
+++ b/examples/workers/syncs/salesforce/src/accounts.ts
@@ -1,0 +1,151 @@
+import { notionIcon } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+export const INITIAL_TITLE = "Salesforce Accounts"
+export const PRIMARY_KEY = "Account ID"
+
+export const ACCOUNT_FIELDS = [
+  "Id",
+  "IsDeleted",
+  "Name",
+  "Industry",
+  "Type",
+  "Website",
+  "Phone",
+  "BillingCity",
+  "BillingCountry",
+  "AnnualRevenue",
+  "NumberOfEmployees",
+  "Owner.Name",
+  "CreatedDate",
+  "LastModifiedDate",
+  "SystemModstamp",
+  "Description",
+] as const
+
+export type SalesforceAccount = {
+  Id: string
+  IsDeleted: boolean
+  Name: string
+  Industry: string | null
+  Type: string | null
+  Website: string | null
+  Phone: string | null
+  BillingCity: string | null
+  BillingCountry: string | null
+  AnnualRevenue: number | null
+  NumberOfEmployees: number | null
+  Owner: { Name: string | null } | null
+  CreatedDate: string
+  LastModifiedDate: string
+  SystemModstamp: string
+  Description: string | null
+}
+
+export const accountSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("briefcase"),
+  properties: {
+    Name: Schema.title(),
+
+    Industry: Schema.select([]),
+
+    Type: Schema.select([]),
+
+    Website: Schema.url(),
+
+    Phone: Schema.phoneNumber(),
+
+    "Billing City": Schema.richText(),
+
+    "Billing Country": Schema.richText(),
+
+    "Annual Revenue": Schema.number(),
+
+    Employees: Schema.number(),
+
+    Owner: Schema.richText(),
+
+    Created: Schema.date(),
+
+    Updated: Schema.date(),
+
+    "Account Link": Schema.url(),
+
+    "Account ID": Schema.richText(),
+  },
+}
+
+export function accountToChange(
+  account: SalesforceAccount,
+  instanceUrl: string
+) {
+  const website = normalizeWebsite(account.Website)
+
+  return {
+    type: "upsert" as const,
+    key: account.Id,
+    upstreamUpdatedAt: account.SystemModstamp,
+    pageContentMarkdown: account.Description ?? "",
+    properties: {
+      Name: Builder.title(account.Name),
+      ...(account.Industry != null
+        ? { Industry: Builder.select(account.Industry) }
+        : {}),
+      ...(account.Type != null ? { Type: Builder.select(account.Type) } : {}),
+      ...(website ? { Website: Builder.url(website) } : {}),
+      ...(account.Phone != null
+        ? { Phone: Builder.phoneNumber(account.Phone) }
+        : {}),
+      ...(account.BillingCity != null
+        ? { "Billing City": Builder.richText(account.BillingCity) }
+        : {}),
+      ...(account.BillingCountry != null
+        ? { "Billing Country": Builder.richText(account.BillingCountry) }
+        : {}),
+      ...(account.AnnualRevenue != null &&
+      Number.isFinite(account.AnnualRevenue)
+        ? { "Annual Revenue": Builder.number(account.AnnualRevenue) }
+        : {}),
+      ...(account.NumberOfEmployees != null &&
+      Number.isFinite(account.NumberOfEmployees)
+        ? { Employees: Builder.number(account.NumberOfEmployees) }
+        : {}),
+      ...(account.Owner?.Name != null
+        ? { Owner: Builder.richText(account.Owner.Name) }
+        : {}),
+      Created: Builder.dateTime(account.CreatedDate),
+      Updated: Builder.dateTime(account.LastModifiedDate),
+      "Account Link": Builder.url(
+        lightningRecordUrl(instanceUrl, "Account", account.Id)
+      ),
+      "Account ID": Builder.richText(account.Id),
+    },
+  }
+}
+
+function normalizeWebsite(value: string | null): string | undefined {
+  const website = value?.trim()
+  if (!website) return undefined
+
+  const candidate = /^[a-z][a-z\d+.-]*:/i.test(website)
+    ? website
+    : `https://${website}`
+  try {
+    const url = new URL(candidate)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function lightningRecordUrl(
+  instanceUrl: string,
+  objectName: string,
+  recordId: string
+): string {
+  const baseUrl = instanceUrl.replace(/\/+$/, "")
+  return `${baseUrl}/lightning/r/${objectName}/${recordId}/view`
+}

--- a/examples/workers/syncs/salesforce/src/index.ts
+++ b/examples/workers/syncs/salesforce/src/index.ts
@@ -1,0 +1,139 @@
+// Entry point — syncs Salesforce Accounts and Opportunities into two related
+// managed Notion databases.
+//
+// Each database has:
+//   - a 5-minute incremental sync for new and changed records (including
+//     queryAll soft-delete markers)
+//   - a daily replacement reconciliation for purged deletes, permission
+//     changes, and any records missed while the worker was offline
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  ACCOUNT_FIELDS,
+  INITIAL_TITLE as ACCOUNTS_TITLE,
+  PRIMARY_KEY as ACCOUNTS_PK,
+  accountSchema,
+  accountToChange,
+} from "./accounts.js"
+import type { SalesforceAccount } from "./accounts.js"
+import {
+  OPPORTUNITY_FIELDS,
+  INITIAL_TITLE as OPPORTUNITIES_TITLE,
+  PRIMARY_KEY as OPPORTUNITIES_PK,
+  opportunitySchema,
+  opportunityToChange,
+} from "./opportunities.js"
+import type { SalesforceOpportunity } from "./opportunities.js"
+import {
+  createSalesforceClient,
+  getSalesforceLoginUrl,
+} from "./salesforce.js"
+import {
+  runIncrementalPage,
+  runReconciliationPage,
+} from "./sync.js"
+import type {
+  IncrementalSyncState,
+  ReconciliationSyncState,
+  SalesforceResource,
+} from "./sync.js"
+
+const worker = new Worker()
+
+// Register OAuth even before credentials exist so the first deployment can
+// allocate the callback URL used by the Salesforce External Client App.
+const loginUrl = getSalesforceLoginUrl()
+const salesforceAuth = worker.oauth("salesforceAuth", {
+  name: "salesforce",
+  authorizationEndpoint: `${loginUrl}/services/oauth2/authorize`,
+  tokenEndpoint: `${loginUrl}/services/oauth2/token`,
+  scope: "api refresh_token",
+  clientId: process.env.SALESFORCE_CLIENT_ID?.trim() ?? "",
+  clientSecret: process.env.SALESFORCE_CLIENT_SECRET?.trim() ?? "",
+  // Salesforce can omit expires_in. Give Workers a conservative fallback so
+  // it refreshes the access token instead of retaining it indefinitely.
+  accessTokenExpireMs: 60 * 60 * 1_000,
+})
+
+// Salesforce API quotas vary by edition and license count. This conservative
+// shared burst limit prevents all four syncs from issuing requests at once;
+// provider limit responses are also surfaced through RateLimitError.
+const pacer = worker.pacer("salesforce", {
+  allowedRequests: 8,
+  intervalMs: 1_000,
+})
+
+const createClient = () =>
+  createSalesforceClient(
+    () => salesforceAuth.accessToken(),
+    () => pacer.wait()
+  )
+
+const accountResource: SalesforceResource<SalesforceAccount> = {
+  objectName: "Account",
+  fields: ACCOUNT_FIELDS,
+  toChange: accountToChange,
+}
+
+const opportunityResource: SalesforceResource<SalesforceOpportunity> = {
+  objectName: "Opportunity",
+  fields: OPPORTUNITY_FIELDS,
+  toChange: opportunityToChange,
+}
+
+// ---------------------------------------------------------------------------
+// Accounts
+// ---------------------------------------------------------------------------
+
+const accounts = worker.database("accounts", {
+  type: "managed",
+  initialTitle: ACCOUNTS_TITLE,
+  primaryKeyProperty: ACCOUNTS_PK,
+  schema: accountSchema,
+})
+
+worker.sync("accountsSync", {
+  database: accounts,
+  mode: "incremental",
+  schedule: "5m",
+  execute: (state: IncrementalSyncState | undefined) =>
+    runIncrementalPage(createClient(), accountResource, state),
+})
+
+worker.sync("accountsReconciliation", {
+  database: accounts,
+  mode: "replace",
+  schedule: "1d",
+  execute: (state: ReconciliationSyncState | undefined) =>
+    runReconciliationPage(createClient(), accountResource, state),
+})
+
+// ---------------------------------------------------------------------------
+// Opportunities — Account IDs become relations to the Accounts database
+// ---------------------------------------------------------------------------
+
+const opportunities = worker.database("opportunities", {
+  type: "managed",
+  initialTitle: OPPORTUNITIES_TITLE,
+  primaryKeyProperty: OPPORTUNITIES_PK,
+  schema: opportunitySchema,
+})
+
+worker.sync("opportunitiesSync", {
+  database: opportunities,
+  mode: "incremental",
+  schedule: "5m",
+  execute: (state: IncrementalSyncState | undefined) =>
+    runIncrementalPage(createClient(), opportunityResource, state),
+})
+
+worker.sync("opportunitiesReconciliation", {
+  database: opportunities,
+  mode: "replace",
+  schedule: "1d",
+  execute: (state: ReconciliationSyncState | undefined) =>
+    runReconciliationPage(createClient(), opportunityResource, state),
+})
+
+export default worker

--- a/examples/workers/syncs/salesforce/src/index.ts
+++ b/examples/workers/syncs/salesforce/src/index.ts
@@ -1,5 +1,5 @@
 // Entry point — syncs Salesforce Accounts and Opportunities into two related
-// managed Notion databases.
+// managed Notion databases using a Salesforce External Client App.
 //
 // Each database has:
 //   - a 5-minute incremental sync for new and changed records (including
@@ -27,12 +27,9 @@ import {
 import type { SalesforceOpportunity } from "./opportunities.js"
 import {
   createSalesforceClient,
-  getSalesforceLoginUrl,
+  createSalesforceSessionProvider,
 } from "./salesforce.js"
-import {
-  runIncrementalPage,
-  runReconciliationPage,
-} from "./sync.js"
+import { runIncrementalPage, runReconciliationPage } from "./sync.js"
 import type {
   IncrementalSyncState,
   ReconciliationSyncState,
@@ -40,21 +37,6 @@ import type {
 } from "./sync.js"
 
 const worker = new Worker()
-
-// Register OAuth even before credentials exist so the first deployment can
-// allocate the callback URL used by the Salesforce External Client App.
-const loginUrl = getSalesforceLoginUrl()
-const salesforceAuth = worker.oauth("salesforceAuth", {
-  name: "salesforce",
-  authorizationEndpoint: `${loginUrl}/services/oauth2/authorize`,
-  tokenEndpoint: `${loginUrl}/services/oauth2/token`,
-  scope: "api refresh_token",
-  clientId: process.env.SALESFORCE_CLIENT_ID?.trim() ?? "",
-  clientSecret: process.env.SALESFORCE_CLIENT_SECRET?.trim() ?? "",
-  // Salesforce can omit expires_in. Give Workers a conservative fallback so
-  // it refreshes the access token instead of retaining it indefinitely.
-  accessTokenExpireMs: 60 * 60 * 1_000,
-})
 
 // Salesforce API quotas vary by edition and license count. This conservative
 // shared burst limit prevents all four syncs from issuing requests at once;
@@ -64,23 +46,27 @@ const pacer = worker.pacer("salesforce", {
   intervalMs: 1_000,
 })
 
+const salesforceSession = createSalesforceSessionProvider()
 const createClient = () =>
-  createSalesforceClient(
-    () => salesforceAuth.accessToken(),
-    () => pacer.wait()
-  )
+  createSalesforceClient(salesforceSession, () => pacer.wait())
 
-const accountResource: SalesforceResource<SalesforceAccount> = {
+const accountResource = {
   objectName: "Account",
   fields: ACCOUNT_FIELDS,
   toChange: accountToChange,
-}
+} satisfies SalesforceResource<
+  SalesforceAccount,
+  ReturnType<typeof accountToChange>
+>
 
-const opportunityResource: SalesforceResource<SalesforceOpportunity> = {
+const opportunityResource = {
   objectName: "Opportunity",
   fields: OPPORTUNITY_FIELDS,
   toChange: opportunityToChange,
-}
+} satisfies SalesforceResource<
+  SalesforceOpportunity,
+  ReturnType<typeof opportunityToChange>
+>
 
 // ---------------------------------------------------------------------------
 // Accounts

--- a/examples/workers/syncs/salesforce/src/opportunities.ts
+++ b/examples/workers/syncs/salesforce/src/opportunities.ts
@@ -1,4 +1,4 @@
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import * as Builder from "@notionhq/workers/builder"
 import * as Schema from "@notionhq/workers/schema"
 
@@ -47,7 +47,7 @@ export type SalesforceOpportunity = {
   Description: string | null
 }
 
-export const opportunitySchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const opportunitySchema = {
   databaseIcon: notionIcon("cash"),
   properties: {
     Name: Schema.title(),
@@ -85,12 +85,12 @@ export const opportunitySchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Opportunity ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 export function opportunityToChange(
   opportunity: SalesforceOpportunity,
   instanceUrl: string
-) {
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof opportunitySchema.properties> {
   return {
     type: "upsert" as const,
     key: opportunity.Id,
@@ -99,32 +99,31 @@ export function opportunityToChange(
     properties: {
       Name: Builder.title(opportunity.Name),
       Stage: Builder.select(opportunity.StageName),
-      ...(opportunity.Amount != null && Number.isFinite(opportunity.Amount)
-        ? { Amount: Builder.number(opportunity.Amount) }
-        : {}),
-      ...(opportunity.Probability != null &&
-      Number.isFinite(opportunity.Probability)
-        ? { Probability: Builder.number(opportunity.Probability / 100) }
-        : {}),
+      Amount:
+        opportunity.Amount != null && Number.isFinite(opportunity.Amount)
+          ? Builder.number(opportunity.Amount)
+          : [],
+      Probability:
+        opportunity.Probability != null &&
+        Number.isFinite(opportunity.Probability)
+          ? Builder.number(opportunity.Probability / 100)
+          : [],
       "Close Date": Builder.date(opportunity.CloseDate),
-      ...(opportunity.Type != null
-        ? { Type: Builder.select(opportunity.Type) }
-        : {}),
-      ...(opportunity.LeadSource != null
-        ? { "Lead Source": Builder.select(opportunity.LeadSource) }
-        : {}),
-      ...(opportunity.ForecastCategoryName != null
-        ? {
-            "Forecast Category": Builder.select(
-              opportunity.ForecastCategoryName
-            ),
-          }
-        : {}),
+      Type: opportunity.Type != null ? Builder.select(opportunity.Type) : [],
+      "Lead Source":
+        opportunity.LeadSource != null
+          ? Builder.select(opportunity.LeadSource)
+          : [],
+      "Forecast Category":
+        opportunity.ForecastCategoryName != null
+          ? Builder.select(opportunity.ForecastCategoryName)
+          : [],
       "Is Closed": Builder.checkbox(opportunity.IsClosed),
       "Is Won": Builder.checkbox(opportunity.IsWon),
-      ...(opportunity.Owner?.Name != null
-        ? { Owner: Builder.richText(opportunity.Owner.Name) }
-        : {}),
+      Owner:
+        opportunity.Owner?.Name != null
+          ? Builder.richText(opportunity.Owner.Name)
+          : [],
       Account: opportunity.AccountId
         ? [Builder.relation(opportunity.AccountId)]
         : [],

--- a/examples/workers/syncs/salesforce/src/opportunities.ts
+++ b/examples/workers/syncs/salesforce/src/opportunities.ts
@@ -1,0 +1,148 @@
+import { notionIcon } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+export const INITIAL_TITLE = "Salesforce Opportunities"
+export const PRIMARY_KEY = "Opportunity ID"
+
+export const OPPORTUNITY_FIELDS = [
+  "Id",
+  "IsDeleted",
+  "Name",
+  "StageName",
+  "Amount",
+  "Probability",
+  "CloseDate",
+  "Type",
+  "LeadSource",
+  "ForecastCategoryName",
+  "IsClosed",
+  "IsWon",
+  "Owner.Name",
+  "AccountId",
+  "CreatedDate",
+  "LastModifiedDate",
+  "SystemModstamp",
+  "Description",
+] as const
+
+export type SalesforceOpportunity = {
+  Id: string
+  IsDeleted: boolean
+  Name: string
+  StageName: string
+  Amount: number | null
+  Probability: number | null
+  CloseDate: string
+  Type: string | null
+  LeadSource: string | null
+  ForecastCategoryName: string | null
+  IsClosed: boolean
+  IsWon: boolean
+  Owner: { Name: string | null } | null
+  AccountId: string | null
+  CreatedDate: string
+  LastModifiedDate: string
+  SystemModstamp: string
+  Description: string | null
+}
+
+export const opportunitySchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("cash"),
+  properties: {
+    Name: Schema.title(),
+
+    Stage: Schema.select([]),
+
+    Amount: Schema.number(),
+
+    Probability: Schema.number("percent"),
+
+    "Close Date": Schema.date(),
+
+    Type: Schema.select([]),
+
+    "Lead Source": Schema.select([]),
+
+    "Forecast Category": Schema.select([]),
+
+    "Is Closed": Schema.checkbox(),
+
+    "Is Won": Schema.checkbox(),
+
+    Owner: Schema.richText(),
+
+    Account: Schema.relation("accounts", {
+      twoWay: true,
+      relatedPropertyName: "Opportunities",
+    }),
+
+    Created: Schema.date(),
+
+    Updated: Schema.date(),
+
+    "Opportunity Link": Schema.url(),
+
+    "Opportunity ID": Schema.richText(),
+  },
+}
+
+export function opportunityToChange(
+  opportunity: SalesforceOpportunity,
+  instanceUrl: string
+) {
+  return {
+    type: "upsert" as const,
+    key: opportunity.Id,
+    upstreamUpdatedAt: opportunity.SystemModstamp,
+    pageContentMarkdown: opportunity.Description ?? "",
+    properties: {
+      Name: Builder.title(opportunity.Name),
+      Stage: Builder.select(opportunity.StageName),
+      ...(opportunity.Amount != null && Number.isFinite(opportunity.Amount)
+        ? { Amount: Builder.number(opportunity.Amount) }
+        : {}),
+      ...(opportunity.Probability != null &&
+      Number.isFinite(opportunity.Probability)
+        ? { Probability: Builder.number(opportunity.Probability / 100) }
+        : {}),
+      "Close Date": Builder.date(opportunity.CloseDate),
+      ...(opportunity.Type != null
+        ? { Type: Builder.select(opportunity.Type) }
+        : {}),
+      ...(opportunity.LeadSource != null
+        ? { "Lead Source": Builder.select(opportunity.LeadSource) }
+        : {}),
+      ...(opportunity.ForecastCategoryName != null
+        ? {
+            "Forecast Category": Builder.select(
+              opportunity.ForecastCategoryName
+            ),
+          }
+        : {}),
+      "Is Closed": Builder.checkbox(opportunity.IsClosed),
+      "Is Won": Builder.checkbox(opportunity.IsWon),
+      ...(opportunity.Owner?.Name != null
+        ? { Owner: Builder.richText(opportunity.Owner.Name) }
+        : {}),
+      Account: opportunity.AccountId
+        ? [Builder.relation(opportunity.AccountId)]
+        : [],
+      Created: Builder.dateTime(opportunity.CreatedDate),
+      Updated: Builder.dateTime(opportunity.LastModifiedDate),
+      "Opportunity Link": Builder.url(
+        lightningRecordUrl(instanceUrl, "Opportunity", opportunity.Id)
+      ),
+      "Opportunity ID": Builder.richText(opportunity.Id),
+    },
+  }
+}
+
+function lightningRecordUrl(
+  instanceUrl: string,
+  objectName: string,
+  recordId: string
+): string {
+  const baseUrl = instanceUrl.replace(/\/+$/, "")
+  return `${baseUrl}/lightning/r/${objectName}/${recordId}/view`
+}

--- a/examples/workers/syncs/salesforce/src/salesforce.ts
+++ b/examples/workers/syncs/salesforce/src/salesforce.ts
@@ -1,5 +1,6 @@
-// Salesforce REST API client. Handles OAuth bearer headers, SOQL query
-// pagination, configured org URLs, and rate-limit responses.
+// Salesforce REST API client. Handles the External Client App client-
+// credentials exchange, bearer-token renewal, SOQL query pagination, and
+// rate-limit responses.
 
 import { RateLimitError } from "@notionhq/workers"
 
@@ -7,7 +8,16 @@ export const SALESFORCE_API_VERSION = "v67.0"
 const QUERY_BATCH_SIZE = 2_000
 
 export type BeforeRequest = () => Promise<void>
-export type GetAccessToken = () => Promise<string>
+
+export type SalesforceSession = {
+  accessToken: string
+  instanceUrl: string
+}
+
+export type SalesforceSessionProvider = {
+  getSession(): Promise<SalesforceSession>
+  invalidate(accessToken: string): void
+}
 
 export type SalesforceQueryPage<T> = {
   records: T[]
@@ -36,13 +46,22 @@ type SalesforceError = {
   message?: string
 }
 
-function configuredOrigin(
-  name: string,
-  fallback: string | undefined = undefined
-): string {
-  const raw = process.env[name]?.trim() || fallback
+type SalesforceTokenResponse = {
+  access_token?: unknown
+  instance_url?: unknown
+  token_type?: unknown
+  error?: unknown
+  error_description?: unknown
+}
+
+function configuredOrigin(name: string): string {
+  const raw = process.env[name]?.trim()
   if (!raw) throw new Error(`${name} is not set.`)
 
+  return normalizeOrigin(raw, name)
+}
+
+function normalizeOrigin(raw: string, name: string): string {
   let url: URL
   try {
     url = new URL(raw)
@@ -64,15 +83,106 @@ function configuredOrigin(
   return url.origin
 }
 
-export function getSalesforceLoginUrl(): string {
-  return configuredOrigin(
-    "SALESFORCE_LOGIN_URL",
-    "https://login.salesforce.com"
-  )
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is not set.`)
+  return value
 }
 
-export function getSalesforceInstanceUrl(): string {
-  return configuredOrigin("SALESFORCE_INSTANCE_URL")
+export function getSalesforceOrgUrl(): string {
+  return configuredOrigin("SALESFORCE_ORG_URL")
+}
+
+function parseTokenResponse(text: string): SalesforceTokenResponse {
+  try {
+    const value: unknown = JSON.parse(text)
+    return value != null && typeof value === "object"
+      ? (value as SalesforceTokenResponse)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+async function requestSalesforceSession(): Promise<SalesforceSession> {
+  const orgUrl = getSalesforceOrgUrl()
+  const clientId = requiredEnv("SALESFORCE_CLIENT_ID")
+  const clientSecret = requiredEnv("SALESFORCE_CLIENT_SECRET")
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64"
+  )
+  const response = await fetch(
+    new URL("/services/oauth2/token", `${orgUrl}/`),
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({ grant_type: "client_credentials" }),
+      redirect: "error",
+    }
+  )
+  const text = await response.text()
+  const token = parseTokenResponse(text)
+
+  if (!response.ok) {
+    const detail =
+      typeof token.error_description === "string"
+        ? token.error_description
+        : typeof token.error === "string"
+          ? token.error
+          : "No error details returned"
+    throw new Error(`Salesforce OAuth error (${response.status}): ${detail}`)
+  }
+  if (typeof token.access_token !== "string" || !token.access_token.trim()) {
+    throw new Error("Salesforce OAuth response is missing access_token.")
+  }
+  if (typeof token.instance_url !== "string") {
+    throw new Error("Salesforce OAuth response is missing instance_url.")
+  }
+  if (
+    token.token_type !== undefined &&
+    (typeof token.token_type !== "string" ||
+      token.token_type.toLowerCase() !== "bearer")
+  ) {
+    throw new Error(
+      "Salesforce OAuth response returned an unsupported token type."
+    )
+  }
+
+  return {
+    accessToken: token.access_token,
+    instanceUrl: normalizeOrigin(
+      token.instance_url,
+      "Salesforce OAuth instance_url"
+    ),
+  }
+}
+
+export function createSalesforceSessionProvider(): SalesforceSessionProvider {
+  let current: SalesforceSession | undefined
+  let pending: Promise<SalesforceSession> | undefined
+
+  return {
+    async getSession() {
+      if (current) return current
+
+      pending ??= requestSalesforceSession()
+        .then((session) => {
+          current = session
+          return session
+        })
+        .finally(() => {
+          pending = undefined
+        })
+      return pending
+    },
+    invalidate(accessToken) {
+      if (current?.accessToken === accessToken) current = undefined
+    },
+  }
 }
 
 function retryAfterSeconds(response: Response): number | undefined {
@@ -119,52 +229,68 @@ function queryCursorUrl(instanceUrl: string, cursor: string): URL {
 }
 
 export function createSalesforceClient(
-  getAccessToken: GetAccessToken,
+  sessionProvider: SalesforceSessionProvider,
   beforeRequest: BeforeRequest
 ): SalesforceClient {
-  const instanceUrl = getSalesforceInstanceUrl()
+  let currentInstanceUrl = getSalesforceOrgUrl()
 
-  async function fetchJson<T>(url: URL): Promise<T> {
-    await beforeRequest()
-    const accessToken = await getAccessToken()
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: "application/json",
-        "Sforce-Query-Options": `batchSize=${QUERY_BATCH_SIZE}`,
-      },
-      redirect: "error",
-    })
+  async function fetchJson<T>(
+    createUrl: (instanceUrl: string) => URL
+  ): Promise<T> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await beforeRequest()
+      const session = await sessionProvider.getSession()
+      currentInstanceUrl = session.instanceUrl
+      const response = await fetch(createUrl(session.instanceUrl), {
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: "application/json",
+          "Sforce-Query-Options": `batchSize=${QUERY_BATCH_SIZE}`,
+        },
+        redirect: "error",
+      })
 
-    const text = await response.text()
-    if (isRateLimitResponse(response, text)) {
-      throw new RateLimitError({ retryAfter: retryAfterSeconds(response) })
+      const text = await response.text()
+      if (response.status === 401 && attempt === 0) {
+        sessionProvider.invalidate(session.accessToken)
+        continue
+      }
+      if (isRateLimitResponse(response, text)) {
+        throw new RateLimitError({ retryAfter: retryAfterSeconds(response) })
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Salesforce API error (${response.status}): ${text || "No response body"}`
+        )
+      }
+
+      return JSON.parse(text) as T
     }
-    if (!response.ok) {
-      throw new Error(
-        `Salesforce API error (${response.status}): ${text || "No response body"}`
-      )
-    }
 
-    return JSON.parse(text) as T
+    throw new Error("Salesforce API authentication failed after token renewal.")
   }
 
   return {
-    instanceUrl,
+    get instanceUrl() {
+      return currentInstanceUrl
+    },
     async queryPage<T>(
       soql: string,
       cursor?: string,
       includeDeleted = false
     ): Promise<SalesforceQueryPage<T>> {
-      const url = cursor
-        ? queryCursorUrl(instanceUrl, cursor)
-        : new URL(
-            `/services/data/${SALESFORCE_API_VERSION}/${includeDeleted ? "queryAll/" : "query/"}`,
-            instanceUrl
-          )
-      if (!cursor) url.searchParams.set("q", soql)
-
-      const response = await fetchJson<SalesforceQueryResponse<T>>(url)
+      const response = await fetchJson<SalesforceQueryResponse<T>>(
+        (instanceUrl) => {
+          const url = cursor
+            ? queryCursorUrl(instanceUrl, cursor)
+            : new URL(
+                `/services/data/${SALESFORCE_API_VERSION}/${includeDeleted ? "queryAll/" : "query/"}`,
+                instanceUrl
+              )
+          if (!cursor) url.searchParams.set("q", soql)
+          return url
+        }
+      )
       if (!response.done && !response.nextRecordsUrl?.trim()) {
         throw new Error(
           "Salesforce pagination response is missing nextRecordsUrl."

--- a/examples/workers/syncs/salesforce/src/salesforce.ts
+++ b/examples/workers/syncs/salesforce/src/salesforce.ts
@@ -1,0 +1,181 @@
+// Salesforce REST API client. Handles OAuth bearer headers, SOQL query
+// pagination, configured org URLs, and rate-limit responses.
+
+import { RateLimitError } from "@notionhq/workers"
+
+export const SALESFORCE_API_VERSION = "v67.0"
+const QUERY_BATCH_SIZE = 2_000
+
+export type BeforeRequest = () => Promise<void>
+export type GetAccessToken = () => Promise<string>
+
+export type SalesforceQueryPage<T> = {
+  records: T[]
+  done: boolean
+  nextCursor?: string
+}
+
+export type SalesforceClient = {
+  instanceUrl: string
+  queryPage<T>(
+    soql: string,
+    cursor?: string,
+    includeDeleted?: boolean
+  ): Promise<SalesforceQueryPage<T>>
+}
+
+type SalesforceQueryResponse<T> = {
+  totalSize: number
+  done: boolean
+  records: T[]
+  nextRecordsUrl?: string
+}
+
+type SalesforceError = {
+  errorCode?: string
+  message?: string
+}
+
+function configuredOrigin(
+  name: string,
+  fallback: string | undefined = undefined
+): string {
+  const raw = process.env[name]?.trim() || fallback
+  if (!raw) throw new Error(`${name} is not set.`)
+
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error(`${name} must be a valid HTTPS origin.`)
+  }
+
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error(`${name} must be a valid HTTPS origin.`)
+  }
+
+  return url.origin
+}
+
+export function getSalesforceLoginUrl(): string {
+  return configuredOrigin(
+    "SALESFORCE_LOGIN_URL",
+    "https://login.salesforce.com"
+  )
+}
+
+export function getSalesforceInstanceUrl(): string {
+  return configuredOrigin("SALESFORCE_INSTANCE_URL")
+}
+
+function retryAfterSeconds(response: Response): number | undefined {
+  const value = response.headers.get("Retry-After")
+  if (!value?.trim()) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds)
+
+  const retryAt = Date.parse(value)
+  if (Number.isNaN(retryAt)) return undefined
+  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1_000))
+}
+
+function parseSalesforceErrors(text: string): SalesforceError[] {
+  try {
+    const value: unknown = JSON.parse(text)
+    return Array.isArray(value) ? (value as SalesforceError[]) : []
+  } catch {
+    return []
+  }
+}
+
+function isRateLimitResponse(response: Response, text: string): boolean {
+  if (response.status === 429) return true
+  return parseSalesforceErrors(text).some(
+    (error) => error.errorCode === "REQUEST_LIMIT_EXCEEDED"
+  )
+}
+
+function queryCursorUrl(instanceUrl: string, cursor: string): URL {
+  if (!cursor.startsWith("/")) {
+    throw new Error("Salesforce pagination cursor must be a relative API path.")
+  }
+
+  const url = new URL(cursor, `${instanceUrl}/`)
+  if (
+    url.origin !== instanceUrl ||
+    !url.pathname.startsWith(`/services/data/${SALESFORCE_API_VERSION}/query/`)
+  ) {
+    throw new Error("Salesforce pagination cursor is outside the query API.")
+  }
+  return url
+}
+
+export function createSalesforceClient(
+  getAccessToken: GetAccessToken,
+  beforeRequest: BeforeRequest
+): SalesforceClient {
+  const instanceUrl = getSalesforceInstanceUrl()
+
+  async function fetchJson<T>(url: URL): Promise<T> {
+    await beforeRequest()
+    const accessToken = await getAccessToken()
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+        "Sforce-Query-Options": `batchSize=${QUERY_BATCH_SIZE}`,
+      },
+      redirect: "error",
+    })
+
+    const text = await response.text()
+    if (isRateLimitResponse(response, text)) {
+      throw new RateLimitError({ retryAfter: retryAfterSeconds(response) })
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Salesforce API error (${response.status}): ${text || "No response body"}`
+      )
+    }
+
+    return JSON.parse(text) as T
+  }
+
+  return {
+    instanceUrl,
+    async queryPage<T>(
+      soql: string,
+      cursor?: string,
+      includeDeleted = false
+    ): Promise<SalesforceQueryPage<T>> {
+      const url = cursor
+        ? queryCursorUrl(instanceUrl, cursor)
+        : new URL(
+            `/services/data/${SALESFORCE_API_VERSION}/${includeDeleted ? "queryAll/" : "query/"}`,
+            instanceUrl
+          )
+      if (!cursor) url.searchParams.set("q", soql)
+
+      const response = await fetchJson<SalesforceQueryResponse<T>>(url)
+      if (!response.done && !response.nextRecordsUrl?.trim()) {
+        throw new Error(
+          "Salesforce pagination response is missing nextRecordsUrl."
+        )
+      }
+
+      return {
+        records: response.records,
+        done: response.done,
+        nextCursor: response.done ? undefined : response.nextRecordsUrl,
+      }
+    },
+  }
+}

--- a/examples/workers/syncs/salesforce/src/sync.ts
+++ b/examples/workers/syncs/salesforce/src/sync.ts
@@ -1,0 +1,147 @@
+// Shared Salesforce sync lifecycle. Fast incremental syncs query records in a
+// fixed SystemModstamp window; daily replacement syncs reconcile deletions and
+// any records missed while the worker was offline.
+
+import type { SalesforceClient } from "./salesforce.js"
+
+const INITIAL_SYNC_START = "1970-01-01T00:00:00.000Z"
+const CURSOR_OVERLAP_MS = 2 * 60 * 1_000
+
+export type SalesforceRecord = {
+  Id: string
+  IsDeleted: boolean
+  SystemModstamp: string
+}
+
+type SalesforceUpsert = {
+  type: "upsert"
+  key: string
+  upstreamUpdatedAt: string
+  properties: any
+  pageContentMarkdown?: string
+}
+
+export type SalesforceResource<T extends SalesforceRecord> = {
+  objectName: "Account" | "Opportunity"
+  fields: readonly string[]
+  toChange(record: T, instanceUrl: string): SalesforceUpsert
+}
+
+export type IncrementalSyncState = {
+  since: string
+  until?: string
+  nextCursor?: string
+}
+
+export type ReconciliationSyncState = {
+  nextCursor: string
+}
+
+function isoDateTime(value: string, label: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${label} must be an ISO 8601 timestamp.`)
+  }
+  return date.toISOString()
+}
+
+export function toSoqlDateTime(value: string): string {
+  return isoDateTime(value, "Salesforce sync timestamp").replace(
+    /\.\d{3}Z$/,
+    "Z"
+  )
+}
+
+function checkpointWithOverlap(until: string): string {
+  const untilMs = new Date(until).getTime()
+  const initialMs = new Date(INITIAL_SYNC_START).getTime()
+  return new Date(Math.max(initialMs, untilMs - CURSOR_OVERLAP_MS)).toISOString()
+}
+
+export function incrementalSoql<T extends SalesforceRecord>(
+  resource: SalesforceResource<T>,
+  since: string,
+  until: string
+): string {
+  return [
+    `SELECT ${resource.fields.join(", ")}`,
+    `FROM ${resource.objectName}`,
+    `WHERE SystemModstamp > ${toSoqlDateTime(since)}`,
+    `AND SystemModstamp <= ${toSoqlDateTime(until)}`,
+    "ORDER BY SystemModstamp ASC, Id ASC",
+  ].join(" ")
+}
+
+export function reconciliationSoql<T extends SalesforceRecord>(
+  resource: SalesforceResource<T>
+): string {
+  return `SELECT ${resource.fields.join(", ")} FROM ${resource.objectName} ORDER BY Id ASC`
+}
+
+export async function runIncrementalPage<T extends SalesforceRecord>(
+  client: SalesforceClient,
+  resource: SalesforceResource<T>,
+  state: IncrementalSyncState | undefined,
+  now: () => Date = () => new Date()
+) {
+  const since = isoDateTime(
+    state?.since ?? INITIAL_SYNC_START,
+    "Salesforce sync state.since"
+  )
+  if (state?.nextCursor && !state.until) {
+    throw new Error("Salesforce paginated sync state is missing until.")
+  }
+
+  // Keep the upper bound fixed while following Salesforce's query locator so
+  // a record changing mid-cycle is picked up by the next overlapping window.
+  const until = state?.nextCursor
+    ? isoDateTime(state.until!, "Salesforce sync state.until")
+    : now().toISOString()
+  const query = incrementalSoql(resource, since, until)
+  const page = await client.queryPage<T>(query, state?.nextCursor, true)
+  const changes = page.records.map((record) =>
+    record.IsDeleted
+      ? { type: "delete" as const, key: record.Id }
+      : resource.toChange(record, client.instanceUrl)
+  )
+
+  if (page.nextCursor) {
+    return {
+      changes,
+      hasMore: true,
+      nextState: { since, until, nextCursor: page.nextCursor },
+    }
+  }
+
+  return {
+    changes,
+    hasMore: false,
+    // Incremental mode persists this checkpoint between scheduled runs. The
+    // overlap makes retries safe and covers indexing/clock skew at the edge.
+    nextState: { since: checkpointWithOverlap(until) },
+  }
+}
+
+export async function runReconciliationPage<T extends SalesforceRecord>(
+  client: SalesforceClient,
+  resource: SalesforceResource<T>,
+  state: ReconciliationSyncState | undefined
+) {
+  const page = await client.queryPage<T>(
+    reconciliationSoql(resource),
+    state?.nextCursor
+  )
+  const changes = page.records.map((record) =>
+    resource.toChange(record, client.instanceUrl)
+  )
+
+  if (page.nextCursor) {
+    return {
+      changes,
+      hasMore: true,
+      nextState: { nextCursor: page.nextCursor },
+    }
+  }
+
+  return { changes, hasMore: false }
+}

--- a/examples/workers/syncs/salesforce/src/sync.ts
+++ b/examples/workers/syncs/salesforce/src/sync.ts
@@ -2,6 +2,9 @@
 // fixed SystemModstamp window; daily replacement syncs reconcile deletions and
 // any records missed while the worker was offline.
 
+import type { SyncChangeUpsert } from "@notionhq/workers"
+import type { PropertySchema } from "@notionhq/workers/schema"
+
 import type { SalesforceClient } from "./salesforce.js"
 
 const INITIAL_SYNC_START = "1970-01-01T00:00:00.000Z"
@@ -13,18 +16,15 @@ export type SalesforceRecord = {
   SystemModstamp: string
 }
 
-type SalesforceUpsert = {
-  type: "upsert"
-  key: string
-  upstreamUpdatedAt: string
-  properties: any
-  pageContentMarkdown?: string
-}
+type SalesforceUpsert = SyncChangeUpsert<string, PropertySchema<string>>
 
-export type SalesforceResource<T extends SalesforceRecord> = {
+export type SalesforceResource<
+  T extends SalesforceRecord,
+  TChange extends SalesforceUpsert,
+> = {
   objectName: "Account" | "Opportunity"
   fields: readonly string[]
-  toChange(record: T, instanceUrl: string): SalesforceUpsert
+  toChange(record: T, instanceUrl: string): TChange
 }
 
 export type IncrementalSyncState = {
@@ -55,11 +55,16 @@ export function toSoqlDateTime(value: string): string {
 function checkpointWithOverlap(until: string): string {
   const untilMs = new Date(until).getTime()
   const initialMs = new Date(INITIAL_SYNC_START).getTime()
-  return new Date(Math.max(initialMs, untilMs - CURSOR_OVERLAP_MS)).toISOString()
+  return new Date(
+    Math.max(initialMs, untilMs - CURSOR_OVERLAP_MS)
+  ).toISOString()
 }
 
-export function incrementalSoql<T extends SalesforceRecord>(
-  resource: SalesforceResource<T>,
+export function incrementalSoql<
+  T extends SalesforceRecord,
+  TChange extends SalesforceUpsert,
+>(
+  resource: SalesforceResource<T, TChange>,
   since: string,
   until: string
 ): string {
@@ -72,15 +77,19 @@ export function incrementalSoql<T extends SalesforceRecord>(
   ].join(" ")
 }
 
-export function reconciliationSoql<T extends SalesforceRecord>(
-  resource: SalesforceResource<T>
-): string {
+export function reconciliationSoql<
+  T extends SalesforceRecord,
+  TChange extends SalesforceUpsert,
+>(resource: SalesforceResource<T, TChange>): string {
   return `SELECT ${resource.fields.join(", ")} FROM ${resource.objectName} ORDER BY Id ASC`
 }
 
-export async function runIncrementalPage<T extends SalesforceRecord>(
+export async function runIncrementalPage<
+  T extends SalesforceRecord,
+  TChange extends SalesforceUpsert,
+>(
   client: SalesforceClient,
-  resource: SalesforceResource<T>,
+  resource: SalesforceResource<T, TChange>,
   state: IncrementalSyncState | undefined,
   now: () => Date = () => new Date()
 ) {
@@ -122,9 +131,12 @@ export async function runIncrementalPage<T extends SalesforceRecord>(
   }
 }
 
-export async function runReconciliationPage<T extends SalesforceRecord>(
+export async function runReconciliationPage<
+  T extends SalesforceRecord,
+  TChange extends SalesforceUpsert,
+>(
   client: SalesforceClient,
-  resource: SalesforceResource<T>,
+  resource: SalesforceResource<T, TChange>,
   state: ReconciliationSyncState | undefined
 ) {
   const page = await client.queryPage<T>(

--- a/examples/workers/syncs/salesforce/test.ts
+++ b/examples/workers/syncs/salesforce/test.ts
@@ -2,13 +2,11 @@
 // No Salesforce connection is made — HTTP assertions use mocked responses.
 // Run: npm test  (or: npx tsx test.ts)
 
-import { RateLimitError } from "@notionhq/workers"
+import { RateLimitError, type SyncChangeUpsert } from "@notionhq/workers"
+import type { PropertySchema } from "@notionhq/workers/schema"
 
 import worker from "./src/index.js"
-import {
-  accountToChange,
-  type SalesforceAccount,
-} from "./src/accounts.js"
+import { accountToChange, type SalesforceAccount } from "./src/accounts.js"
 import {
   opportunityToChange,
   type SalesforceOpportunity,
@@ -16,10 +14,11 @@ import {
 import {
   SALESFORCE_API_VERSION,
   createSalesforceClient,
-  getSalesforceInstanceUrl,
-  getSalesforceLoginUrl,
+  createSalesforceSessionProvider,
+  getSalesforceOrgUrl,
   type SalesforceClient,
   type SalesforceQueryPage,
+  type SalesforceSessionProvider,
 } from "./src/salesforce.js"
 import {
   incrementalSoql,
@@ -45,6 +44,10 @@ function ok(name: string, condition: boolean) {
 
 function contains(value: unknown, expected: string | number): boolean {
   return JSON.stringify(value).includes(String(expected))
+}
+
+function isEmptyProperty(value: unknown): boolean {
+  return Array.isArray(value) && value.length === 0
 }
 
 async function captureError(action: () => unknown | Promise<unknown>) {
@@ -155,16 +158,24 @@ const nullAccountChange = accountToChange(
   "https://acme.my.salesforce.com"
 )
 ok(
-  "null account fields are omitted",
-  nullAccountChange.properties.Industry === undefined &&
-    nullAccountChange.properties.Type === undefined &&
-    nullAccountChange.properties.Website === undefined &&
-    nullAccountChange.properties.Phone === undefined &&
-    nullAccountChange.properties["Billing City"] === undefined &&
-    nullAccountChange.properties["Billing Country"] === undefined &&
-    nullAccountChange.properties["Annual Revenue"] === undefined &&
-    nullAccountChange.properties.Employees === undefined &&
-    nullAccountChange.properties.Owner === undefined
+  "null account fields explicitly clear previous Notion values",
+  isEmptyProperty(nullAccountChange.properties.Industry) &&
+    isEmptyProperty(nullAccountChange.properties.Type) &&
+    isEmptyProperty(nullAccountChange.properties.Website) &&
+    isEmptyProperty(nullAccountChange.properties.Phone) &&
+    isEmptyProperty(nullAccountChange.properties["Billing City"]) &&
+    isEmptyProperty(nullAccountChange.properties["Billing Country"]) &&
+    isEmptyProperty(nullAccountChange.properties["Annual Revenue"]) &&
+    isEmptyProperty(nullAccountChange.properties.Employees) &&
+    isEmptyProperty(nullAccountChange.properties.Owner)
+)
+const invalidWebsiteChange = accountToChange(
+  { ...fullAccount, Website: "javascript:alert(1)" },
+  "https://acme.my.salesforce.com"
+)
+ok(
+  "invalid account websites clear a previous Notion URL",
+  isEmptyProperty(invalidWebsiteChange.properties.Website)
 )
 ok(
   "null account description becomes an empty body",
@@ -249,10 +260,7 @@ ok(
   "opportunity maps dates and its ID",
   contains(opportunityChange.properties.Created, "2024-02-03") &&
     contains(opportunityChange.properties.Updated, "2024-07-03") &&
-    contains(
-      opportunityChange.properties["Opportunity ID"],
-      fullOpportunity.Id
-    )
+    contains(opportunityChange.properties["Opportunity ID"], fullOpportunity.Id)
 )
 
 const zeroOpportunityChange = opportunityToChange(
@@ -280,15 +288,14 @@ const nullOpportunityChange = opportunityToChange(
   "https://acme.my.salesforce.com"
 )
 ok(
-  "null opportunity fields are omitted and its relation is cleared",
-  nullOpportunityChange.properties.Amount === undefined &&
-    nullOpportunityChange.properties.Probability === undefined &&
-    nullOpportunityChange.properties.Type === undefined &&
-    nullOpportunityChange.properties["Lead Source"] === undefined &&
-    nullOpportunityChange.properties["Forecast Category"] === undefined &&
-    nullOpportunityChange.properties.Owner === undefined &&
-    Array.isArray(nullOpportunityChange.properties.Account) &&
-    nullOpportunityChange.properties.Account.length === 0
+  "null opportunity fields explicitly clear previous Notion values",
+  isEmptyProperty(nullOpportunityChange.properties.Amount) &&
+    isEmptyProperty(nullOpportunityChange.properties.Probability) &&
+    isEmptyProperty(nullOpportunityChange.properties.Type) &&
+    isEmptyProperty(nullOpportunityChange.properties["Lead Source"]) &&
+    isEmptyProperty(nullOpportunityChange.properties["Forecast Category"]) &&
+    isEmptyProperty(nullOpportunityChange.properties.Owner) &&
+    isEmptyProperty(nullOpportunityChange.properties.Account)
 )
 ok(
   "null opportunity description becomes an empty body",
@@ -302,33 +309,19 @@ ok(
 function runUrlConfigurationTests() {
   console.log("Salesforce URL configuration:")
 
-  const originalLoginUrl = process.env.SALESFORCE_LOGIN_URL
-  const originalInstanceUrl = process.env.SALESFORCE_INSTANCE_URL
+  const originalOrgUrl = process.env.SALESFORCE_ORG_URL
 
   try {
-    delete process.env.SALESFORCE_LOGIN_URL
+    process.env.SALESFORCE_ORG_URL = " https://acme.my.salesforce.com/ "
     ok(
-      "login URL defaults to Salesforce production",
-      getSalesforceLoginUrl() === "https://login.salesforce.com"
+      "org URL is normalized to its HTTPS origin",
+      getSalesforceOrgUrl() === "https://acme.my.salesforce.com"
     )
 
-    process.env.SALESFORCE_LOGIN_URL = " https://test.salesforce.com/ "
+    delete process.env.SALESFORCE_ORG_URL
     ok(
-      "login URL accepts a configured HTTPS origin",
-      getSalesforceLoginUrl() === "https://test.salesforce.com"
-    )
-
-    process.env.SALESFORCE_INSTANCE_URL =
-      " https://acme.my.salesforce.com/ "
-    ok(
-      "instance URL is normalized to its origin",
-      getSalesforceInstanceUrl() === "https://acme.my.salesforce.com"
-    )
-
-    delete process.env.SALESFORCE_INSTANCE_URL
-    ok(
-      "instance URL is required",
-      captureSynchronousError(getSalesforceInstanceUrl) instanceof Error
+      "org URL is required",
+      captureSynchronousError(getSalesforceOrgUrl) instanceof Error
     )
 
     const invalidOrigins = [
@@ -340,18 +333,15 @@ function runUrlConfigurationTests() {
       "https://acme.my.salesforce.com#fragment",
     ]
     ok(
-      "instance URL rejects non-HTTPS values and URL components",
+      "org URL rejects non-HTTPS values and URL components",
       invalidOrigins.every((value) => {
-        process.env.SALESFORCE_INSTANCE_URL = value
-        return captureSynchronousError(getSalesforceInstanceUrl) instanceof Error
+        process.env.SALESFORCE_ORG_URL = value
+        return captureSynchronousError(getSalesforceOrgUrl) instanceof Error
       })
     )
   } finally {
-    if (originalLoginUrl === undefined) delete process.env.SALESFORCE_LOGIN_URL
-    else process.env.SALESFORCE_LOGIN_URL = originalLoginUrl
-    if (originalInstanceUrl === undefined)
-      delete process.env.SALESFORCE_INSTANCE_URL
-    else process.env.SALESFORCE_INSTANCE_URL = originalInstanceUrl
+    if (originalOrgUrl === undefined) delete process.env.SALESFORCE_ORG_URL
+    else process.env.SALESFORCE_ORG_URL = originalOrgUrl
   }
 }
 
@@ -365,6 +355,92 @@ function captureSynchronousError(action: () => unknown): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// Salesforce client-credentials session — mocked HTTP only
+// ---------------------------------------------------------------------------
+
+async function runSessionProviderTests() {
+  console.log("Salesforce client credentials:")
+
+  const originalFetch = globalThis.fetch
+  const originalClientId = process.env.SALESFORCE_CLIENT_ID
+  const originalClientSecret = process.env.SALESFORCE_CLIENT_SECRET
+  const originalOrgUrl = process.env.SALESFORCE_ORG_URL
+  process.env.SALESFORCE_CLIENT_ID = "client-id"
+  process.env.SALESFORCE_CLIENT_SECRET = "client-secret"
+  process.env.SALESFORCE_ORG_URL = "https://acme.my.salesforce.com"
+
+  try {
+    const requests: Request[] = []
+    const tokenResponses = [
+      {
+        access_token: "access-token-1",
+        instance_url: "https://acme.my.salesforce.com/",
+        token_type: "Bearer",
+      },
+      {
+        access_token: "access-token-2",
+        instance_url: "https://acme.my.salesforce.com",
+        token_type: "Bearer",
+      },
+    ]
+    globalThis.fetch = (async (input, init) => {
+      requests.push(new Request(input, init))
+      return new Response(JSON.stringify(tokenResponses.shift()), {
+        status: 200,
+      })
+    }) as typeof fetch
+
+    const provider = createSalesforceSessionProvider()
+    const [firstSession, concurrentSession] = await Promise.all([
+      provider.getSession(),
+      provider.getSession(),
+    ])
+    const request = requests[0]
+    const body = new URLSearchParams(await request.text())
+    ok(
+      "client credentials use one concurrent token exchange",
+      requests.length === 1 &&
+        firstSession.accessToken === "access-token-1" &&
+        concurrentSession === firstSession
+    )
+    ok(
+      "token exchange uses the org My Domain and HTTP Basic authentication",
+      request.method === "POST" &&
+        new URL(request.url).pathname === "/services/oauth2/token" &&
+        request.headers.get("Authorization") ===
+          `Basic ${Buffer.from("client-id:client-secret").toString("base64")}` &&
+        request.headers
+          .get("Content-Type")
+          ?.startsWith("application/x-www-form-urlencoded") === true &&
+        body.get("grant_type") === "client_credentials" &&
+        body.size === 1
+    )
+    ok(
+      "Salesforce instance URL is normalized from the token response",
+      firstSession.instanceUrl === "https://acme.my.salesforce.com"
+    )
+
+    provider.invalidate("another-token")
+    await provider.getSession()
+    provider.invalidate(firstSession.accessToken)
+    const renewedSession = await provider.getSession()
+    ok(
+      "only the active token can invalidate the cached session",
+      requests.length === 2 && renewedSession.accessToken === "access-token-2"
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalClientId === undefined) delete process.env.SALESFORCE_CLIENT_ID
+    else process.env.SALESFORCE_CLIENT_ID = originalClientId
+    if (originalClientSecret === undefined)
+      delete process.env.SALESFORCE_CLIENT_SECRET
+    else process.env.SALESFORCE_CLIENT_SECRET = originalClientSecret
+    if (originalOrgUrl === undefined) delete process.env.SALESFORCE_ORG_URL
+    else process.env.SALESFORCE_ORG_URL = originalOrgUrl
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Salesforce API client — mocked HTTP only
 // ---------------------------------------------------------------------------
 
@@ -372,8 +448,8 @@ async function runApiClientTests() {
   console.log("Salesforce API client:")
 
   const originalFetch = globalThis.fetch
-  const originalInstanceUrl = process.env.SALESFORCE_INSTANCE_URL
-  process.env.SALESFORCE_INSTANCE_URL = "https://acme.my.salesforce.com"
+  const originalOrgUrl = process.env.SALESFORCE_ORG_URL
+  process.env.SALESFORCE_ORG_URL = "https://acme.my.salesforce.com"
 
   try {
     const requests: Request[] = []
@@ -396,18 +472,26 @@ async function runApiClientTests() {
       return new Response(JSON.stringify(response), { status: 200 })
     }) as typeof fetch
 
-    const client = createSalesforceClient(
-      async () => {
+    const sessionProvider: SalesforceSessionProvider = {
+      async getSession() {
         tokenRequests++
-        return "salesforce-access-token"
+        return {
+          accessToken: "salesforce-access-token",
+          instanceUrl: "https://acme.my.salesforce.com",
+        }
       },
-      async () => {
-        waits++
-      }
-    )
+      invalidate() {},
+    }
+    const client = createSalesforceClient(sessionProvider, async () => {
+      waits++
+    })
     const soql = "SELECT Id FROM Account WHERE Name = 'A&B'"
     const firstPage = await client.queryPage<{ Id: string }>(soql)
-    const queryAllPage = await client.queryPage<{ Id: string }>(soql, undefined, true)
+    const queryAllPage = await client.queryPage<{ Id: string }>(
+      soql,
+      undefined,
+      true
+    )
     const cursorPage = await client.queryPage<{ Id: string }>(
       "THIS QUERY IS IGNORED FOR A CURSOR",
       firstPage.nextCursor
@@ -433,15 +517,14 @@ async function runApiClientTests() {
     )
     ok(
       "pagination follows Salesforce's relative query cursor",
-      firstPage.nextCursor ===
-        "/services/data/v67.0/query/01g-next" &&
+      firstPage.nextCursor === "/services/data/v67.0/query/01g-next" &&
         cursorUrl.pathname === "/services/data/v67.0/query/01g-next" &&
         !cursorUrl.searchParams.has("q") &&
         cursorPage.records[0].Id === "001Next" &&
         cursorPage.nextCursor === undefined
     )
     ok(
-      "each request is paced and obtains a fresh access token",
+      "each request is paced and obtains the current Salesforce session",
       waits === 3 && tokenRequests === 3
     )
     ok(
@@ -473,10 +556,9 @@ async function runApiClientTests() {
     )
 
     globalThis.fetch = (async () =>
-      new Response(
-        JSON.stringify({ totalSize: 1, done: false, records: [] }),
-        { status: 200 }
-      )) as typeof fetch
+      new Response(JSON.stringify({ totalSize: 1, done: false, records: [] }), {
+        status: 200,
+      })) as typeof fetch
     const missingCursorError = await captureError(() =>
       client.queryPage("SELECT Id FROM Account")
     )
@@ -518,11 +600,52 @@ async function runApiClientTests() {
       requestLimitError instanceof RateLimitError &&
         requestLimitError.retryAfter === undefined
     )
+
+    let activeToken = "expired-token"
+    const invalidatedTokens: string[] = []
+    const authRequests: Request[] = []
+    const retryProvider: SalesforceSessionProvider = {
+      async getSession() {
+        return {
+          accessToken: activeToken,
+          instanceUrl: "https://acme.my.salesforce.com",
+        }
+      },
+      invalidate(accessToken) {
+        invalidatedTokens.push(accessToken)
+        if (accessToken === activeToken) activeToken = "renewed-token"
+      },
+    }
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+      authRequests.push(request)
+      if (request.headers.get("Authorization") === "Bearer expired-token") {
+        return new Response(
+          JSON.stringify([
+            { errorCode: "INVALID_SESSION_ID", message: "Session expired" },
+          ]),
+          { status: 401 }
+        )
+      }
+      return new Response(
+        JSON.stringify({ totalSize: 0, done: true, records: [] }),
+        { status: 200 }
+      )
+    }) as typeof fetch
+    const retryClient = createSalesforceClient(retryProvider, async () => {})
+    const retriedPage = await retryClient.queryPage("SELECT Id FROM Account")
+    ok(
+      "a 401 renews the client-credentials token and retries once",
+      retriedPage.done &&
+        authRequests.length === 2 &&
+        invalidatedTokens.length === 1 &&
+        invalidatedTokens[0] === "expired-token" &&
+        authRequests[1].headers.get("Authorization") === "Bearer renewed-token"
+    )
   } finally {
     globalThis.fetch = originalFetch
-    if (originalInstanceUrl === undefined)
-      delete process.env.SALESFORCE_INSTANCE_URL
-    else process.env.SALESFORCE_INSTANCE_URL = originalInstanceUrl
+    if (originalOrgUrl === undefined) delete process.env.SALESFORCE_ORG_URL
+    else process.env.SALESFORCE_ORG_URL = originalOrgUrl
   }
 }
 
@@ -532,7 +655,10 @@ async function runApiClientTests() {
 
 type TestRecord = SalesforceRecord & { Name: string }
 
-const testResource: SalesforceResource<TestRecord> = {
+const testResource: SalesforceResource<
+  TestRecord,
+  SyncChangeUpsert<string, PropertySchema<string>>
+> = {
   objectName: "Account",
   fields: ["Id", "IsDeleted", "Name", "SystemModstamp"],
   toChange: (record, instanceUrl) => ({
@@ -556,7 +682,11 @@ function fakeClient(
 ): SalesforceClient {
   return {
     instanceUrl: "https://acme.my.salesforce.com",
-    async queryPage<T>(soql: string, cursor?: string, includeDeleted?: boolean) {
+    async queryPage<T>(
+      soql: string,
+      cursor?: string,
+      includeDeleted?: boolean
+    ) {
       calls.push({ soql, cursor, includeDeleted })
       const page = pages.shift()
       if (!page) throw new Error("Fake Salesforce client ran out of pages.")
@@ -582,7 +712,12 @@ async function runSyncLifecycleTests() {
     {
       records: [
         record("001Changed", "Changed account", "2024-08-20T11:50:00.000Z"),
-        record("001Deleted", "Deleted account", "2024-08-20T11:51:00.000Z", true),
+        record(
+          "001Deleted",
+          "Deleted account",
+          "2024-08-20T11:51:00.000Z",
+          true
+        ),
       ],
       done: false,
       nextCursor: "/services/data/v67.0/query/incremental-next",
@@ -623,8 +758,7 @@ async function runSyncLifecycleTests() {
   ok(
     "incremental pagination persists the original window and cursor",
     firstIncrementalPage.hasMore &&
-      firstIncrementalPage.nextState.since ===
-        "1970-01-01T00:00:00.000Z" &&
+      firstIncrementalPage.nextState.since === "1970-01-01T00:00:00.000Z" &&
       firstIncrementalPage.nextState.until === firstWindowEnd.toISOString() &&
       firstIncrementalPage.nextState.nextCursor ===
         "/services/data/v67.0/query/incremental-next"
@@ -646,8 +780,7 @@ async function runSyncLifecycleTests() {
   ok(
     "terminal incremental page checkpoints with a two-minute overlap",
     !secondIncrementalPage.hasMore &&
-      secondIncrementalPage.nextState.since ===
-        "2024-08-20T11:58:00.000Z" &&
+      secondIncrementalPage.nextState.since === "2024-08-20T11:58:00.000Z" &&
       secondIncrementalPage.nextState.until === undefined &&
       secondIncrementalPage.nextState.nextCursor === undefined
   )
@@ -747,8 +880,9 @@ function runManifestTests() {
     (capability) => capability._tag === "sync"
   )
   const syncConfig = (key: string): SyncManifestConfig | undefined =>
-    syncCapabilities.find((capability) => capability.key === key)
-      ?.config as SyncManifestConfig | undefined
+    syncCapabilities.find((capability) => capability.key === key)?.config as
+      | SyncManifestConfig
+      | undefined
   const incrementalConfigs = [
     syncConfig("accountsSync"),
     syncConfig("opportunitiesSync"),
@@ -777,29 +911,10 @@ function runManifestTests() {
     )
   )
 
-  const oauthCapability = worker.manifest.capabilities.find(
-    (capability) => capability._tag === "oauth"
-  )
-  const oauthConfig = oauthCapability?.config as
-    | {
-        name?: string
-        authorizationEndpoint?: string
-        tokenEndpoint?: string
-        scope?: string
-        accessTokenExpireMs?: number
-      }
-    | undefined
   ok(
-    "Salesforce OAuth is registered in the manifest",
-    Boolean(
-      oauthCapability?.key === "salesforceAuth" &&
-        oauthConfig?.name === "salesforce" &&
-        oauthConfig.authorizationEndpoint?.endsWith(
-          "/services/oauth2/authorize"
-        ) &&
-        oauthConfig.tokenEndpoint?.endsWith("/services/oauth2/token") &&
-        oauthConfig.scope === "api refresh_token" &&
-        oauthConfig.accessTokenExpireMs === 60 * 60 * 1_000
+    "headless client credentials do not register interactive OAuth",
+    !worker.manifest.capabilities.some(
+      (capability) => capability._tag === "oauth"
     )
   )
 }
@@ -807,6 +922,7 @@ function runManifestTests() {
 async function main() {
   runUrlConfigurationTests()
   runManifestTests()
+  await runSessionProviderTests()
   await runApiClientTests()
   await runSyncLifecycleTests()
 

--- a/examples/workers/syncs/salesforce/test.ts
+++ b/examples/workers/syncs/salesforce/test.ts
@@ -1,0 +1,820 @@
+// Offline tests for the Salesforce sync worker.
+// No Salesforce connection is made — HTTP assertions use mocked responses.
+// Run: npm test  (or: npx tsx test.ts)
+
+import { RateLimitError } from "@notionhq/workers"
+
+import worker from "./src/index.js"
+import {
+  accountToChange,
+  type SalesforceAccount,
+} from "./src/accounts.js"
+import {
+  opportunityToChange,
+  type SalesforceOpportunity,
+} from "./src/opportunities.js"
+import {
+  SALESFORCE_API_VERSION,
+  createSalesforceClient,
+  getSalesforceInstanceUrl,
+  getSalesforceLoginUrl,
+  type SalesforceClient,
+  type SalesforceQueryPage,
+} from "./src/salesforce.js"
+import {
+  incrementalSoql,
+  reconciliationSoql,
+  runIncrementalPage,
+  runReconciliationPage,
+  type SalesforceRecord,
+  type SalesforceResource,
+} from "./src/sync.js"
+
+let passed = 0
+let failed = 0
+
+function ok(name: string, condition: boolean) {
+  if (condition) {
+    passed++
+    console.log(`  ok   ${name}`)
+  } else {
+    failed++
+    console.log(`  FAIL ${name}`)
+  }
+}
+
+function contains(value: unknown, expected: string | number): boolean {
+  return JSON.stringify(value).includes(String(expected))
+}
+
+async function captureError(action: () => unknown | Promise<unknown>) {
+  try {
+    await action()
+  } catch (error) {
+    return error
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Account mapping
+// ---------------------------------------------------------------------------
+
+console.log("accountToChange:")
+
+const fullAccount: SalesforceAccount = {
+  Id: "001Acme",
+  IsDeleted: false,
+  Name: "Acme Corporation",
+  Industry: "Technology",
+  Type: "Customer",
+  Website: "https://acme.example",
+  Phone: "+1 415 555 0100",
+  BillingCity: "San Francisco",
+  BillingCountry: "United States",
+  AnnualRevenue: 12_500_000,
+  NumberOfEmployees: 420,
+  Owner: { Name: "Ada Lovelace" },
+  CreatedDate: "2024-01-02T03:04:05.000Z",
+  LastModifiedDate: "2024-06-02T03:04:05.000Z",
+  SystemModstamp: "2024-06-02T03:05:00.000Z",
+  Description: "Strategic account\n\nRenewal is in Q4.",
+}
+
+const accountChange = accountToChange(
+  fullAccount,
+  "https://acme.my.salesforce.com/"
+)
+
+ok("account is emitted as an upsert", accountChange.type === "upsert")
+ok("account key is the Salesforce ID", accountChange.key === fullAccount.Id)
+ok(
+  "account uses SystemModstamp as its upstream timestamp",
+  accountChange.upstreamUpdatedAt === fullAccount.SystemModstamp
+)
+ok(
+  "account description becomes the page body",
+  accountChange.pageContentMarkdown === fullAccount.Description
+)
+ok(
+  "account maps its standard fields",
+  contains(accountChange.properties.Name, fullAccount.Name) &&
+    contains(accountChange.properties.Industry, "Technology") &&
+    contains(accountChange.properties.Type, "Customer") &&
+    contains(accountChange.properties.Website, "https://acme.example") &&
+    contains(accountChange.properties.Phone, "+1 415 555 0100") &&
+    contains(accountChange.properties["Billing City"], "San Francisco") &&
+    contains(accountChange.properties["Billing Country"], "United States") &&
+    contains(accountChange.properties["Annual Revenue"], 12_500_000) &&
+    contains(accountChange.properties.Employees, 420) &&
+    contains(accountChange.properties.Owner, "Ada Lovelace")
+)
+ok(
+  "account dates and ID are mapped",
+  contains(accountChange.properties.Created, "2024-01-02") &&
+    contains(accountChange.properties.Updated, "2024-06-02") &&
+    contains(accountChange.properties["Account ID"], fullAccount.Id)
+)
+ok(
+  "account link points to Lightning and trims trailing slashes",
+  contains(
+    accountChange.properties["Account Link"],
+    `https://acme.my.salesforce.com/lightning/r/Account/${fullAccount.Id}/view`
+  )
+)
+
+const zeroAccountChange = accountToChange(
+  {
+    ...fullAccount,
+    AnnualRevenue: 0,
+    NumberOfEmployees: 0,
+  },
+  "https://acme.my.salesforce.com"
+)
+ok(
+  "account preserves zero-valued numbers",
+  JSON.stringify(zeroAccountChange.properties["Annual Revenue"]) ===
+    '[["0"]]' &&
+    JSON.stringify(zeroAccountChange.properties.Employees) === '[["0"]]'
+)
+
+const nullAccountChange = accountToChange(
+  {
+    ...fullAccount,
+    Industry: null,
+    Type: null,
+    Website: null,
+    Phone: null,
+    BillingCity: null,
+    BillingCountry: null,
+    AnnualRevenue: null,
+    NumberOfEmployees: null,
+    Owner: null,
+    Description: null,
+  },
+  "https://acme.my.salesforce.com"
+)
+ok(
+  "null account fields are omitted",
+  nullAccountChange.properties.Industry === undefined &&
+    nullAccountChange.properties.Type === undefined &&
+    nullAccountChange.properties.Website === undefined &&
+    nullAccountChange.properties.Phone === undefined &&
+    nullAccountChange.properties["Billing City"] === undefined &&
+    nullAccountChange.properties["Billing Country"] === undefined &&
+    nullAccountChange.properties["Annual Revenue"] === undefined &&
+    nullAccountChange.properties.Employees === undefined &&
+    nullAccountChange.properties.Owner === undefined
+)
+ok(
+  "null account description becomes an empty body",
+  nullAccountChange.pageContentMarkdown === ""
+)
+
+// ---------------------------------------------------------------------------
+// Opportunity mapping
+// ---------------------------------------------------------------------------
+
+console.log("opportunityToChange:")
+
+const fullOpportunity: SalesforceOpportunity = {
+  Id: "006Renewal",
+  IsDeleted: false,
+  Name: "Acme renewal",
+  StageName: "Negotiation/Review",
+  Amount: 75_000,
+  Probability: 35,
+  CloseDate: "2024-12-31",
+  Type: "Existing Business",
+  LeadSource: "Partner Referral",
+  ForecastCategoryName: "Best Case",
+  IsClosed: false,
+  IsWon: false,
+  Owner: { Name: "Grace Hopper" },
+  AccountId: fullAccount.Id,
+  CreatedDate: "2024-02-03T04:05:06.000Z",
+  LastModifiedDate: "2024-07-03T04:05:06.000Z",
+  SystemModstamp: "2024-07-03T04:06:00.000Z",
+  Description: "Renewal for the enterprise plan.",
+}
+
+const opportunityChange = opportunityToChange(
+  fullOpportunity,
+  "https://acme.my.salesforce.com/"
+)
+
+ok(
+  "opportunity is emitted as an upsert with its Salesforce ID",
+  opportunityChange.type === "upsert" &&
+    opportunityChange.key === fullOpportunity.Id
+)
+ok(
+  "opportunity maps standard fields",
+  contains(opportunityChange.properties.Name, "Acme renewal") &&
+    contains(opportunityChange.properties.Stage, "Negotiation/Review") &&
+    contains(opportunityChange.properties.Amount, 75_000) &&
+    contains(opportunityChange.properties["Close Date"], "2024-12-31") &&
+    contains(opportunityChange.properties.Type, "Existing Business") &&
+    contains(opportunityChange.properties["Lead Source"], "Partner Referral") &&
+    contains(opportunityChange.properties["Forecast Category"], "Best Case") &&
+    contains(opportunityChange.properties.Owner, "Grace Hopper")
+)
+ok(
+  "opportunity converts Salesforce percent values to decimal values",
+  JSON.stringify(opportunityChange.properties.Probability) === '[["0.35"]]'
+)
+ok(
+  "opportunity preserves boolean values",
+  contains(opportunityChange.properties["Is Closed"], "No") &&
+    contains(opportunityChange.properties["Is Won"], "No")
+)
+ok(
+  "opportunity relates to its account by primary key",
+  JSON.stringify(opportunityChange.properties.Account) ===
+    `[{"type":"primaryKey","value":"${fullAccount.Id}"}]`
+)
+ok(
+  "opportunity uses its body and SystemModstamp",
+  opportunityChange.pageContentMarkdown === fullOpportunity.Description &&
+    opportunityChange.upstreamUpdatedAt === fullOpportunity.SystemModstamp
+)
+ok(
+  "opportunity link points to Lightning and trims trailing slashes",
+  contains(
+    opportunityChange.properties["Opportunity Link"],
+    `https://acme.my.salesforce.com/lightning/r/Opportunity/${fullOpportunity.Id}/view`
+  )
+)
+ok(
+  "opportunity maps dates and its ID",
+  contains(opportunityChange.properties.Created, "2024-02-03") &&
+    contains(opportunityChange.properties.Updated, "2024-07-03") &&
+    contains(
+      opportunityChange.properties["Opportunity ID"],
+      fullOpportunity.Id
+    )
+)
+
+const zeroOpportunityChange = opportunityToChange(
+  { ...fullOpportunity, Amount: 0, Probability: 0 },
+  "https://acme.my.salesforce.com"
+)
+ok(
+  "opportunity preserves zero amount and probability",
+  JSON.stringify(zeroOpportunityChange.properties.Amount) === '[["0"]]' &&
+    JSON.stringify(zeroOpportunityChange.properties.Probability) === '[["0"]]'
+)
+
+const nullOpportunityChange = opportunityToChange(
+  {
+    ...fullOpportunity,
+    Amount: null,
+    Probability: null,
+    Type: null,
+    LeadSource: null,
+    ForecastCategoryName: null,
+    Owner: null,
+    AccountId: null,
+    Description: null,
+  },
+  "https://acme.my.salesforce.com"
+)
+ok(
+  "null opportunity fields are omitted and its relation is cleared",
+  nullOpportunityChange.properties.Amount === undefined &&
+    nullOpportunityChange.properties.Probability === undefined &&
+    nullOpportunityChange.properties.Type === undefined &&
+    nullOpportunityChange.properties["Lead Source"] === undefined &&
+    nullOpportunityChange.properties["Forecast Category"] === undefined &&
+    nullOpportunityChange.properties.Owner === undefined &&
+    Array.isArray(nullOpportunityChange.properties.Account) &&
+    nullOpportunityChange.properties.Account.length === 0
+)
+ok(
+  "null opportunity description becomes an empty body",
+  nullOpportunityChange.pageContentMarkdown === ""
+)
+
+// ---------------------------------------------------------------------------
+// Configured Salesforce origins
+// ---------------------------------------------------------------------------
+
+function runUrlConfigurationTests() {
+  console.log("Salesforce URL configuration:")
+
+  const originalLoginUrl = process.env.SALESFORCE_LOGIN_URL
+  const originalInstanceUrl = process.env.SALESFORCE_INSTANCE_URL
+
+  try {
+    delete process.env.SALESFORCE_LOGIN_URL
+    ok(
+      "login URL defaults to Salesforce production",
+      getSalesforceLoginUrl() === "https://login.salesforce.com"
+    )
+
+    process.env.SALESFORCE_LOGIN_URL = " https://test.salesforce.com/ "
+    ok(
+      "login URL accepts a configured HTTPS origin",
+      getSalesforceLoginUrl() === "https://test.salesforce.com"
+    )
+
+    process.env.SALESFORCE_INSTANCE_URL =
+      " https://acme.my.salesforce.com/ "
+    ok(
+      "instance URL is normalized to its origin",
+      getSalesforceInstanceUrl() === "https://acme.my.salesforce.com"
+    )
+
+    delete process.env.SALESFORCE_INSTANCE_URL
+    ok(
+      "instance URL is required",
+      captureSynchronousError(getSalesforceInstanceUrl) instanceof Error
+    )
+
+    const invalidOrigins = [
+      "not a URL",
+      "http://acme.my.salesforce.com",
+      "https://user:password@acme.my.salesforce.com",
+      "https://acme.my.salesforce.com/services/data",
+      "https://acme.my.salesforce.com?query=yes",
+      "https://acme.my.salesforce.com#fragment",
+    ]
+    ok(
+      "instance URL rejects non-HTTPS values and URL components",
+      invalidOrigins.every((value) => {
+        process.env.SALESFORCE_INSTANCE_URL = value
+        return captureSynchronousError(getSalesforceInstanceUrl) instanceof Error
+      })
+    )
+  } finally {
+    if (originalLoginUrl === undefined) delete process.env.SALESFORCE_LOGIN_URL
+    else process.env.SALESFORCE_LOGIN_URL = originalLoginUrl
+    if (originalInstanceUrl === undefined)
+      delete process.env.SALESFORCE_INSTANCE_URL
+    else process.env.SALESFORCE_INSTANCE_URL = originalInstanceUrl
+  }
+}
+
+function captureSynchronousError(action: () => unknown): unknown {
+  try {
+    action()
+  } catch (error) {
+    return error
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Salesforce API client — mocked HTTP only
+// ---------------------------------------------------------------------------
+
+async function runApiClientTests() {
+  console.log("Salesforce API client:")
+
+  const originalFetch = globalThis.fetch
+  const originalInstanceUrl = process.env.SALESFORCE_INSTANCE_URL
+  process.env.SALESFORCE_INSTANCE_URL = "https://acme.my.salesforce.com"
+
+  try {
+    const requests: Request[] = []
+    let waits = 0
+    let tokenRequests = 0
+    const responses = [
+      {
+        totalSize: 1,
+        done: false,
+        records: [{ Id: "001Acme" }],
+        nextRecordsUrl: `/services/data/${SALESFORCE_API_VERSION}/query/01g-next`,
+      },
+      { totalSize: 0, done: true, records: [] },
+      { totalSize: 1, done: true, records: [{ Id: "001Next" }] },
+    ]
+
+    globalThis.fetch = (async (input, init) => {
+      requests.push(new Request(input, init))
+      const response = responses.shift()
+      return new Response(JSON.stringify(response), { status: 200 })
+    }) as typeof fetch
+
+    const client = createSalesforceClient(
+      async () => {
+        tokenRequests++
+        return "salesforce-access-token"
+      },
+      async () => {
+        waits++
+      }
+    )
+    const soql = "SELECT Id FROM Account WHERE Name = 'A&B'"
+    const firstPage = await client.queryPage<{ Id: string }>(soql)
+    const queryAllPage = await client.queryPage<{ Id: string }>(soql, undefined, true)
+    const cursorPage = await client.queryPage<{ Id: string }>(
+      "THIS QUERY IS IGNORED FOR A CURSOR",
+      firstPage.nextCursor
+    )
+
+    const queryUrl = new URL(requests[0].url)
+    const queryAllUrl = new URL(requests[1].url)
+    const cursorUrl = new URL(requests[2].url)
+    ok(
+      "standard queries use the current versioned query endpoint",
+      SALESFORCE_API_VERSION === "v67.0" &&
+        queryUrl.pathname === "/services/data/v67.0/query/"
+    )
+    ok(
+      "deleted-record queries use queryAll",
+      queryAllUrl.pathname === "/services/data/v67.0/queryAll/" &&
+        queryAllPage.done
+    )
+    ok(
+      "SOQL is URL encoded without changing its value",
+      queryUrl.searchParams.get("q") === soql &&
+        !requests[0].url.includes("Name = 'A&B'")
+    )
+    ok(
+      "pagination follows Salesforce's relative query cursor",
+      firstPage.nextCursor ===
+        "/services/data/v67.0/query/01g-next" &&
+        cursorUrl.pathname === "/services/data/v67.0/query/01g-next" &&
+        !cursorUrl.searchParams.has("q") &&
+        cursorPage.records[0].Id === "001Next" &&
+        cursorPage.nextCursor === undefined
+    )
+    ok(
+      "each request is paced and obtains a fresh access token",
+      waits === 3 && tokenRequests === 3
+    )
+    ok(
+      "requests send bearer, JSON, and 2000-record batch headers",
+      requests.every(
+        (request) =>
+          request.headers.get("Authorization") ===
+            "Bearer salesforce-access-token" &&
+          request.headers.get("Accept") === "application/json" &&
+          request.headers.get("Sforce-Query-Options") === "batchSize=2000" &&
+          request.redirect === "error"
+      )
+    )
+
+    const invalidCursorErrors = await Promise.all(
+      [
+        "not-a-relative-path",
+        "/services/data/v66.0/query/old-version",
+        "/services/data/v67.0/sobjects/Account",
+        "//evil.example/services/data/v67.0/query/cursor",
+      ].map((cursor) =>
+        captureError(() => client.queryPage("SELECT Id FROM Account", cursor))
+      )
+    )
+    ok(
+      "pagination rejects malformed, cross-origin, and non-query cursors",
+      invalidCursorErrors.every((error) => error instanceof Error) &&
+        requests.length === 3
+    )
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ totalSize: 1, done: false, records: [] }),
+        { status: 200 }
+      )) as typeof fetch
+    const missingCursorError = await captureError(() =>
+      client.queryPage("SELECT Id FROM Account")
+    )
+    ok(
+      "non-terminal pages require nextRecordsUrl",
+      missingCursorError instanceof Error &&
+        missingCursorError.message.includes("missing nextRecordsUrl")
+    )
+
+    globalThis.fetch = (async () =>
+      new Response("Too many requests", {
+        status: 429,
+        headers: { "Retry-After": "7" },
+      })) as typeof fetch
+    const rateLimitError = await captureError(() =>
+      client.queryPage("SELECT Id FROM Account")
+    )
+    ok(
+      "429 responses preserve Retry-After for Workers backoff",
+      rateLimitError instanceof RateLimitError &&
+        rateLimitError.retryAfter === 7
+    )
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify([
+          {
+            errorCode: "REQUEST_LIMIT_EXCEEDED",
+            message: "Concurrent API request limit exceeded.",
+          },
+        ]),
+        { status: 403 }
+      )) as typeof fetch
+    const requestLimitError = await captureError(() =>
+      client.queryPage("SELECT Id FROM Account")
+    )
+    ok(
+      "Salesforce REQUEST_LIMIT_EXCEEDED errors trigger Workers backoff",
+      requestLimitError instanceof RateLimitError &&
+        requestLimitError.retryAfter === undefined
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalInstanceUrl === undefined)
+      delete process.env.SALESFORCE_INSTANCE_URL
+    else process.env.SALESFORCE_INSTANCE_URL = originalInstanceUrl
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Incremental and reconciliation lifecycle
+// ---------------------------------------------------------------------------
+
+type TestRecord = SalesforceRecord & { Name: string }
+
+const testResource: SalesforceResource<TestRecord> = {
+  objectName: "Account",
+  fields: ["Id", "IsDeleted", "Name", "SystemModstamp"],
+  toChange: (record, instanceUrl) => ({
+    type: "upsert",
+    key: record.Id,
+    upstreamUpdatedAt: record.SystemModstamp,
+    pageContentMarkdown: record.Name,
+    properties: { Name: [[record.Name]], Instance: [[instanceUrl]] },
+  }),
+}
+
+type QueryCall = {
+  soql: string
+  cursor: string | undefined
+  includeDeleted: boolean | undefined
+}
+
+function fakeClient(
+  pages: SalesforceQueryPage<TestRecord>[],
+  calls: QueryCall[]
+): SalesforceClient {
+  return {
+    instanceUrl: "https://acme.my.salesforce.com",
+    async queryPage<T>(soql: string, cursor?: string, includeDeleted?: boolean) {
+      calls.push({ soql, cursor, includeDeleted })
+      const page = pages.shift()
+      if (!page) throw new Error("Fake Salesforce client ran out of pages.")
+      return page as unknown as SalesforceQueryPage<T>
+    },
+  }
+}
+
+function record(
+  Id: string,
+  Name: string,
+  SystemModstamp: string,
+  IsDeleted = false
+): TestRecord {
+  return { Id, Name, SystemModstamp, IsDeleted }
+}
+
+async function runSyncLifecycleTests() {
+  console.log("Salesforce sync lifecycle:")
+
+  const firstWindowEnd = new Date("2024-08-20T12:00:00.000Z")
+  const incrementalPages: SalesforceQueryPage<TestRecord>[] = [
+    {
+      records: [
+        record("001Changed", "Changed account", "2024-08-20T11:50:00.000Z"),
+        record("001Deleted", "Deleted account", "2024-08-20T11:51:00.000Z", true),
+      ],
+      done: false,
+      nextCursor: "/services/data/v67.0/query/incremental-next",
+    },
+    {
+      records: [
+        record("001Later", "Later account", "2024-08-20T11:55:00.000Z"),
+      ],
+      done: true,
+    },
+  ]
+  const incrementalCalls: QueryCall[] = []
+  const incrementalClient = fakeClient(incrementalPages, incrementalCalls)
+
+  const firstIncrementalPage = await runIncrementalPage(
+    incrementalClient,
+    testResource,
+    undefined,
+    () => firstWindowEnd
+  )
+  const expectedIncrementalSoql = [
+    "SELECT Id, IsDeleted, Name, SystemModstamp FROM Account",
+    "WHERE SystemModstamp > 1970-01-01T00:00:00Z",
+    "AND SystemModstamp <= 2024-08-20T12:00:00Z",
+    "ORDER BY SystemModstamp ASC, Id ASC",
+  ].join(" ")
+  ok(
+    "incremental query uses a fixed inclusive window and stable order",
+    incrementalCalls[0].soql === expectedIncrementalSoql
+  )
+  ok(
+    "incremental pages include Salesforce soft-delete markers",
+    incrementalCalls[0].includeDeleted === true &&
+      firstIncrementalPage.changes[0].type === "upsert" &&
+      firstIncrementalPage.changes[1].type === "delete" &&
+      firstIncrementalPage.changes[1].key === "001Deleted"
+  )
+  ok(
+    "incremental pagination persists the original window and cursor",
+    firstIncrementalPage.hasMore &&
+      firstIncrementalPage.nextState.since ===
+        "1970-01-01T00:00:00.000Z" &&
+      firstIncrementalPage.nextState.until === firstWindowEnd.toISOString() &&
+      firstIncrementalPage.nextState.nextCursor ===
+        "/services/data/v67.0/query/incremental-next"
+  )
+
+  const secondIncrementalPage = await runIncrementalPage(
+    incrementalClient,
+    testResource,
+    firstIncrementalPage.nextState,
+    () => new Date("2024-08-20T13:00:00.000Z")
+  )
+  ok(
+    "later pages keep the first page's upper bound",
+    incrementalCalls[1].soql === incrementalCalls[0].soql &&
+      incrementalCalls[1].cursor ===
+        "/services/data/v67.0/query/incremental-next" &&
+      incrementalCalls[1].includeDeleted === true
+  )
+  ok(
+    "terminal incremental page checkpoints with a two-minute overlap",
+    !secondIncrementalPage.hasMore &&
+      secondIncrementalPage.nextState.since ===
+        "2024-08-20T11:58:00.000Z" &&
+      secondIncrementalPage.nextState.until === undefined &&
+      secondIncrementalPage.nextState.nextCursor === undefined
+  )
+
+  const callsBeforeInvalidState = incrementalCalls.length
+  const missingWindowError = await captureError(() =>
+    runIncrementalPage(incrementalClient, testResource, {
+      since: "2024-08-20T11:00:00.000Z",
+      nextCursor: "/services/data/v67.0/query/missing-window",
+    })
+  )
+  ok(
+    "paginated incremental state requires its fixed upper bound",
+    missingWindowError instanceof Error &&
+      missingWindowError.message.includes("missing until") &&
+      incrementalCalls.length === callsBeforeInvalidState
+  )
+
+  ok(
+    "SOQL helpers normalize timestamps and select declared fields",
+    incrementalSoql(
+      testResource,
+      "2024-08-20T10:00:00.123Z",
+      "2024-08-20T11:00:00.987Z"
+    ).includes(
+      "SystemModstamp > 2024-08-20T10:00:00Z AND SystemModstamp <= 2024-08-20T11:00:00Z"
+    ) &&
+      reconciliationSoql(testResource) ===
+        "SELECT Id, IsDeleted, Name, SystemModstamp FROM Account ORDER BY Id ASC"
+  )
+
+  const reconciliationPages: SalesforceQueryPage<TestRecord>[] = [
+    {
+      records: [
+        record("001First", "First account", "2024-08-20T11:00:00.000Z"),
+      ],
+      done: false,
+      nextCursor: "/services/data/v67.0/query/reconciliation-next",
+    },
+    {
+      records: [
+        record("001Second", "Second account", "2024-08-20T11:10:00.000Z"),
+      ],
+      done: true,
+    },
+  ]
+  const reconciliationCalls: QueryCall[] = []
+  const reconciliationClient = fakeClient(
+    reconciliationPages,
+    reconciliationCalls
+  )
+  const firstReconciliationPage = await runReconciliationPage(
+    reconciliationClient,
+    testResource,
+    undefined
+  )
+  const finalReconciliationPage = await runReconciliationPage(
+    reconciliationClient,
+    testResource,
+    firstReconciliationPage.nextState
+  )
+  ok(
+    "replacement reconciliation follows query pagination",
+    firstReconciliationPage.hasMore &&
+      firstReconciliationPage.nextState?.nextCursor ===
+        "/services/data/v67.0/query/reconciliation-next" &&
+      reconciliationCalls[1].cursor ===
+        "/services/data/v67.0/query/reconciliation-next" &&
+      reconciliationCalls[0].soql === reconciliationCalls[1].soql
+  )
+  ok(
+    "reconciliation uses standard query and emits all records as upserts",
+    reconciliationCalls.every((call) => !call.includeDeleted) &&
+      firstReconciliationPage.changes[0].type === "upsert" &&
+      finalReconciliationPage.changes[0].type === "upsert"
+  )
+  ok(
+    "terminal reconciliation page has no continuation state",
+    !finalReconciliationPage.hasMore &&
+      !("nextState" in finalReconciliationPage)
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Worker manifest
+// ---------------------------------------------------------------------------
+
+type SyncManifestConfig = {
+  mode?: string
+  schedule?: { type: string; intervalMs?: number }
+}
+
+function runManifestTests() {
+  console.log("Worker manifest:")
+
+  const syncCapabilities = worker.manifest.capabilities.filter(
+    (capability) => capability._tag === "sync"
+  )
+  const syncConfig = (key: string): SyncManifestConfig | undefined =>
+    syncCapabilities.find((capability) => capability.key === key)
+      ?.config as SyncManifestConfig | undefined
+  const incrementalConfigs = [
+    syncConfig("accountsSync"),
+    syncConfig("opportunitiesSync"),
+  ]
+  const reconciliationConfigs = [
+    syncConfig("accountsReconciliation"),
+    syncConfig("opportunitiesReconciliation"),
+  ]
+
+  ok(
+    "accounts and opportunities increment every five minutes",
+    incrementalConfigs.every(
+      (config) =>
+        config?.mode === "incremental" &&
+        config.schedule?.type === "interval" &&
+        config.schedule.intervalMs === 5 * 60_000
+    )
+  )
+  ok(
+    "accounts and opportunities reconcile with a daily replacement",
+    reconciliationConfigs.every(
+      (config) =>
+        config?.mode === "replace" &&
+        config.schedule?.type === "interval" &&
+        config.schedule.intervalMs === 24 * 60 * 60_000
+    )
+  )
+
+  const oauthCapability = worker.manifest.capabilities.find(
+    (capability) => capability._tag === "oauth"
+  )
+  const oauthConfig = oauthCapability?.config as
+    | {
+        name?: string
+        authorizationEndpoint?: string
+        tokenEndpoint?: string
+        scope?: string
+        accessTokenExpireMs?: number
+      }
+    | undefined
+  ok(
+    "Salesforce OAuth is registered in the manifest",
+    Boolean(
+      oauthCapability?.key === "salesforceAuth" &&
+        oauthConfig?.name === "salesforce" &&
+        oauthConfig.authorizationEndpoint?.endsWith(
+          "/services/oauth2/authorize"
+        ) &&
+        oauthConfig.tokenEndpoint?.endsWith("/services/oauth2/token") &&
+        oauthConfig.scope === "api refresh_token" &&
+        oauthConfig.accessTokenExpireMs === 60 * 60 * 1_000
+    )
+  )
+}
+
+async function main() {
+  runUrlConfigurationTests()
+  runManifestTests()
+  await runApiClientTests()
+  await runSyncLifecycleTests()
+
+  console.log(`\n${passed} passed, ${failed} failed`)
+  if (failed > 0) process.exit(1)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/examples/workers/syncs/salesforce/tsconfig.json
+++ b/examples/workers/syncs/salesforce/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/workers/syncs/salesforce/tsconfig.test.json
+++ b/examples/workers/syncs/salesforce/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- replace the Salesforce placeholder with an off-the-shelf Worker sync for Accounts and Opportunities
- create related managed databases with Salesforce descriptions as page content and a two-way Account ↔ Opportunity relation
- use the current Salesforce External Client App OAuth flow, configurable production/sandbox login origins, and REST API v67.0
- run bounded `queryAll` incremental windows every 5 minutes with opaque query-locator pagination, overlap, soft-delete markers, and persisted checkpoints
- run automatic daily replacement reconciliations to remove purged, missed, or newly inaccessible records without manual cleanup
- add shared pacing, Salesforce rate-limit backoff, cursor/origin validation, least-privilege setup guidance, and explicit deletion/freshness expectations
- add 49 offline contract tests covering schemas, transforms, OAuth manifest configuration, API requests, pagination, rate limits, checkpoints, deletes, and reconciliation

## Validation

- `npm run check`
- `npm run build`
- `npm test` — 49 passed
- focused Markdown lint
- focused Prettier check
- `git diff --check`

## Not run

- live Salesforce OAuth, token refresh, and sync preview; no Salesforce org credentials were available in this environment
