### PR TITLE
Add a connected Intercom sync for support teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ directory.
   [email notifications](examples/database-email-update/).
 - **Bring external data into Notion:** use a Worker sync for
   [GitHub](workers/github-sync/), [HubSpot](workers/hubspot-sync/),
-  [Jira](workers/jira-sync/), [Linear](workers/linear-sync/),
-  [PagerDuty](workers/pagerduty-sync/), [Salesforce](workers/salesforce-sync/),
-  [Snowflake](workers/snowflake-sync/), or [Zendesk](workers/zendesk-sync/).
+  [Intercom](workers/intercom-sync/), [Jira](workers/jira-sync/),
+  [Linear](workers/linear-sync/), [PagerDuty](workers/pagerduty-sync/),
+  [Salesforce](workers/salesforce-sync/), [Snowflake](workers/snowflake-sync/), or
+  [Zendesk](workers/zendesk-sync/).
 - **Give a Notion agent a new tool:** connect it to
   [Airflow](workers/airflow/), [CloudWatch Logs](workers/cloudwatch-logs/),
   [Postgres](workers/postgres-query/), or one of the other Worker tools below.
@@ -56,6 +57,7 @@ and a **webhook** handles events from another service. See the complete
 | Learn the sync pattern with seeded, in-memory data          | [DuckDB sync](workers/duckdb-sync/)         | DuckDB     |
 | Sync issues and pull requests                               | [GitHub sync](workers/github-sync/)         | GitHub     |
 | Sync contacts, deals, and companies                         | [HubSpot sync](workers/hubspot-sync/)       | HubSpot    |
+| Sync companies, contacts, conversations, and tickets        | [Intercom sync](workers/intercom-sync/)     | Intercom   |
 | Sync issues, sprints, analytics, and projects               | [Jira sync](workers/jira-sync/)             | Jira Cloud |
 | Sync projects, issues, and initiatives                      | [Linear sync](workers/linear-sync/)         | Linear     |
 | Monitor PagerDuty incidents and service readiness in Notion | [PagerDuty sync](workers/pagerduty-sync/)   | PagerDuty  |

--- a/catalog.json
+++ b/catalog.json
@@ -273,6 +273,25 @@
       }
     },
     {
+      "id": "intercom-sync",
+      "title": "Intercom sync",
+      "summary": "Sync Intercom companies, contacts, conversations, and tickets into a connected support workspace in Notion.",
+      "path": "workers/intercom-sync",
+      "kind": "worker-sync",
+      "status": "ready",
+      "language": "typescript",
+      "runtime": "node",
+      "integrations": ["notion-workers", "intercom"],
+      "entrypoints": ["src/index.ts"],
+      "commands": {
+        "install": "npm install",
+        "check": "npm run check",
+        "test": "npm test",
+        "build": "npm run build",
+        "deploy": "ntn workers deploy --name intercom-sync"
+      }
+    },
+    {
       "id": "jira-sync",
       "title": "Jira sync",
       "summary": "Sync Jira Cloud issues, current sprints, sprint analytics, and projects into managed Notion databases.",

--- a/workers/README.md
+++ b/workers/README.md
@@ -19,6 +19,7 @@ For local programs built directly on the Notion API, see the
 | [DuckDB sync](duckdb-sync/)         | A self-contained managed database populated from seeded, in-memory DuckDB data; useful for learning the sync contract. |
 | [GitHub sync](github-sync/)         | Issues, all pull requests, and open pull requests with review and CI status.                                           |
 | [HubSpot sync](hubspot-sync/)       | CRM contacts, deals, and companies.                                                                                    |
+| [Intercom sync](intercom-sync/)     | Companies, contacts, conversations, and tickets linked for support operations and customer context.                    |
 | [Jira sync](jira-sync/)             | Jira Cloud issues, current sprints, sprint analytics, and projects.                                                    |
 | [Linear sync](linear-sync/)         | Linear projects, issues, and initiatives.                                                                              |
 | [PagerDuty sync](pagerduty-sync/)   | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.     |

--- a/workers/intercom-sync/.env.example
+++ b/workers/intercom-sync/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` for local testing. `.env` is gitignored.
+# For a deployed worker, use `ntn workers env set KEY=value` instead.
+
+# Access token from a private Intercom app for one workspace.
+INTERCOM_ACCESS_TOKEN=
+
+# Data-hosting region: us (default), eu, or au.
+INTERCOM_REGION=us

--- a/workers/intercom-sync/.gitignore
+++ b/workers/intercom-sync/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+workers.json

--- a/workers/intercom-sync/README.md
+++ b/workers/intercom-sync/README.md
@@ -26,6 +26,8 @@ not use Tickets, leave `ticketsSync` paused and do not trigger
 `ticketsReconciliation`. The other three databases work independently; you do
 not need to edit the bundle.
 
+### Preview locally
+
 Install the example and preview one page from each core resource locally before
 deploying. Local preview calls Intercom but never writes to Notion:
 
@@ -56,6 +58,8 @@ the last Company preview request, let its scroll expire before deployment:
 ```sh
 sleep 65
 ```
+
+### Deploy and initialize
 
 Now deploy without cloud credentials and pause every schedule:
 
@@ -106,9 +110,15 @@ for sync in companiesSync contactsSync conversationsSync; do
 done
 ```
 
+These first runs backfill every Company, Contact, and Conversation visible to
+the private app and returned by these APIs. The optional Ticket run does the
+same for Tickets.
+
 Notion creates and manages all four databases; you do not provide a Notion API
 token. New Conversation and Ticket changes inside the one-minute consistency
 buffer arrive on the next five-minute cycle.
+
+### Redeploy safely
 
 Use `--name intercom-sync` only for the first deployment. Before redeploying an
 existing credentialed Worker, pause every capability that is scheduled or
@@ -116,6 +126,12 @@ running and wait for status to show no active run because stored credentials
 survive deployments. Older versions also scheduled both reconciliation keys,
 so pause those while upgrading. If a Company run did not finish successfully,
 wait another 65 seconds before redeploying so its Intercom scroll expires.
+
+Then update the existing Worker:
+
+```sh
+ntn workers deploy
+```
 
 ## What you get
 
@@ -147,6 +163,9 @@ are not snapshots and deleted records do not appear in search results. Ticket
 replacement also aborts if Intercom's `total_count` changes or the completed
 sweep does not match it, preventing an incomplete run from removing Notion
 rows.
+
+Trigger the manual reconciliations when you need to repair drift or remove
+deleted or newly hidden records, such as after an outage or access change.
 
 Keep replacement and delta runs from overlapping: pause `conversationsSync` or
 `ticketsSync`, use `ntn workers sync status <key>` to confirm it is idle,
@@ -232,7 +251,8 @@ format, so this example does not invent one.
   can therefore be partial. Filter **Incomplete Associations** for affected
   Contacts before relying on either list as exhaustive.
 - Ticket APIs can return `403 api_plan_restricted` when the workspace plan does
-  not include them. Keep both Ticket capabilities paused in that case.
+  not include them. Keep `ticketsSync` paused and do not trigger
+  `ticketsReconciliation` in that case.
 - Ticket requests use pages of 20 because Intercom may include large
   `ticket_parts` collections even though this example does not copy them.
 - Full transcripts are not copied; Intercom caps returned Conversation/Ticket

--- a/workers/intercom-sync/README.md
+++ b/workers/intercom-sync/README.md
@@ -1,0 +1,181 @@
+# Worker sync: Intercom
+
+Turn Intercom into a connected support workspace in Notion. One deploy creates
+four related databases—**Companies**, **Contacts**, **Conversations**, and
+**Tickets**—so support and customer-success teams can triage work, spot account
+risk, and understand service quality without assembling separate recipes.
+
+The sync is read-only. Intercom remains the system of record, and later syncs
+overwrite edits to managed properties in Notion.
+
+## Quickstart
+
+You need Node.js 22+, an Intercom workspace, and a token from a
+[private Intercom app](https://developers.intercom.com/docs/build-an-integration/learn-more/authentication).
+Grant only these permissions:
+
+- **Read and list users and companies**
+- **Read tags**
+- **Read conversations**
+- **Read admins**
+- **Read tickets**
+
+Tickets API access also depends on your Intercom plan. If your workspace does
+not use Tickets, remove the clearly labeled Tickets import, database, and sync
+blocks from `src/index.ts`; the other three databases work independently.
+
+From the repository root:
+
+```sh
+npm install --global ntn
+cd workers/intercom-sync
+npm install
+ntn login
+ntn workers deploy --name intercom-sync
+ntn workers env set INTERCOM_ACCESS_TOKEN=your-private-app-token
+```
+
+US-hosted workspaces need no region setting. For EU or Australia hosting, add
+one of:
+
+```sh
+ntn workers env set INTERCOM_REGION=eu
+ntn workers env set INTERCOM_REGION=au
+```
+
+Preview in dependency order, then remove `--preview` to write to Notion:
+
+```sh
+ntn workers sync trigger companiesSync --preview
+ntn workers sync trigger contactsSync --preview
+ntn workers sync trigger conversationsSync --preview
+ntn workers sync trigger ticketsSync --preview
+```
+
+Notion creates and manages the databases; you do not provide a Notion API
+token. The first runs backfill all records visible to the private app. New
+Conversation and Ticket changes inside the one-minute consistency buffer arrive
+on the next scheduled cycle.
+
+## What you get
+
+| Database          | Useful questions                                                                                                                                     |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Companies**     | Which accounts are active, high-usage, high-spend, or in a key segment? What support work and contacts belong to each account?                       |
+| **Contacts**      | Who are our users and leads, who owns them, and who is inactive or cannot receive email? Which companies, conversations, and tickets relate to them? |
+| **Conversations** | Which open, unread, or priority conversations are waiting? Where are reply time, handling time, reopen, SLA, CSAT, or AI-resolution signals weak?    |
+| **Tickets**       | Which structured requests are open, waiting on a customer, snoozed, or unassigned? Which customer and teammate own the next step?                    |
+
+Relations connect Companies to Contacts and Conversations, and Contacts to
+Conversations and Tickets. Each related property is visible from both sides.
+
+## Sync behavior
+
+| Capability                    | Database      | Mode        | Schedule | Why it exists                                                         |
+| ----------------------------- | ------------- | ----------- | -------- | --------------------------------------------------------------------- |
+| `companiesSync`               | Companies     | replace     | hourly   | Refresh the canonical Company scroll and remove missing records.      |
+| `contactsSync`                | Contacts      | replace     | hourly   | Avoid unsafe day-granularity Contact timestamp cursors.               |
+| `conversationsSync`           | Conversations | incremental | 2 min    | Deliver changed Conversations quickly with a buffered, pinned window. |
+| `conversationsReconciliation` | Conversations | replace     | daily    | Repair drift and remove deleted or newly hidden records.              |
+| `ticketsSync`                 | Tickets       | incremental | 2 min    | Deliver changed Tickets quickly with the same overlap strategy.       |
+| `ticketsReconciliation`       | Tickets       | replace     | daily    | Repair drift and remove Tickets no longer returned by Intercom.       |
+
+Incremental searches pin their upper timestamp across every page, sort by
+immutable Intercom ID, wait one minute for indexing, and replay a five-minute
+overlap. Daily replacement is still necessary because Intercom search cursors
+are not snapshots and deleted records do not appear in search results. Ticket
+replacement also aborts if Intercom's `total_count` changes or the completed
+sweep does not match it, preventing an incomplete run from removing Notion
+rows.
+
+Every record is keyed by Intercom's immutable API `id`. The human-facing
+`ticket_id` is copied only as **Inbox Ticket ID** and is never used for API
+queries.
+
+## Data copied
+
+- Companies: plan, industry, website, employee/user/session counts, monthly
+  spend, activity, tags, segments, and timestamps.
+- Contacts: identity, role, owner, email/phone, company relations, tags,
+  country, activity, and email restrictions.
+- Conversations: state, priority, contacts/company, assignment, channel, tags,
+  SLA, CSAT, first/median reply time, handling time, last reply, reopens, and AI
+  resolution. The page body contains a sanitized opening message and rating
+  comment when present.
+- Tickets: state, type, category, contacts, assignment, visibility, snooze and
+  timestamps. The page body contains only the sanitized default description.
+
+Arbitrary custom attributes, full Conversation transcripts, Ticket parts,
+attachments, internal notes, and temporary file URLs are deliberately omitted.
+They vary by workspace, can expose sensitive data, or are incomplete in list
+responses. Add only fields your team has reviewed and needs.
+
+The copied data can include customer names, contact details, support messages,
+and rating comments. Review the managed databases' Notion sharing settings
+before granting broader access, and store the Intercom token only with
+`ntn workers env set`.
+
+## Project map and extension points
+
+```text
+src/
+├── index.ts          — database registration, schedules, pacing, and caches
+├── intercom.ts       — regional Intercom client, API types, and lookups
+├── pagination.ts     — bounded starting_after cursor protection
+├── companies.ts      — Company schema, transform, and scroll execution
+├── contacts.ts       — Contact schema, transform, and replacement execution
+├── conversations.ts  — Conversation schema, transform, windows, and execution
+├── tickets.ts        — Ticket schema, transform, windows, and execution
+└── helpers.ts        — timestamps, text sanitization, and formatting
+```
+
+For an agent extending one resource, start in that resource file: its schema,
+transform, state policy, and page executor live together. Then update the API
+DTO in `intercom.ts`, this README, and `test.ts`. Preserve these invariants:
+
+- emit `[]` when an upstream nullable value clears;
+- use API `id` as the key and `updated_at` as `upstreamUpdatedAt`;
+- keep incremental time bounds fixed while a cursor is active;
+- bound text and pagination state;
+- add custom attributes through an explicit allowlist, not a generic dump.
+
+Good extensions include selected Company/Contact/Ticket custom attributes,
+webhook-triggered refreshes, or a reviewed subset of Conversation parts.
+Intercom publishes no supported Company, Conversation, or Ticket Inbox deep-link
+format, so this example does not invent one.
+
+## Limitations
+
+- Intercom permits only one active Company scroll per app, expires it after one
+  idle minute, and may return the same scroll token for multiple distinct pages.
+  Do not overlap manual Company runs. The Worker detects repeated pages and
+  performs at most two safe restarts for expired or documented server-error
+  sessions.
+- Company Scroll omits Companies with no associated users.
+- A Contact embeds at most ten Companies and ten Tags; those relation/tag lists
+  can therefore be partial when `has_more` is true.
+- Ticket APIs can return `403 api_plan_restricted` when the workspace plan does
+  not include them.
+- Full transcripts are not copied; Intercom caps returned Conversation/Ticket
+  parts and those parts may include internal or redacted content.
+
+See Intercom's official guides for
+[regional hosts and API versioning](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis),
+[cursor behavior](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination),
+and [Company Scroll](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/scrollOverAllCompanies).
+
+## Verify
+
+Offline checks make no Intercom or Notion calls:
+
+```sh
+npm run check
+npm test
+npm run build
+```
+
+For a live smoke test, preview each capability in the Quickstart order. Confirm
+that Company and Contact counts are plausible, relations resolve, a recently
+updated Conversation and Ticket appear after the consistency buffer, and no
+unexpected message or custom-attribute content is copied. Then run without
+`--preview` and compare a small sample against Intercom.

--- a/workers/intercom-sync/README.md
+++ b/workers/intercom-sync/README.md
@@ -10,7 +10,8 @@ overwrite edits to managed properties in Notion.
 
 ## Quickstart
 
-You need Node.js 22+, an Intercom workspace, and a token from a
+You need Node.js 22+, Notion CLI 0.18.1 or newer, an Intercom workspace,
+and a token from a
 [private Intercom app](https://developers.intercom.com/docs/build-an-integration/learn-more/authentication).
 Grant only these permissions:
 
@@ -18,44 +19,103 @@ Grant only these permissions:
 - **Read tags**
 - **Read conversations**
 - **Read admins**
-- **Read tickets**
+- **Read tickets**—only when you intend to sync Tickets
 
 Tickets API access also depends on your Intercom plan. If your workspace does
-not use Tickets, remove the clearly labeled Tickets import, database, and sync
-blocks from `src/index.ts`; the other three databases work independently.
+not use Tickets, leave `ticketsSync` paused and do not trigger
+`ticketsReconciliation`. The other three databases work independently; you do
+not need to edit the bundle.
 
-From the repository root:
+Install the example and preview one page from each core resource locally before
+deploying. Local preview calls Intercom but never writes to Notion:
 
 ```sh
-npm install --global ntn
+npm install --global ntn@latest
+ntn --version
 cd workers/intercom-sync
 npm install
+cp .env.example .env
+# Add INTERCOM_ACCESS_TOKEN and the correct INTERCOM_REGION to .env.
+ntn workers sync trigger contactsSync --local --preview
+ntn workers sync trigger conversationsSync --local --preview
+ntn workers sync trigger companiesSync --local --preview
+```
+
+Run the optional Ticket preview too if you intend to use Tickets. A successful
+preview confirms that the private app and workspace plan can read them:
+
+```sh
+ntn workers sync trigger ticketsSync --local --preview
+```
+
+Company preview opens Intercom's single app-wide Company Scroll. `--preview`
+executes one page. To inspect every preview page, rerun the command with
+`--context '<nextContext>'` from the previous result until it completes. After
+the last Company preview request, let its scroll expire before deployment:
+
+```sh
+sleep 65
+```
+
+Now deploy without cloud credentials and pause every schedule:
+
+```sh
 ntn login
 ntn workers deploy --name intercom-sync
+for sync in companiesSync contactsSync conversationsSync ticketsSync; do
+  ntn workers sync pause "$sync"
+done
+ntn workers sync status --no-watch
+```
+
+Stop here unless status reports all four scheduled capabilities paused with no
+active run. Then set the region before the token:
+
+```sh
+ntn workers env set INTERCOM_REGION=us
 ntn workers env set INTERCOM_ACCESS_TOKEN=your-private-app-token
 ```
 
-US-hosted workspaces need no region setting. For EU or Australia hosting, add
-one of:
+Use `eu` or `au` instead of `us` for those hosting regions. Trigger each core
+backfill in dependency order and wait for it to complete before continuing.
+Each status command watches the run; press Ctrl-C after it reports completion.
 
 ```sh
-ntn workers env set INTERCOM_REGION=eu
-ntn workers env set INTERCOM_REGION=au
+ntn workers sync trigger companiesSync
+ntn workers sync status companiesSync
+ntn workers sync trigger contactsSync
+ntn workers sync status contactsSync
+ntn workers sync trigger conversationsSync
+ntn workers sync status conversationsSync
 ```
 
-Preview in dependency order, then remove `--preview` to write to Notion:
+If the Ticket preview succeeded, initialize and enable Tickets too. Otherwise
+leave Ticket syncing disabled:
 
 ```sh
-ntn workers sync trigger companiesSync --preview
-ntn workers sync trigger contactsSync --preview
-ntn workers sync trigger conversationsSync --preview
-ntn workers sync trigger ticketsSync --preview
+ntn workers sync trigger ticketsSync
+ntn workers sync status ticketsSync
+ntn workers sync resume ticketsSync
 ```
 
-Notion creates and manages the databases; you do not provide a Notion API
-token. The first runs backfill all records visible to the private app. New
-Conversation and Ticket changes inside the one-minute consistency buffer arrive
-on the next scheduled cycle.
+Finally, enable the core schedules:
+
+```sh
+for sync in companiesSync contactsSync conversationsSync; do
+  ntn workers sync resume "$sync"
+done
+```
+
+Notion creates and manages all four databases; you do not provide a Notion API
+token. New Conversation and Ticket changes inside the one-minute consistency
+buffer arrive on the next five-minute cycle.
+
+Use `--name intercom-sync` only for the first deployment. Before redeploying an
+existing credentialed Worker, pause every capability that is scheduled or
+running and wait for status to show no active run because stored credentials
+survive deployments. Older versions also scheduled both reconciliation keys,
+so pause those while upgrading. If a Company run did not finish successfully,
+wait another 65 seconds before redeploying so its Intercom scroll expires.
 
 ## What you get
 
@@ -75,18 +135,34 @@ Conversations and Tickets. Each related property is visible from both sides.
 | ----------------------------- | ------------- | ----------- | -------- | --------------------------------------------------------------------- |
 | `companiesSync`               | Companies     | replace     | hourly   | Refresh the canonical Company scroll and remove missing records.      |
 | `contactsSync`                | Contacts      | replace     | hourly   | Avoid unsafe day-granularity Contact timestamp cursors.               |
-| `conversationsSync`           | Conversations | incremental | 2 min    | Deliver changed Conversations quickly with a buffered, pinned window. |
-| `conversationsReconciliation` | Conversations | replace     | daily    | Repair drift and remove deleted or newly hidden records.              |
-| `ticketsSync`                 | Tickets       | incremental | 2 min    | Deliver changed Tickets quickly with the same overlap strategy.       |
-| `ticketsReconciliation`       | Tickets       | replace     | daily    | Repair drift and remove Tickets no longer returned by Intercom.       |
+| `conversationsSync`           | Conversations | incremental | 5 min    | Deliver changed Conversations quickly with a buffered, pinned window. |
+| `conversationsReconciliation` | Conversations | replace     | manual   | Repair drift and remove deleted or newly hidden records.              |
+| `ticketsSync`                 | Tickets       | incremental | 5 min    | Deliver changed Tickets quickly with the same overlap strategy.       |
+| `ticketsReconciliation`       | Tickets       | replace     | manual   | Repair drift and remove Tickets no longer returned by Intercom.       |
 
 Incremental searches pin their upper timestamp across every page, sort by
 immutable Intercom ID, wait one minute for indexing, and replay a five-minute
-overlap. Daily replacement is still necessary because Intercom search cursors
+overlap. Manual replacement is still necessary because Intercom search cursors
 are not snapshots and deleted records do not appear in search results. Ticket
 replacement also aborts if Intercom's `total_count` changes or the completed
 sweep does not match it, preventing an incomplete run from removing Notion
 rows.
+
+Keep replacement and delta runs from overlapping: pause `conversationsSync` or
+`ticketsSync`, use `ntn workers sync status <key>` to confirm it is idle,
+trigger the matching reconciliation, wait for that run to finish, then resume
+the delta. This follows the Workers backfill pattern and prevents a replacement
+from deleting a newer row written by a concurrent delta.
+
+```sh
+ntn workers sync pause conversationsSync
+ntn workers sync status conversationsSync
+ntn workers sync trigger conversationsReconciliation
+ntn workers sync status conversationsReconciliation
+ntn workers sync resume conversationsSync
+```
+
+For Tickets, use `ticketsSync` and `ticketsReconciliation` in the same sequence.
 
 Every record is keyed by Intercom's immutable API `id`. The human-facing
 `ticket_id` is copied only as **Inbox Ticket ID** and is never used for API
@@ -97,7 +173,7 @@ queries.
 - Companies: plan, industry, website, employee/user/session counts, monthly
   spend, activity, tags, segments, and timestamps.
 - Contacts: identity, role, owner, email/phone, company relations, tags,
-  country, activity, and email restrictions.
+  association completeness, country, activity, and email restrictions.
 - Conversations: state, priority, contacts/company, assignment, channel, tags,
   SLA, CSAT, first/median reply time, handling time, last reply, reopens, and AI
   resolution. The page body contains a sanitized opening message and rating
@@ -148,14 +224,17 @@ format, so this example does not invent one.
 
 - Intercom permits only one active Company scroll per app, expires it after one
   idle minute, and may return the same scroll token for multiple distinct pages.
-  Do not overlap manual Company runs. The Worker detects repeated pages and
-  performs at most two safe restarts for expired or documented server-error
-  sessions.
+  Never overlap Company runs, previews, or deployments that share a private-app
+  token. The Worker detects expired/repeated pages, performs at most two full
+  restarts, and fails before replacement deletion if it cannot finish safely.
 - Company Scroll omits Companies with no associated users.
 - A Contact embeds at most ten Companies and ten Tags; those relation/tag lists
-  can therefore be partial when `has_more` is true.
+  can therefore be partial. Filter **Incomplete Associations** for affected
+  Contacts before relying on either list as exhaustive.
 - Ticket APIs can return `403 api_plan_restricted` when the workspace plan does
-  not include them.
+  not include them. Keep both Ticket capabilities paused in that case.
+- Ticket requests use pages of 20 because Intercom may include large
+  `ticket_parts` collections even though this example does not copy them.
 - Full transcripts are not copied; Intercom caps returned Conversation/Ticket
   parts and those parts may include internal or redacted content.
 
@@ -174,8 +253,9 @@ npm test
 npm run build
 ```
 
-For a live smoke test, preview each capability in the Quickstart order. Confirm
-that Company and Contact counts are plausible, relations resolve, a recently
-updated Conversation and Ticket appear after the consistency buffer, and no
-unexpected message or custom-attribute content is copied. Then run without
-`--preview` and compare a small sample against Intercom.
+For a live smoke test, follow the Quickstart's local-preview and paused-deploy
+flow. Confirm that the Company run reaches a terminal state, Company and Contact
+counts are plausible, relations resolve, and a recently updated Conversation
+and optional Ticket appear after the consistency buffer. Compare a small sample
+against Intercom and check **Incomplete Associations** before treating Contact
+relations or tags as exhaustive.

--- a/workers/intercom-sync/README.md
+++ b/workers/intercom-sync/README.md
@@ -5,8 +5,9 @@ four related databases—**Companies**, **Contacts**, **Conversations**, and
 **Tickets**—so support and customer-success teams can triage work, spot account
 risk, and understand service quality without assembling separate recipes.
 
-The sync is read-only. Intercom remains the system of record, and later syncs
-overwrite edits to managed properties in Notion.
+The Worker only reads from Intercom. It writes to managed Notion databases;
+Intercom remains the system of record, and later syncs overwrite edits to
+managed properties in Notion.
 
 ## Quickstart
 
@@ -16,7 +17,6 @@ and a token from a
 Grant only these permissions:
 
 - **Read and list users and companies**
-- **Read tags**
 - **Read conversations**
 - **Read admins**
 - **Read tickets**—only when you intend to sync Tickets
@@ -156,13 +156,13 @@ Conversations and Tickets. Each related property is visible from both sides.
 | `ticketsSync`                 | Tickets       | incremental | 5 min    | Deliver changed Tickets quickly with the same overlap strategy.       |
 | `ticketsReconciliation`       | Tickets       | replace     | manual   | Repair drift and remove Tickets no longer returned by Intercom.       |
 
-Incremental searches pin their upper timestamp across every page, sort by
-immutable Intercom ID, wait one minute for indexing, and replay a five-minute
-overlap. Manual replacement is still necessary because Intercom search cursors
-are not snapshots and deleted records do not appear in search results. Ticket
-replacement also aborts if Intercom's `total_count` changes or the completed
-sweep does not match it, preventing an incomplete run from removing Notion
-rows.
+Incremental searches pin their upper timestamp across every page, request and
+verify ascending order by immutable Intercom ID, wait one minute for indexing,
+and replay a five-minute overlap. Manual replacement is still necessary because
+Intercom search cursors are not snapshots and deleted records do not appear in
+search results. Conversation and Ticket replacements pin Intercom's
+`total_count` and abort if it changes or the completed sweep does not match it,
+so incomplete or count-drifting runs fail before replacement deletion.
 
 Trigger the manual reconciliations when you need to repair drift or remove
 deleted or newly hidden records, such as after an outage or access change.
@@ -216,7 +216,7 @@ before granting broader access, and store the Intercom token only with
 src/
 ├── index.ts          — database registration, schedules, pacing, and caches
 ├── intercom.ts       — regional Intercom client, API types, and lookups
-├── pagination.ts     — bounded starting_after cursor protection
+├── pagination.ts     — bounded cursor and record-order protection
 ├── companies.ts      — Company schema, transform, and scroll execution
 ├── contacts.ts       — Contact schema, transform, and replacement execution
 ├── conversations.ts  — Conversation schema, transform, windows, and execution
@@ -247,6 +247,10 @@ format, so this example does not invent one.
   token. The Worker detects expired/repeated pages, performs at most two full
   restarts, and fails before replacement deletion if it cannot finish safely.
 - Company Scroll omits Companies with no associated users.
+- Companies and Contacts use hourly replacement sweeps. Notion recommends
+  replacement for sources with fewer than roughly 10,000 records; above that,
+  validate runtime and API load, then lower the cadence or adapt the example
+  before production use.
 - A Contact embeds at most ten Companies and ten Tags; those relation/tag lists
   can therefore be partial. Filter **Incomplete Associations** for affected
   Contacts before relying on either list as exhaustive.

--- a/workers/intercom-sync/package.json
+++ b/workers/intercom-sync/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@notion-cookbook/intercom-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --project tsconfig.test.json",
+    "test": "tsx test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": "^0.4.0"
+  }
+}

--- a/workers/intercom-sync/src/companies.ts
+++ b/workers/intercom-sync/src/companies.ts
@@ -1,0 +1,214 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  IntercomApiError,
+  type IntercomClient,
+  type IntercomCompany,
+  type IntercomCompanyPage,
+} from "./intercom.js"
+import {
+  humanize,
+  nonEmpty,
+  optionalUnixSecondsToIso,
+  uniqueStrings,
+  unixSecondsToIso,
+} from "./helpers.js"
+import { advancePageGuard, type PaginationGuardState } from "./pagination.js"
+
+export const INITIAL_TITLE = "Intercom Companies"
+export const PRIMARY_KEY = "Company ID"
+
+export const companySchema = {
+  databaseIcon: notionIcon("briefcase"),
+  properties: {
+    Name: Schema.title(),
+
+    Plan: Schema.select([]),
+
+    Industry: Schema.select([]),
+
+    Website: Schema.url(),
+
+    Employees: Schema.number(),
+
+    Users: Schema.number(),
+
+    Sessions: Schema.number(),
+
+    "Monthly Spend": Schema.number(),
+
+    "Last Active": Schema.date(),
+
+    Tags: Schema.multiSelect([]),
+
+    Segments: Schema.multiSelect([]),
+
+    Updated: Schema.date(),
+
+    Created: Schema.date(),
+
+    "Created at Source": Schema.date(),
+
+    "External Company ID": Schema.richText(),
+
+    "Company ID": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+export type CompanySyncState = PaginationGuardState & {
+  scrollParameter: string
+  restartCount?: number
+}
+
+const MAX_SCROLL_RESTARTS = 2
+
+function companyId(company: IntercomCompany): string {
+  const id = nonEmpty(company.id)
+  if (!id) throw new Error("Intercom company is missing its id.")
+  return id
+}
+
+function finiteNumber(value: number | null | undefined): number | undefined {
+  return value != null && Number.isFinite(value) ? value : undefined
+}
+
+function normalizeWebsite(
+  value: string | null | undefined
+): string | undefined {
+  const website = nonEmpty(value)
+  if (!website) return undefined
+  const candidate = /^[a-z][a-z\d+.-]*:/i.test(website)
+    ? website
+    : `https://${website}`
+  try {
+    const url = new URL(candidate)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function namedValues(
+  values: Array<{ id?: string | null; name?: string | null }>
+): string[] {
+  return uniqueStrings(
+    values.map((value) => {
+      const id = nonEmpty(value.id)
+      return nonEmpty(value.name) ?? (id ? `Unknown (${id})` : undefined)
+    })
+  )
+}
+
+export function companyToChange(
+  company: IntercomCompany
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof companySchema.properties> {
+  const id = companyId(company)
+  const updated = unixSecondsToIso(company.updated_at, "Company updated_at")
+  const created = unixSecondsToIso(company.created_at, "Company created_at")
+  const sourceCreated = optionalUnixSecondsToIso(
+    company.remote_created_at,
+    "Company remote_created_at"
+  )
+  const lastActive = optionalUnixSecondsToIso(
+    company.last_request_at,
+    "Company last_request_at"
+  )
+  const plan = nonEmpty(company.plan?.name)
+  const industry = nonEmpty(company.industry)
+  const website = normalizeWebsite(company.website)
+  const employees = finiteNumber(company.size)
+  const users = finiteNumber(company.user_count)
+  const sessions = finiteNumber(company.session_count)
+  const monthlySpend = finiteNumber(company.monthly_spend)
+  const tags = namedValues(company.tags?.tags ?? [])
+  const segments = namedValues(company.segments?.segments ?? [])
+  const externalId = nonEmpty(company.company_id)
+
+  return {
+    type: "upsert",
+    key: id,
+    upstreamUpdatedAt: updated,
+    properties: {
+      Name: Builder.title(
+        nonEmpty(company.name) ?? externalId ?? `Company ${id}`
+      ),
+      Plan: plan ? Builder.select(plan) : [],
+      Industry: industry ? Builder.select(humanize(industry)) : [],
+      Website: website ? Builder.url(website) : [],
+      Employees: employees !== undefined ? Builder.number(employees) : [],
+      Users: users !== undefined ? Builder.number(users) : [],
+      Sessions: sessions !== undefined ? Builder.number(sessions) : [],
+      "Monthly Spend":
+        monthlySpend !== undefined ? Builder.number(monthlySpend) : [],
+      "Last Active": lastActive ? Builder.dateTime(lastActive) : [],
+      Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
+      Segments: segments.length > 0 ? Builder.multiSelect(...segments) : [],
+      Updated: Builder.dateTime(updated),
+      Created: Builder.dateTime(created),
+      "Created at Source": sourceCreated ? Builder.dateTime(sourceCreated) : [],
+      "External Company ID": externalId ? Builder.richText(externalId) : [],
+      "Company ID": Builder.richText(id),
+    },
+  }
+}
+
+export async function runCompaniesPage(
+  client: IntercomClient,
+  state: CompanySyncState | undefined
+) {
+  let page: IntercomCompanyPage
+  let restartCount = state?.restartCount ?? 0
+  let restarted = false
+  try {
+    page = await client.scrollCompanies(state?.scrollParameter)
+  } catch (error) {
+    const restartable =
+      state?.scrollParameter &&
+      error instanceof IntercomApiError &&
+      [400, 404, 500].includes(error.status)
+    if (!restartable || restartCount >= MAX_SCROLL_RESTARTS) throw error
+
+    // A scroll session expires after one idle minute, and Intercom documents
+    // some 500s as requiring a restart. Replaying earlier upserts is safe
+    // inside the same replacement cycle; bounded restarts prevent a loop.
+    restartCount++
+    restarted = true
+    page = await client.scrollCompanies()
+  }
+  const changes = page.records.map(companyToChange)
+
+  // Intercom terminates a company scroll with an empty data page. Its scroll
+  // token can stay constant while records advance, so guard on page identity.
+  if (page.records.length === 0) {
+    if (restarted && state?.pageCount) {
+      throw new Error(
+        "Intercom company scroll restarted into an empty collection; retry the replacement."
+      )
+    }
+    return { changes, hasMore: false as const }
+  }
+  if (!page.scrollParameter) {
+    throw new Error("Intercom company scroll is missing scroll_param.")
+  }
+
+  const first = companyId(page.records[0])
+  const last = companyId(page.records[page.records.length - 1])
+  const guard = advancePageGuard(
+    restarted ? undefined : state,
+    `${first}:${last}:${page.records.length}`,
+    "company scroll"
+  )
+  return {
+    changes,
+    hasMore: true as const,
+    nextState: {
+      scrollParameter: page.scrollParameter,
+      restartCount,
+      ...guard,
+    },
+  }
+}

--- a/workers/intercom-sync/src/companies.ts
+++ b/workers/intercom-sync/src/companies.ts
@@ -60,9 +60,48 @@ export const companySchema = {
 export type CompanySyncState = PaginationGuardState & {
   scrollParameter: string
   restartCount?: number
+  lastRequestAt?: number
 }
 
 const MAX_SCROLL_RESTARTS = 2
+// Intercom expires a Company Scroll after one idle minute. A small grace
+// avoids starting a replacement scroll while the previous one may still own
+// the app-wide single-scroll slot.
+export const COMPANY_SCROLL_RESTART_AFTER_MS = 65_000
+
+function clockMillis(now: () => Date): number {
+  const value = now().getTime()
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Intercom company sync clock is invalid.")
+  }
+  return value
+}
+
+function scrollExpired(
+  state: CompanySyncState | undefined,
+  nowMillis: number
+): boolean {
+  if (!state?.scrollParameter || state.lastRequestAt === undefined) return false
+  if (
+    !Number.isSafeInteger(state.lastRequestAt) ||
+    state.lastRequestAt < 0 ||
+    state.lastRequestAt > nowMillis
+  ) {
+    throw new Error("Intercom company scroll state has an invalid timestamp.")
+  }
+  return nowMillis - state.lastRequestAt >= COMPANY_SCROLL_RESTART_AFTER_MS
+}
+
+function restartableScrollError(error: unknown): boolean {
+  if (!(error instanceof IntercomApiError)) return false
+  if (error.status === 400 || error.status === 404) return true
+  return (
+    error.status === 500 &&
+    /internal network error[\s\S]*restart the scroll operation/i.test(
+      error.message
+    )
+  )
+}
 
 function companyId(company: IntercomCompany): string {
   const id = nonEmpty(company.id)
@@ -158,27 +197,48 @@ export function companyToChange(
 
 export async function runCompaniesPage(
   client: IntercomClient,
-  state: CompanySyncState | undefined
+  state: CompanySyncState | undefined,
+  now: () => Date = () => new Date()
 ) {
   let page: IntercomCompanyPage
   let restartCount = state?.restartCount ?? 0
   let restarted = false
-  try {
-    page = await client.scrollCompanies(state?.scrollParameter)
-  } catch (error) {
-    const restartable =
-      state?.scrollParameter &&
-      error instanceof IntercomApiError &&
-      [400, 404, 500].includes(error.status)
-    if (!restartable || restartCount >= MAX_SCROLL_RESTARTS) throw error
-
-    // A scroll session expires after one idle minute, and Intercom documents
-    // some 500s as requiring a restart. Replaying earlier upserts is safe
-    // inside the same replacement cycle; bounded restarts prevent a loop.
+  if (
+    !Number.isSafeInteger(restartCount) ||
+    restartCount < 0 ||
+    restartCount > MAX_SCROLL_RESTARTS
+  ) {
+    throw new Error(
+      "Intercom company scroll state has an invalid restart count."
+    )
+  }
+  const beforeRequest = clockMillis(now)
+  if (scrollExpired(state, beforeRequest)) {
+    if (restartCount >= MAX_SCROLL_RESTARTS) {
+      throw new Error(
+        "Intercom company scroll repeatedly expired between Worker continuations."
+      )
+    }
     restartCount++
     restarted = true
     page = await client.scrollCompanies()
+  } else {
+    try {
+      page = await client.scrollCompanies(state?.scrollParameter)
+    } catch (error) {
+      const restartable =
+        state?.scrollParameter && restartableScrollError(error)
+      if (!restartable || restartCount >= MAX_SCROLL_RESTARTS) throw error
+
+      // Some documented Company Scroll errors require a full restart.
+      // Replayed upserts are safe in the same replacement cycle, and the
+      // restart limit makes the cycle fail closed before Notion deletes rows.
+      restartCount++
+      restarted = true
+      page = await client.scrollCompanies()
+    }
   }
+  const lastRequestAt = clockMillis(now)
   const changes = page.records.map(companyToChange)
 
   // Intercom terminates a company scroll with an empty data page. Its scroll
@@ -208,6 +268,7 @@ export async function runCompaniesPage(
     nextState: {
       scrollParameter: page.scrollParameter,
       restartCount,
+      lastRequestAt,
       ...guard,
     },
   }

--- a/workers/intercom-sync/src/contacts.ts
+++ b/workers/intercom-sync/src/contacts.ts
@@ -43,6 +43,11 @@ export const contactSchema = {
 
     Tags: Schema.multiSelect([]),
 
+    "Incomplete Associations": Schema.multiSelect([
+      { name: "Companies" },
+      { name: "Tags" },
+    ]),
+
     "Last Seen": Schema.date(),
 
     "Signed Up": Schema.date(),
@@ -125,6 +130,29 @@ function emailRestrictions(contact: IntercomContact): string[] {
   ].filter((value): value is string => value !== undefined)
 }
 
+function incompleteAssociations(contact: IntercomContact): string[] {
+  const companies = contact.companies
+  const tags = contact.tags
+  const companiesIncomplete =
+    companies?.has_more === true ||
+    (Number.isSafeInteger(companies?.total_count) &&
+      (companies?.total_count ?? 0) > (companies?.data?.length ?? 0)) ||
+    (companies?.has_more == null &&
+      !Number.isSafeInteger(companies?.total_count) &&
+      (companies?.data?.length ?? 0) >= 10)
+  const tagsIncomplete =
+    tags?.has_more === true ||
+    (Number.isSafeInteger(tags?.total_count) &&
+      (tags?.total_count ?? 0) > (tags?.data?.length ?? 0)) ||
+    (tags?.has_more == null &&
+      !Number.isSafeInteger(tags?.total_count) &&
+      (tags?.data?.length ?? 0) >= 10)
+  return [
+    companiesIncomplete ? "Companies" : undefined,
+    tagsIncomplete ? "Tags" : undefined,
+  ].filter((value): value is string => value !== undefined)
+}
+
 export function contactToChange(
   contact: IntercomContact,
   directory: ContactDirectory
@@ -139,6 +167,7 @@ export function contactToChange(
   const companies = companyIds(contact)
   const country = nonEmpty(contact.location?.country)
   const tags = tagNames(contact, directory)
+  const incomplete = incompleteAssociations(contact)
   const lastSeen = optionalUnixSecondsToIso(
     contact.last_seen_at,
     "Contact last_seen_at"
@@ -172,6 +201,8 @@ export function contactToChange(
       Companies: companies.map((companyId) => Builder.relation(companyId)),
       Country: country ? Builder.select(country) : [],
       Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
+      "Incomplete Associations":
+        incomplete.length > 0 ? Builder.multiSelect(...incomplete) : [],
       "Last Seen": lastSeen ? Builder.dateTime(lastSeen) : [],
       "Signed Up": signedUp ? Builder.dateTime(signedUp) : [],
       "Last Contacted": lastContacted ? Builder.dateTime(lastContacted) : [],

--- a/workers/intercom-sync/src/contacts.ts
+++ b/workers/intercom-sync/src/contacts.ts
@@ -1,0 +1,206 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  type ContactDirectory,
+  type IntercomClient,
+  type IntercomContact,
+} from "./intercom.js"
+import {
+  humanize,
+  nonEmpty,
+  optionalUnixSecondsToIso,
+  uniqueStrings,
+  unixSecondsToIso,
+} from "./helpers.js"
+import { nextCursorState, type CursorSyncState } from "./pagination.js"
+
+export const INITIAL_TITLE = "Intercom Contacts"
+export const PRIMARY_KEY = "Contact ID"
+
+export const contactSchema = {
+  databaseIcon: notionIcon("people"),
+  properties: {
+    Name: Schema.title(),
+
+    Role: Schema.select([{ name: "User" }, { name: "Lead" }]),
+
+    Owner: Schema.richText(),
+
+    Updated: Schema.date(),
+
+    Email: Schema.email(),
+
+    Phone: Schema.phoneNumber(),
+
+    Companies: Schema.relation("companies", {
+      twoWay: true,
+      relatedPropertyName: "Contacts",
+    }),
+
+    Country: Schema.select([]),
+
+    Tags: Schema.multiSelect([]),
+
+    "Last Seen": Schema.date(),
+
+    "Signed Up": Schema.date(),
+
+    "Last Contacted": Schema.date(),
+
+    "Last Replied": Schema.date(),
+
+    "Email Restrictions": Schema.multiSelect([
+      { name: "Unsubscribed" },
+      { name: "Marked spam" },
+      { name: "Hard bounced" },
+    ]),
+
+    Created: Schema.date(),
+
+    "External ID": Schema.richText(),
+
+    "Contact ID": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+function contactName(contact: IntercomContact): string {
+  return (
+    nonEmpty(contact.name) ??
+    nonEmpty(contact.email) ??
+    nonEmpty(contact.phone) ??
+    nonEmpty(contact.external_id) ??
+    `Contact ${contact.id}`
+  )
+}
+
+function contactId(contact: IntercomContact): string {
+  const id = nonEmpty(contact.id)
+  if (!id) throw new Error("Intercom contact is missing its id.")
+  return id
+}
+
+function roleName(value: string | null | undefined): string | undefined {
+  const role = nonEmpty(value)
+  return role ? humanize(role) : undefined
+}
+
+function ownerName(
+  ownerId: string | number | null | undefined,
+  directory: ContactDirectory
+): string | undefined {
+  if (ownerId == null) return undefined
+  const id = String(ownerId).trim()
+  if (!id || id === "0") return undefined
+  return directory.admins.get(id) ?? `Unknown admin (${id})`
+}
+
+function companyIds(contact: IntercomContact): string[] {
+  return uniqueStrings(
+    (contact.companies?.data ?? []).map((company) => company.id ?? undefined)
+  )
+}
+
+function tagNames(
+  contact: IntercomContact,
+  directory: ContactDirectory
+): string[] {
+  return uniqueStrings(
+    (contact.tags?.data ?? []).map((tag) => {
+      const id = nonEmpty(tag.id)
+      return (
+        nonEmpty(tag.name) ??
+        (id ? (directory.tags.get(id) ?? `Unknown tag (${id})`) : undefined)
+      )
+    })
+  )
+}
+
+function emailRestrictions(contact: IntercomContact): string[] {
+  return [
+    contact.unsubscribed_from_emails ? "Unsubscribed" : undefined,
+    contact.marked_email_as_spam ? "Marked spam" : undefined,
+    contact.has_hard_bounced ? "Hard bounced" : undefined,
+  ].filter((value): value is string => value !== undefined)
+}
+
+export function contactToChange(
+  contact: IntercomContact,
+  directory: ContactDirectory
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof contactSchema.properties> {
+  const id = contactId(contact)
+  const updated = unixSecondsToIso(contact.updated_at, "Contact updated_at")
+  const created = unixSecondsToIso(contact.created_at, "Contact created_at")
+  const role = roleName(contact.role)
+  const owner = ownerName(contact.owner_id, directory)
+  const email = nonEmpty(contact.email)
+  const phone = nonEmpty(contact.phone)
+  const companies = companyIds(contact)
+  const country = nonEmpty(contact.location?.country)
+  const tags = tagNames(contact, directory)
+  const lastSeen = optionalUnixSecondsToIso(
+    contact.last_seen_at,
+    "Contact last_seen_at"
+  )
+  const signedUp = optionalUnixSecondsToIso(
+    contact.signed_up_at,
+    "Contact signed_up_at"
+  )
+  const lastContacted = optionalUnixSecondsToIso(
+    contact.last_contacted_at,
+    "Contact last_contacted_at"
+  )
+  const lastReplied = optionalUnixSecondsToIso(
+    contact.last_replied_at,
+    "Contact last_replied_at"
+  )
+  const restrictions = emailRestrictions(contact)
+  const externalId = nonEmpty(contact.external_id)
+
+  return {
+    type: "upsert",
+    key: id,
+    upstreamUpdatedAt: updated,
+    properties: {
+      Name: Builder.title(contactName(contact)),
+      Role: role ? Builder.select(role) : [],
+      Owner: owner ? Builder.richText(owner) : [],
+      Updated: Builder.dateTime(updated),
+      Email: email ? Builder.email(email) : [],
+      Phone: phone ? Builder.phoneNumber(phone) : [],
+      Companies: companies.map((companyId) => Builder.relation(companyId)),
+      Country: country ? Builder.select(country) : [],
+      Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
+      "Last Seen": lastSeen ? Builder.dateTime(lastSeen) : [],
+      "Signed Up": signedUp ? Builder.dateTime(signedUp) : [],
+      "Last Contacted": lastContacted ? Builder.dateTime(lastContacted) : [],
+      "Last Replied": lastReplied ? Builder.dateTime(lastReplied) : [],
+      "Email Restrictions":
+        restrictions.length > 0 ? Builder.multiSelect(...restrictions) : [],
+      Created: Builder.dateTime(created),
+      "External ID": externalId ? Builder.richText(externalId) : [],
+      "Contact ID": Builder.richText(id),
+    },
+  }
+}
+
+export async function runContactsPage(
+  client: IntercomClient,
+  directory: ContactDirectory,
+  state: CursorSyncState | undefined
+) {
+  const page = await client.listContacts(state?.after)
+  const changes = page.records.map((contact) =>
+    contactToChange(contact, directory)
+  )
+
+  if (page.nextCursor) {
+    return {
+      changes,
+      hasMore: true as const,
+      nextState: nextCursorState(state, page.nextCursor, "contacts"),
+    }
+  }
+  return { changes, hasMore: false as const }
+}

--- a/workers/intercom-sync/src/conversations.ts
+++ b/workers/intercom-sync/src/conversations.ts
@@ -18,6 +18,7 @@ import {
   unixSecondsToIso,
 } from "./helpers.js"
 import {
+  lastAscendingRecordId,
   nextCursorState,
   validatedPageCount,
   validatedRecentCursors,
@@ -308,6 +309,13 @@ export type ConversationIncrementalState = {
   after?: string
   recentCursors?: string[]
   pageCount?: number
+  lastRecordId?: string
+}
+
+export type ConversationReconciliationState = CursorSyncState & {
+  expectedTotalCount: number
+  seenCount: number
+  recentRecordIds: string[]
 }
 
 export const INITIAL_CONVERSATION_WATERMARK = 0
@@ -373,20 +381,48 @@ export async function runConversationIncrementalPage(
   state: ConversationIncrementalState | undefined,
   now: () => Date = () => new Date()
 ) {
-  const { since, until } = conversationIncrementalWindow(state, now)
-  const page = await client.searchConversations(since, until, state?.after)
+  // State written before record-order checkpoints existed cannot prove the
+  // ordering across its next page. Restarting the window is safe because
+  // incremental changes are keyed upserts and the overlap already permits
+  // replay.
+  const effectiveState =
+    state?.after && state.lastRecordId === undefined
+      ? { since: state.since }
+      : state
+  const { since, until } = conversationIncrementalWindow(effectiveState, now)
+  const page = await client.searchConversations(
+    since,
+    until,
+    effectiveState?.after
+  )
+  const recordIds = page.records.map(conversationId)
+  const lastRecordId = lastAscendingRecordId(
+    recordIds,
+    effectiveState?.lastRecordId,
+    "conversation search"
+  )
   const changes = page.records.map((conversation) =>
     conversationToChange(conversation, directory)
   )
 
   if (page.nextCursor) {
+    if (recordIds.length === 0 || lastRecordId === undefined) {
+      throw new Error(
+        "Intercom conversation search returned a cursor without records."
+      )
+    }
     return {
       changes,
       hasMore: true as const,
       nextState: {
         since,
         until,
-        ...nextCursorState(state, page.nextCursor, "conversation search"),
+        ...nextCursorState(
+          effectiveState,
+          page.nextCursor,
+          "conversation search"
+        ),
+        lastRecordId,
       },
     }
   }
@@ -398,26 +434,112 @@ export async function runConversationIncrementalPage(
   }
 }
 
+const MAX_RECENT_CONVERSATION_IDS = 300
+
+function expectedConversationCount(
+  value: number | undefined,
+  state: ConversationReconciliationState | undefined
+): number {
+  if (!Number.isSafeInteger(value) || value == null || value < 0) {
+    throw new Error(
+      "Intercom conversation reconciliation has an invalid total_count."
+    )
+  }
+  if (state && state.expectedTotalCount !== value) {
+    throw new Error(
+      "Intercom conversation total changed during replacement; retry the full sweep."
+    )
+  }
+  return value
+}
+
 export async function runConversationReconciliationPage(
   client: IntercomClient,
   directory: AssignmentDirectory,
-  state: CursorSyncState | undefined
+  state: ConversationReconciliationState | undefined
 ) {
-  const page = await client.listConversations(state?.after)
+  // A deployment can resume state written before reconciliation guards were
+  // added. Restart that sweep from page one; keyed upserts make replay safe,
+  // while completing from unverified state could make replace deletion unsafe.
+  const guardState = state as
+    | (Partial<ConversationReconciliationState> &
+        Pick<CursorSyncState, "after">)
+    | undefined
+  const effectiveState =
+    guardState?.after &&
+    (guardState.expectedTotalCount === undefined ||
+      guardState.seenCount === undefined ||
+      guardState.recentRecordIds === undefined)
+      ? undefined
+      : state
+  const page = await client.listConversations(effectiveState?.after)
+  const totalCount = expectedConversationCount(page.totalCount, effectiveState)
+  const recentRecordIds = effectiveState?.recentRecordIds ?? []
+  if (
+    !Array.isArray(recentRecordIds) ||
+    recentRecordIds.length > MAX_RECENT_CONVERSATION_IDS ||
+    recentRecordIds.some((id) => typeof id !== "string" || !id.trim())
+  ) {
+    throw new Error(
+      "Intercom conversation reconciliation has invalid recent record state."
+    )
+  }
+  const previousSeenCount = effectiveState?.seenCount ?? 0
+  if (
+    !Number.isSafeInteger(previousSeenCount) ||
+    previousSeenCount < 0 ||
+    previousSeenCount > totalCount
+  ) {
+    throw new Error(
+      "Intercom conversation reconciliation has invalid seen record state."
+    )
+  }
+
+  const recordIds = page.records.map(conversationId)
+  const seenRecordIds = new Set(recentRecordIds)
+  for (const id of recordIds) {
+    if (seenRecordIds.has(id)) {
+      throw new Error("Intercom conversation reconciliation repeated a record.")
+    }
+    seenRecordIds.add(id)
+  }
   const changes = page.records.map((conversation) =>
     conversationToChange(conversation, directory)
   )
+  const seenCount = previousSeenCount + page.records.length
+  if (seenCount > totalCount) {
+    throw new Error(
+      "Intercom conversation reconciliation returned more records than total_count."
+    )
+  }
 
   if (page.nextCursor) {
+    if (recordIds.length === 0) {
+      throw new Error(
+        "Intercom conversation reconciliation returned a cursor without records."
+      )
+    }
     return {
       changes,
       hasMore: true as const,
-      nextState: nextCursorState(
-        state,
-        page.nextCursor,
-        "conversation reconciliation"
-      ),
+      nextState: {
+        ...nextCursorState(
+          effectiveState,
+          page.nextCursor,
+          "conversation reconciliation"
+        ),
+        expectedTotalCount: totalCount,
+        seenCount,
+        recentRecordIds: [...recentRecordIds, ...recordIds].slice(
+          -MAX_RECENT_CONVERSATION_IDS
+        ),
+      },
     }
+  }
+  if (seenCount !== totalCount) {
+    throw new Error(
+      "Intercom conversation replacement ended before total_count was reached."
+    )
   }
   return { changes, hasMore: false as const }
 }

--- a/workers/intercom-sync/src/conversations.ts
+++ b/workers/intercom-sync/src/conversations.ts
@@ -1,0 +1,423 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  type AssignmentDirectory,
+  type IntercomClient,
+  type IntercomConversation,
+} from "./intercom.js"
+import {
+  escapeMarkdown,
+  htmlToPlainText,
+  humanize,
+  nonEmpty,
+  optionalUnixSecondsToIso,
+  secondsToMinutes,
+  uniqueStrings,
+  unixSecondsToIso,
+} from "./helpers.js"
+import {
+  nextCursorState,
+  validatedPageCount,
+  validatedRecentCursors,
+  type CursorSyncState,
+} from "./pagination.js"
+
+export const INITIAL_TITLE = "Intercom Conversations"
+export const PRIMARY_KEY = "Conversation ID"
+
+export const conversationSchema = {
+  databaseIcon: notionIcon("chat"),
+  properties: {
+    Title: Schema.title(),
+
+    State: Schema.select([
+      { name: "Open" },
+      { name: "Closed" },
+      { name: "Snoozed" },
+    ]),
+
+    Priority: Schema.checkbox(),
+
+    Unread: Schema.checkbox(),
+
+    Contacts: Schema.relation("contacts", {
+      twoWay: true,
+      relatedPropertyName: "Conversations",
+    }),
+
+    Assignee: Schema.richText(),
+
+    Team: Schema.richText(),
+
+    Updated: Schema.date(),
+
+    "Waiting Since": Schema.date(),
+
+    Channel: Schema.select([]),
+
+    Tags: Schema.multiSelect([]),
+
+    "SLA Status": Schema.select([
+      { name: "Active" },
+      { name: "Hit" },
+      { name: "Missed" },
+      { name: "Cancelled" },
+    ]),
+
+    Rating: Schema.number(),
+
+    Company: Schema.relation("companies", {
+      twoWay: true,
+      relatedPropertyName: "Conversations",
+    }),
+
+    "First Reply (min)": Schema.number(),
+
+    "Median Reply (min)": Schema.number(),
+
+    "Handling Time (min)": Schema.number(),
+
+    "Last Contact Reply": Schema.date(),
+
+    Reopens: Schema.number(),
+
+    "AI Resolution": Schema.select([
+      { name: "Assumed Resolution" },
+      { name: "Confirmed Resolution" },
+      { name: "Escalated" },
+      { name: "Negative Feedback" },
+      { name: "Procedure Handoff" },
+    ]),
+
+    "Snoozed Until": Schema.date(),
+
+    Created: Schema.date(),
+
+    "Conversation ID": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+const CHANNEL_NAMES: Record<string, string> = {
+  conversation: "Messenger",
+  email: "Email",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  phone_call: "Phone call",
+  phone_switch: "Phone switch",
+  push: "Push",
+  sms: "SMS",
+  twitter: "Twitter",
+  whatsapp: "WhatsApp",
+}
+
+function boundedTitle(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim()
+  return normalized.length > 200
+    ? `${normalized.slice(0, 197).trimEnd()}...`
+    : normalized
+}
+
+function conversationId(conversation: IntercomConversation): string {
+  const id = nonEmpty(conversation.id)
+  if (!id) throw new Error("Intercom conversation is missing its id.")
+  return id
+}
+
+export function conversationTitle(conversation: IntercomConversation): string {
+  const title = nonEmpty(conversation.title)
+  if (title) return boundedTitle(title)
+
+  const subject = nonEmpty(conversation.source?.subject)
+  if (subject) return boundedTitle(subject)
+
+  if (!conversation.source?.redacted) {
+    const body = htmlToPlainText(conversation.source?.body)
+    if (body) return boundedTitle(body)
+  }
+
+  return `Conversation ${conversationId(conversation)}`
+}
+
+export function conversationPageContent(
+  conversation: IntercomConversation
+): string {
+  const sections: string[] = []
+
+  if (conversation.source?.redacted) {
+    sections.push(
+      "## Opening message\n\n_This opening message was redacted in Intercom._"
+    )
+  } else {
+    const body = htmlToPlainText(conversation.source?.body)
+    if (body) sections.push(`## Opening message\n\n${escapeMarkdown(body)}`)
+  }
+
+  const ratingRemark = nonEmpty(conversation.conversation_rating?.remark)
+  if (ratingRemark) {
+    sections.push(
+      `## Customer rating comment\n\n${escapeMarkdown(ratingRemark)}`
+    )
+  }
+
+  return sections.join("\n\n")
+}
+
+function contactIds(conversation: IntercomConversation): string[] {
+  return uniqueStrings(
+    (conversation.contacts?.contacts ?? []).map(
+      (contact) => contact.id ?? undefined
+    )
+  )
+}
+
+function lookupName(
+  lookup: Map<string, string>,
+  id: string | number | null | undefined,
+  kind: "admin" | "team"
+): string | undefined {
+  if (id == null) return undefined
+  const normalized = String(id).trim()
+  if (!normalized || normalized === "0") return undefined
+  return lookup.get(normalized) ?? `Unknown ${kind} (${normalized})`
+}
+
+function channelName(value: string | null | undefined): string | undefined {
+  const channel = nonEmpty(value)
+  return channel ? (CHANNEL_NAMES[channel] ?? humanize(channel)) : undefined
+}
+
+function tagNames(conversation: IntercomConversation): string[] {
+  return uniqueStrings(
+    (conversation.tags?.tags ?? []).map((tag) => {
+      const id = nonEmpty(tag.id)
+      return nonEmpty(tag.name) ?? (id ? `Unknown tag (${id})` : undefined)
+    })
+  )
+}
+
+function finiteNumber(value: number | null | undefined): number | undefined {
+  return value != null && Number.isFinite(value) ? value : undefined
+}
+
+export function conversationToChange(
+  conversation: IntercomConversation,
+  directory: AssignmentDirectory
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof conversationSchema.properties> {
+  const id = conversationId(conversation)
+  const updated = unixSecondsToIso(
+    conversation.updated_at,
+    "Conversation updated_at"
+  )
+  const created = unixSecondsToIso(
+    conversation.created_at,
+    "Conversation created_at"
+  )
+  const state = nonEmpty(conversation.state)
+  const contacts = contactIds(conversation)
+  const assignee = lookupName(
+    directory.admins,
+    conversation.admin_assignee_id,
+    "admin"
+  )
+  const team = lookupName(
+    directory.teams,
+    conversation.team_assignee_id,
+    "team"
+  )
+  const waitingSince = optionalUnixSecondsToIso(
+    conversation.waiting_since,
+    "Conversation waiting_since"
+  )
+  const channel = channelName(conversation.source?.type)
+  const tags = tagNames(conversation)
+  const slaStatus = nonEmpty(conversation.sla_applied?.sla_status)
+  const rating = finiteNumber(conversation.conversation_rating?.rating)
+  const companyId = nonEmpty(conversation.company?.id)
+  const firstReplyMinutes = secondsToMinutes(
+    conversation.statistics?.time_to_admin_reply
+  )
+  const medianReplyMinutes = secondsToMinutes(
+    conversation.statistics?.median_time_to_reply
+  )
+  const handlingTimeMinutes = secondsToMinutes(
+    conversation.statistics?.adjusted_handling_time ??
+      conversation.statistics?.handling_time
+  )
+  const lastContactReply = optionalUnixSecondsToIso(
+    conversation.statistics?.last_contact_reply_at,
+    "Conversation statistics.last_contact_reply_at"
+  )
+  const reopens = finiteNumber(conversation.statistics?.count_reopens)
+  const aiResolution = nonEmpty(conversation.ai_agent?.resolution_state)
+  const snoozedUntil = optionalUnixSecondsToIso(
+    conversation.snoozed_until,
+    "Conversation snoozed_until"
+  )
+
+  return {
+    type: "upsert",
+    key: id,
+    upstreamUpdatedAt: updated,
+    pageContentMarkdown: conversationPageContent(conversation),
+    properties: {
+      Title: Builder.title(conversationTitle(conversation)),
+      State: state ? Builder.select(humanize(state)) : [],
+      Priority: Builder.checkbox(conversation.priority === "priority"),
+      Unread: Builder.checkbox(conversation.read === false),
+      Contacts: contacts.map((contactId) => Builder.relation(contactId)),
+      Assignee: assignee ? Builder.richText(assignee) : [],
+      Team: team ? Builder.richText(team) : [],
+      Updated: Builder.dateTime(updated),
+      "Waiting Since": waitingSince ? Builder.dateTime(waitingSince) : [],
+      Channel: channel ? Builder.select(channel) : [],
+      Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
+      "SLA Status": slaStatus ? Builder.select(humanize(slaStatus)) : [],
+      Rating: rating !== undefined ? Builder.number(rating) : [],
+      Company: companyId ? [Builder.relation(companyId)] : [],
+      "First Reply (min)":
+        firstReplyMinutes !== undefined
+          ? Builder.number(firstReplyMinutes)
+          : [],
+      "Median Reply (min)":
+        medianReplyMinutes !== undefined
+          ? Builder.number(medianReplyMinutes)
+          : [],
+      "Handling Time (min)":
+        handlingTimeMinutes !== undefined
+          ? Builder.number(handlingTimeMinutes)
+          : [],
+      "Last Contact Reply": lastContactReply
+        ? Builder.dateTime(lastContactReply)
+        : [],
+      Reopens: reopens !== undefined ? Builder.number(reopens) : [],
+      "AI Resolution": aiResolution
+        ? Builder.select(humanize(aiResolution))
+        : [],
+      "Snoozed Until": snoozedUntil ? Builder.dateTime(snoozedUntil) : [],
+      Created: Builder.dateTime(created),
+      "Conversation ID": Builder.richText(id),
+    },
+  }
+}
+
+export type ConversationIncrementalState = {
+  since: number
+  until?: number
+  after?: string
+  recentCursors?: string[]
+  pageCount?: number
+}
+
+export const INITIAL_CONVERSATION_WATERMARK = 0
+export const CONSISTENCY_BUFFER_SECONDS = 60
+export const WATERMARK_OVERLAP_SECONDS = 5 * 60
+
+function unixSeconds(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(
+      `${label} must be a non-negative Unix timestamp in seconds.`
+    )
+  }
+  return value
+}
+
+export function conversationIncrementalWindow(
+  state: ConversationIncrementalState | undefined,
+  now: () => Date = () => new Date()
+): { since: number; until: number } {
+  const since = unixSeconds(
+    state?.since ?? INITIAL_CONVERSATION_WATERMARK,
+    "Intercom conversation state.since"
+  )
+
+  if (state?.after && state.until === undefined) {
+    throw new Error(
+      "Intercom paginated conversation state is missing its pinned until."
+    )
+  }
+  if (!state?.after && state?.until !== undefined) {
+    throw new Error(
+      "Intercom conversation state has until without a pagination cursor."
+    )
+  }
+  validatedRecentCursors(state?.recentCursors)
+  validatedPageCount(state?.pageCount)
+
+  const nowSeconds = Math.floor(now().getTime() / 1_000)
+  if (!Number.isSafeInteger(nowSeconds) || nowSeconds < 0) {
+    throw new Error("Intercom conversation sync clock is invalid.")
+  }
+  const until = unixSeconds(
+    state?.until ?? Math.max(since, nowSeconds - CONSISTENCY_BUFFER_SECONDS),
+    "Intercom conversation state.until"
+  )
+  if (until < since) {
+    throw new Error("Intercom conversation sync window ends before it starts.")
+  }
+  return { since, until }
+}
+
+export function nextConversationWatermark(until: number): number {
+  return Math.max(
+    INITIAL_CONVERSATION_WATERMARK,
+    unixSeconds(until, "Intercom conversation watermark") -
+      WATERMARK_OVERLAP_SECONDS
+  )
+}
+
+export async function runConversationIncrementalPage(
+  client: IntercomClient,
+  directory: AssignmentDirectory,
+  state: ConversationIncrementalState | undefined,
+  now: () => Date = () => new Date()
+) {
+  const { since, until } = conversationIncrementalWindow(state, now)
+  const page = await client.searchConversations(since, until, state?.after)
+  const changes = page.records.map((conversation) =>
+    conversationToChange(conversation, directory)
+  )
+
+  if (page.nextCursor) {
+    return {
+      changes,
+      hasMore: true as const,
+      nextState: {
+        since,
+        until,
+        ...nextCursorState(state, page.nextCursor, "conversation search"),
+      },
+    }
+  }
+
+  return {
+    changes,
+    hasMore: false as const,
+    nextState: { since: nextConversationWatermark(until) },
+  }
+}
+
+export async function runConversationReconciliationPage(
+  client: IntercomClient,
+  directory: AssignmentDirectory,
+  state: CursorSyncState | undefined
+) {
+  const page = await client.listConversations(state?.after)
+  const changes = page.records.map((conversation) =>
+    conversationToChange(conversation, directory)
+  )
+
+  if (page.nextCursor) {
+    return {
+      changes,
+      hasMore: true as const,
+      nextState: nextCursorState(
+        state,
+        page.nextCursor,
+        "conversation reconciliation"
+      ),
+    }
+  }
+  return { changes, hasMore: false as const }
+}

--- a/workers/intercom-sync/src/helpers.ts
+++ b/workers/intercom-sync/src/helpers.ts
@@ -1,0 +1,120 @@
+const MAX_HTML_INPUT_LENGTH = 100_000
+const MAX_PAGE_TEXT_LENGTH = 20_000
+
+export function nonEmpty(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+export function unixSecondsToIso(value: number, label: string): string {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(
+      `${label} must be a non-negative Unix timestamp in seconds.`
+    )
+  }
+
+  const date = new Date(value * 1_000)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${label} must be a valid Unix timestamp in seconds.`)
+  }
+  return date.toISOString()
+}
+
+export function optionalUnixSecondsToIso(
+  value: number | null | undefined,
+  label: string
+): string | undefined {
+  return value == null || value === 0
+    ? undefined
+    : unixSecondsToIso(value, label)
+}
+
+export function secondsToMinutes(
+  value: number | null | undefined
+): number | undefined {
+  if (value == null || !Number.isFinite(value) || value < 0) return undefined
+  return Math.round((value / 60) * 100) / 100
+}
+
+export function humanize(value: string): string {
+  return value
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function decodeEntity(entity: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  }
+  const normalized = entity.toLowerCase()
+  if (named[normalized] !== undefined) return named[normalized]
+
+  const hexadecimal = normalized.startsWith("#x")
+  const decimal = normalized.startsWith("#")
+  if (!hexadecimal && !decimal) return `&${entity};`
+
+  const parsed = Number.parseInt(
+    entity.slice(hexadecimal ? 2 : 1),
+    hexadecimal ? 16 : 10
+  )
+  try {
+    return Number.isInteger(parsed) && parsed >= 0
+      ? String.fromCodePoint(parsed)
+      : `&${entity};`
+  } catch {
+    return `&${entity};`
+  }
+}
+
+export function htmlToPlainText(value: string | null | undefined): string {
+  // Remove hidden blocks before bounding the input so truncation cannot cut a
+  // closing tag and accidentally expose script or style content as text.
+  const html = (value ?? "")
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, " ")
+    .slice(0, MAX_HTML_INPUT_LENGTH)
+  return html
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(
+      /<\/(?:address|article|aside|blockquote|div|h[1-6]|li|p|pre|section|table|tr)\s*>/gi,
+      "\n"
+    )
+    .replace(/<li\b[^>]*>/gi, "• ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&([#a-zA-Z0-9]+);/g, (_match, entity: string) =>
+      decodeEntity(entity)
+    )
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\t\f\v ]+/g, " ")
+    .replace(/ +([,.;:!?])/g, "$1")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+    .slice(0, MAX_PAGE_TEXT_LENGTH)
+}
+
+export function escapeMarkdown(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/([`*_{}\[\]()<>#+.!|])/g, "\\$1")
+    .replace(/^([>-])/gm, "\\$1")
+}
+
+export function uniqueStrings(values: Array<string | undefined>): string[] {
+  const result: string[] = []
+  const seen = new Set<string>()
+  for (const value of values) {
+    const normalized = nonEmpty(value)
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized)
+      result.push(normalized)
+    }
+  }
+  return result
+}

--- a/workers/intercom-sync/src/index.ts
+++ b/workers/intercom-sync/src/index.ts
@@ -1,6 +1,7 @@
 // Entry point — registers one connected Intercom support workspace in Notion.
 // Resource modules own their transforms and pagination behavior; this file
-// keeps only database registration, schedules, pacing, and cycle caches.
+// keeps only database registration, schedules, pacing, and process-local lookup
+// caches.
 
 import { Worker } from "@notionhq/workers"
 
@@ -76,8 +77,10 @@ export function createCycleCache<T>(): CycleCache<T> {
   }
 }
 
-// Each capability gets its own lookup cache. A directory is fetched once for a
-// multi-page cycle, retained across retries, and discarded only on completion.
+// Each capability gets its own process-local lookup cache. A warm process can
+// reuse a directory across continuation pages or retries, but correctness never
+// depends on that memory: a cold invocation refetches it. Terminal pages clear
+// the cached value so the next cycle sees current lookup data.
 const contactDirectories = createCycleCache<ContactDirectory>()
 const incrementalConversationDirectories =
   createCycleCache<AssignmentDirectory>()

--- a/workers/intercom-sync/src/index.ts
+++ b/workers/intercom-sync/src/index.ts
@@ -148,7 +148,7 @@ const conversations = worker.database("conversations", {
 worker.sync("conversationsSync", {
   database: conversations,
   mode: "incremental",
-  schedule: "2m",
+  schedule: "5m",
   execute: async (state: ConversationIncrementalState | undefined) => {
     if (!state?.after) incrementalConversationDirectories.clear()
     const client = createClient()
@@ -168,7 +168,7 @@ worker.sync("conversationsSync", {
 worker.sync("conversationsReconciliation", {
   database: conversations,
   mode: "replace",
-  schedule: "1d",
+  schedule: "manual",
   execute: async (state: CursorSyncState | undefined) => {
     if (!state) reconciliationConversationDirectories.clear()
     const client = createClient()
@@ -186,8 +186,8 @@ worker.sync("conversationsReconciliation", {
 })
 
 // ---------------------------------------------------------------------------
-// Tickets — optional in Intercom plans, but included in the same deploy so a
-// support team can copy one complete bundle and remove this block if unused.
+// Tickets — optional in Intercom plans, but included in the same deploy. Keep
+// the scheduled sync paused and do not trigger reconciliation without access.
 // ---------------------------------------------------------------------------
 
 const tickets = worker.database("tickets", {
@@ -200,7 +200,7 @@ const tickets = worker.database("tickets", {
 worker.sync("ticketsSync", {
   database: tickets,
   mode: "incremental",
-  schedule: "2m",
+  schedule: "5m",
   execute: async (state: TicketIncrementalState | undefined) => {
     if (!state?.after) incrementalTicketDirectories.clear()
     const client = createClient()
@@ -216,7 +216,7 @@ worker.sync("ticketsSync", {
 worker.sync("ticketsReconciliation", {
   database: tickets,
   mode: "replace",
-  schedule: "1d",
+  schedule: "manual",
   execute: async (state: TicketReconciliationState | undefined) => {
     if (!state) reconciliationTicketDirectories.clear()
     const client = createClient()

--- a/workers/intercom-sync/src/index.ts
+++ b/workers/intercom-sync/src/index.ts
@@ -1,0 +1,232 @@
+// Entry point — registers one connected Intercom support workspace in Notion.
+// Resource modules own their transforms and pagination behavior; this file
+// keeps only database registration, schedules, pacing, and cycle caches.
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  INITIAL_TITLE as COMPANIES_TITLE,
+  PRIMARY_KEY as COMPANIES_PK,
+  companySchema,
+  runCompaniesPage,
+  type CompanySyncState,
+} from "./companies.js"
+import {
+  INITIAL_TITLE as CONTACTS_TITLE,
+  PRIMARY_KEY as CONTACTS_PK,
+  contactSchema,
+  runContactsPage,
+} from "./contacts.js"
+import {
+  INITIAL_TITLE as CONVERSATIONS_TITLE,
+  PRIMARY_KEY as CONVERSATIONS_PK,
+  conversationSchema,
+  runConversationIncrementalPage,
+  runConversationReconciliationPage,
+  type ConversationIncrementalState,
+} from "./conversations.js"
+import {
+  createIntercomClient,
+  type AssignmentDirectory,
+  type ContactDirectory,
+} from "./intercom.js"
+import {
+  INITIAL_TITLE as TICKETS_TITLE,
+  PRIMARY_KEY as TICKETS_PK,
+  runTicketIncrementalPage,
+  runTicketReconciliationPage,
+  ticketSchema,
+  type TicketIncrementalState,
+  type TicketReconciliationState,
+} from "./tickets.js"
+import type { CursorSyncState } from "./pagination.js"
+
+const worker = new Worker()
+
+// Intercom applies app-wide quotas in ten-second windows. This shared pacer
+// leaves headroom below the default quota; HTTP 429 responses also surface the
+// provider's reset time through RateLimitError.
+const pacer = worker.pacer("intercom", {
+  allowedRequests: 1_000,
+  intervalMs: 10_000,
+})
+const createClient = () => createIntercomClient(() => pacer.wait())
+
+type CycleCache<T> = {
+  get(load: () => Promise<T>): Promise<T>
+  clear(): void
+}
+
+export function createCycleCache<T>(): CycleCache<T> {
+  let current: Promise<T> | undefined
+  return {
+    get(load) {
+      if (current) return current
+
+      const request = load().catch((error: unknown) => {
+        if (current === request) current = undefined
+        throw error
+      })
+      current = request
+      return request
+    },
+    clear() {
+      current = undefined
+    },
+  }
+}
+
+// Each capability gets its own lookup cache. A directory is fetched once for a
+// multi-page cycle, retained across retries, and discarded only on completion.
+const contactDirectories = createCycleCache<ContactDirectory>()
+const incrementalConversationDirectories =
+  createCycleCache<AssignmentDirectory>()
+const reconciliationConversationDirectories =
+  createCycleCache<AssignmentDirectory>()
+const incrementalTicketDirectories = createCycleCache<AssignmentDirectory>()
+const reconciliationTicketDirectories = createCycleCache<AssignmentDirectory>()
+
+// ---------------------------------------------------------------------------
+// Companies — the only capability that owns Intercom's single active company
+// scroll. Contacts and Conversations relate to these records by immutable ID.
+// ---------------------------------------------------------------------------
+
+const companies = worker.database("companies", {
+  type: "managed",
+  initialTitle: COMPANIES_TITLE,
+  primaryKeyProperty: COMPANIES_PK,
+  schema: companySchema,
+})
+
+worker.sync("companiesSync", {
+  database: companies,
+  mode: "replace",
+  schedule: "1h",
+  execute: (state: CompanySyncState | undefined) =>
+    runCompaniesPage(createClient(), state),
+})
+
+// ---------------------------------------------------------------------------
+// Contacts — a full replacement avoids unsafe day-granularity search cursors
+// and removes contacts that were merged or are no longer visible.
+// ---------------------------------------------------------------------------
+
+const contacts = worker.database("contacts", {
+  type: "managed",
+  initialTitle: CONTACTS_TITLE,
+  primaryKeyProperty: CONTACTS_PK,
+  schema: contactSchema,
+})
+
+worker.sync("contactsSync", {
+  database: contacts,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state: CursorSyncState | undefined) => {
+    if (!state) contactDirectories.clear()
+    const client = createClient()
+    const directory = await contactDirectories.get(() =>
+      client.fetchContactDirectory()
+    )
+    const result = await runContactsPage(client, directory, state)
+    if (!result.hasMore) contactDirectories.clear()
+    return result
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Conversations — Contact IDs become relations to the Contacts database.
+// ---------------------------------------------------------------------------
+
+const conversations = worker.database("conversations", {
+  type: "managed",
+  initialTitle: CONVERSATIONS_TITLE,
+  primaryKeyProperty: CONVERSATIONS_PK,
+  schema: conversationSchema,
+})
+
+worker.sync("conversationsSync", {
+  database: conversations,
+  mode: "incremental",
+  schedule: "2m",
+  execute: async (state: ConversationIncrementalState | undefined) => {
+    if (!state?.after) incrementalConversationDirectories.clear()
+    const client = createClient()
+    const directory = await incrementalConversationDirectories.get(() =>
+      client.fetchAssignmentDirectory()
+    )
+    const result = await runConversationIncrementalPage(
+      client,
+      directory,
+      state
+    )
+    if (!result.hasMore) incrementalConversationDirectories.clear()
+    return result
+  },
+})
+
+worker.sync("conversationsReconciliation", {
+  database: conversations,
+  mode: "replace",
+  schedule: "1d",
+  execute: async (state: CursorSyncState | undefined) => {
+    if (!state) reconciliationConversationDirectories.clear()
+    const client = createClient()
+    const directory = await reconciliationConversationDirectories.get(() =>
+      client.fetchAssignmentDirectory()
+    )
+    const result = await runConversationReconciliationPage(
+      client,
+      directory,
+      state
+    )
+    if (!result.hasMore) reconciliationConversationDirectories.clear()
+    return result
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Tickets — optional in Intercom plans, but included in the same deploy so a
+// support team can copy one complete bundle and remove this block if unused.
+// ---------------------------------------------------------------------------
+
+const tickets = worker.database("tickets", {
+  type: "managed",
+  initialTitle: TICKETS_TITLE,
+  primaryKeyProperty: TICKETS_PK,
+  schema: ticketSchema,
+})
+
+worker.sync("ticketsSync", {
+  database: tickets,
+  mode: "incremental",
+  schedule: "2m",
+  execute: async (state: TicketIncrementalState | undefined) => {
+    if (!state?.after) incrementalTicketDirectories.clear()
+    const client = createClient()
+    const directory = await incrementalTicketDirectories.get(() =>
+      client.fetchAssignmentDirectory()
+    )
+    const result = await runTicketIncrementalPage(client, directory, state)
+    if (!result.hasMore) incrementalTicketDirectories.clear()
+    return result
+  },
+})
+
+worker.sync("ticketsReconciliation", {
+  database: tickets,
+  mode: "replace",
+  schedule: "1d",
+  execute: async (state: TicketReconciliationState | undefined) => {
+    if (!state) reconciliationTicketDirectories.clear()
+    const client = createClient()
+    const directory = await reconciliationTicketDirectories.get(() =>
+      client.fetchAssignmentDirectory()
+    )
+    const result = await runTicketReconciliationPage(client, directory, state)
+    if (!result.hasMore) reconciliationTicketDirectories.clear()
+    return result
+  },
+})
+
+export default worker

--- a/workers/intercom-sync/src/index.ts
+++ b/workers/intercom-sync/src/index.ts
@@ -25,6 +25,7 @@ import {
   runConversationIncrementalPage,
   runConversationReconciliationPage,
   type ConversationIncrementalState,
+  type ConversationReconciliationState,
 } from "./conversations.js"
 import {
   createIntercomClient,
@@ -172,7 +173,7 @@ worker.sync("conversationsReconciliation", {
   database: conversations,
   mode: "replace",
   schedule: "manual",
-  execute: async (state: CursorSyncState | undefined) => {
+  execute: async (state: ConversationReconciliationState | undefined) => {
     if (!state) reconciliationConversationDirectories.clear()
     const client = createClient()
     const directory = await reconciliationConversationDirectories.get(() =>

--- a/workers/intercom-sync/src/intercom.ts
+++ b/workers/intercom-sync/src/intercom.ts
@@ -1,6 +1,7 @@
 // Intercom REST API client. It pins the stable API version, selects the
-// workspace's regional host, follows cursor pagination, resolves opaque IDs,
-// and turns provider throttling into a Workers retry signal.
+// workspace's regional host, resolves opaque IDs, and turns provider throttling
+// into a Workers retry signal. Collection methods fetch exactly one provider
+// page; resource executors own cursor continuation through persisted state.
 
 import { RateLimitError } from "@notionhq/workers"
 
@@ -25,6 +26,10 @@ export class IntercomApiError extends Error {
   }
 }
 
+// These DTOs intentionally model only the fields consumed from the API 2.15
+// List, Search, and Scroll responses used by this recipe. Intercom response
+// shapes vary by endpoint, so verify the exact collection endpoint before
+// extending a projection with fields documented for a Retrieve response.
 export type IntercomTag = {
   id?: string | null
   name?: string | null
@@ -213,7 +218,7 @@ export type IntercomClient = {
     until: number,
     cursor?: string
   ): Promise<IntercomPage<IntercomTicket>>
-  listTickets(
+  searchTicketsForReconciliation(
     createdBefore: number,
     cursor?: string
   ): Promise<IntercomPage<IntercomTicket>>
@@ -502,7 +507,7 @@ export function createIntercomClient(
     }
   }
 
-  async function listTickets(
+  async function searchTicketsForReconciliation(
     createdBefore: number,
     cursor?: string
   ): Promise<IntercomPage<IntercomTicket>> {
@@ -511,27 +516,31 @@ export function createIntercomClient(
     }
     if (cursor) pagination.starting_after = cursor
 
-    const body = await fetchJson("/tickets/search", "listing all tickets", {
-      method: "POST",
-      body: JSON.stringify({
-        // Ticket Search is the only collection read endpoint. Creation time
-        // is immutable, so this broad query keeps replacement membership
-        // steadier than an updated_at filter while the sweep is in flight.
-        query: {
-          operator: "AND",
-          value: [
-            { field: "created_at", operator: ">", value: 0 },
-            {
-              field: "created_at",
-              operator: "<",
-              value: createdBefore,
-            },
-          ],
-        },
-        pagination,
-        sort: { field: "id", order: "ascending" },
-      }),
-    })
+    const body = await fetchJson(
+      "/tickets/search",
+      "searching tickets for reconciliation",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          // Ticket Search is the only collection read endpoint. Creation time
+          // is immutable, so this broad query keeps replacement membership
+          // steadier than an updated_at filter while the sweep is in flight.
+          query: {
+            operator: "AND",
+            value: [
+              { field: "created_at", operator: ">", value: 0 },
+              {
+                field: "created_at",
+                operator: "<",
+                value: createdBefore,
+              },
+            ],
+          },
+          pagination,
+          sort: { field: "id", order: "ascending" },
+        }),
+      }
+    )
     const totalCount = body.total_count
     if (
       typeof totalCount !== "number" ||
@@ -595,7 +604,7 @@ export function createIntercomClient(
     searchConversations,
     listConversations,
     searchTickets,
-    listTickets,
+    searchTicketsForReconciliation,
     async fetchContactDirectory() {
       const [admins, tags] = await Promise.all([fetchAdmins(), fetchTags()])
       return { admins, tags }

--- a/workers/intercom-sync/src/intercom.ts
+++ b/workers/intercom-sync/src/intercom.ts
@@ -6,6 +6,10 @@ import { RateLimitError } from "@notionhq/workers"
 
 export const INTERCOM_API_VERSION = "2.15"
 export const INTERCOM_PAGE_SIZE = 150
+// Ticket Search returns full Ticket objects, including potentially large
+// ticket_parts collections. Keep Ticket responses much smaller than the
+// lightweight list/search endpoints used by the other resources.
+export const INTERCOM_TICKET_PAGE_SIZE = 20
 const DEFAULT_RETRY_AFTER_SECONDS = 10
 const MAX_ERROR_DETAIL_LENGTH = 500
 
@@ -209,7 +213,10 @@ export type IntercomClient = {
     until: number,
     cursor?: string
   ): Promise<IntercomPage<IntercomTicket>>
-  listTickets(cursor?: string): Promise<IntercomPage<IntercomTicket>>
+  listTickets(
+    createdBefore: number,
+    cursor?: string
+  ): Promise<IntercomPage<IntercomTicket>>
   fetchContactDirectory(): Promise<ContactDirectory>
   fetchAssignmentDirectory(): Promise<AssignmentDirectory>
 }
@@ -471,7 +478,7 @@ export function createIntercomClient(
     cursor?: string
   ): Promise<IntercomPage<IntercomTicket>> {
     const pagination: { per_page: number; starting_after?: string } = {
-      per_page: INTERCOM_PAGE_SIZE,
+      per_page: INTERCOM_TICKET_PAGE_SIZE,
     }
     if (cursor) pagination.starting_after = cursor
 
@@ -496,10 +503,11 @@ export function createIntercomClient(
   }
 
   async function listTickets(
+    createdBefore: number,
     cursor?: string
   ): Promise<IntercomPage<IntercomTicket>> {
     const pagination: { per_page: number; starting_after?: string } = {
-      per_page: INTERCOM_PAGE_SIZE,
+      per_page: INTERCOM_TICKET_PAGE_SIZE,
     }
     if (cursor) pagination.starting_after = cursor
 
@@ -509,7 +517,17 @@ export function createIntercomClient(
         // Ticket Search is the only collection read endpoint. Creation time
         // is immutable, so this broad query keeps replacement membership
         // steadier than an updated_at filter while the sweep is in flight.
-        query: { field: "created_at", operator: ">", value: 0 },
+        query: {
+          operator: "AND",
+          value: [
+            { field: "created_at", operator: ">", value: 0 },
+            {
+              field: "created_at",
+              operator: "<",
+              value: createdBefore,
+            },
+          ],
+        },
         pagination,
         sort: { field: "id", order: "ascending" },
       }),

--- a/workers/intercom-sync/src/intercom.ts
+++ b/workers/intercom-sync/src/intercom.ts
@@ -1,0 +1,590 @@
+// Intercom REST API client. It pins the stable API version, selects the
+// workspace's regional host, follows cursor pagination, resolves opaque IDs,
+// and turns provider throttling into a Workers retry signal.
+
+import { RateLimitError } from "@notionhq/workers"
+
+export const INTERCOM_API_VERSION = "2.15"
+export const INTERCOM_PAGE_SIZE = 150
+const DEFAULT_RETRY_AFTER_SECONDS = 10
+const MAX_ERROR_DETAIL_LENGTH = 500
+
+export type BeforeRequest = () => Promise<void>
+
+export class IntercomApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message)
+    this.name = "IntercomApiError"
+  }
+}
+
+export type IntercomTag = {
+  id?: string | null
+  name?: string | null
+}
+
+export type IntercomContact = {
+  id: string
+  external_id?: string | null
+  workspace_id?: string | null
+  role?: string | null
+  email?: string | null
+  phone?: string | null
+  name?: string | null
+  owner_id?: string | number | null
+  has_hard_bounced?: boolean | null
+  marked_email_as_spam?: boolean | null
+  unsubscribed_from_emails?: boolean | null
+  created_at: number
+  updated_at: number
+  signed_up_at?: number | null
+  last_seen_at?: number | null
+  last_replied_at?: number | null
+  last_contacted_at?: number | null
+  language_override?: string | null
+  tags?: {
+    data?: IntercomTag[] | null
+    total_count?: number | null
+    has_more?: boolean | null
+  } | null
+  companies?: {
+    data?: Array<{
+      id?: string | null
+      name?: string | null
+    }> | null
+    total_count?: number | null
+    has_more?: boolean | null
+  } | null
+  location?: {
+    country?: string | null
+    region?: string | null
+    city?: string | null
+  } | null
+}
+
+export type IntercomCompany = {
+  id: string
+  name?: string | null
+  company_id?: string | null
+  created_at: number
+  updated_at: number
+  remote_created_at?: number | null
+  last_request_at?: number | null
+  size?: number | null
+  website?: string | null
+  industry?: string | null
+  monthly_spend?: number | null
+  session_count?: number | null
+  user_count?: number | null
+  plan?: {
+    id?: string | null
+    name?: string | null
+  } | null
+  tags?: {
+    tags?: IntercomTag[] | null
+  } | null
+  segments?: {
+    segments?: Array<{ id?: string | null; name?: string | null }> | null
+  } | null
+}
+
+export type IntercomConversation = {
+  id: string
+  title?: string | null
+  created_at: number
+  updated_at: number
+  waiting_since?: number | null
+  snoozed_until?: number | null
+  state?: string | null
+  read?: boolean | null
+  priority?: string | null
+  admin_assignee_id?: string | number | null
+  team_assignee_id?: string | number | null
+  company?: {
+    id?: string | null
+    name?: string | null
+  } | null
+  tags?: { tags?: IntercomTag[] | null } | null
+  source?: {
+    type?: string | null
+    subject?: string | null
+    body?: string | null
+    url?: string | null
+    redacted?: boolean | null
+  } | null
+  contacts?: {
+    contacts?: Array<{
+      id?: string | null
+      external_id?: string | null
+    }> | null
+  } | null
+  conversation_rating?: {
+    rating?: number | null
+    remark?: string | null
+  } | null
+  sla_applied?: {
+    sla_name?: string | null
+    sla_status?: string | null
+  } | null
+  statistics?: {
+    time_to_admin_reply?: number | null
+    median_time_to_reply?: number | null
+    handling_time?: number | null
+    adjusted_handling_time?: number | null
+    last_contact_reply_at?: number | null
+    count_reopens?: number | null
+    count_assignments?: number | null
+    count_conversation_parts?: number | null
+  } | null
+  ai_agent?: {
+    resolution_state?: string | null
+  } | null
+  ai_agent_participated?: boolean | null
+}
+
+export type IntercomTicket = {
+  id: string
+  ticket_id?: string | null
+  category?: string | null
+  created_at: number
+  updated_at: number
+  open?: boolean | null
+  snoozed_until?: number | null
+  is_shared?: boolean | null
+  admin_assignee_id?: string | number | null
+  team_assignee_id?: string | number | null
+  ticket_attributes?: Record<string, unknown> | null
+  ticket_state?: {
+    id?: string | null
+    category?: string | null
+    internal_label?: string | null
+    external_label?: string | null
+  } | null
+  ticket_type?: {
+    id?: string | null
+    name?: string | null
+  } | null
+  contacts?: {
+    contacts?: Array<{ id?: string | null }> | null
+  } | null
+}
+
+export type IntercomPage<T> = {
+  records: T[]
+  nextCursor?: string
+  totalCount?: number
+}
+
+export type IntercomCompanyPage = {
+  records: IntercomCompany[]
+  scrollParameter?: string
+}
+
+export type ContactDirectory = {
+  admins: Map<string, string>
+  tags: Map<string, string>
+}
+
+export type AssignmentDirectory = {
+  admins: Map<string, string>
+  teams: Map<string, string>
+}
+
+export type IntercomClient = {
+  listContacts(cursor?: string): Promise<IntercomPage<IntercomContact>>
+  scrollCompanies(scrollParameter?: string): Promise<IntercomCompanyPage>
+  searchConversations(
+    since: number,
+    until: number,
+    cursor?: string
+  ): Promise<IntercomPage<IntercomConversation>>
+  listConversations(
+    cursor?: string
+  ): Promise<IntercomPage<IntercomConversation>>
+  searchTickets(
+    since: number,
+    until: number,
+    cursor?: string
+  ): Promise<IntercomPage<IntercomTicket>>
+  listTickets(cursor?: string): Promise<IntercomPage<IntercomTicket>>
+  fetchContactDirectory(): Promise<ContactDirectory>
+  fetchAssignmentDirectory(): Promise<AssignmentDirectory>
+}
+
+const API_ROOTS = {
+  us: "https://api.intercom.io",
+  eu: "https://api.eu.intercom.io",
+  au: "https://api.au.intercom.io",
+} as const
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is not set.`)
+  return value
+}
+
+export function getIntercomApiRoot(): string {
+  const region = (process.env.INTERCOM_REGION?.trim().toLowerCase() ||
+    "us") as keyof typeof API_ROOTS
+  const root = API_ROOTS[region]
+  if (!root) {
+    throw new Error("INTERCOM_REGION must be one of: us, eu, au.")
+  }
+  return root
+}
+
+function errorDetail(text: string): string {
+  try {
+    const value: unknown = JSON.parse(text)
+    if (value && typeof value === "object") {
+      const errors = (value as { errors?: unknown }).errors
+      if (Array.isArray(errors)) {
+        const details = errors
+          .map((error) => {
+            if (!error || typeof error !== "object") return undefined
+            const item = error as { code?: unknown; message?: unknown }
+            const code = typeof item.code === "string" ? item.code : undefined
+            const message =
+              typeof item.message === "string" ? item.message : undefined
+            return [code, message].filter(Boolean).join(": ") || undefined
+          })
+          .filter((detail): detail is string => Boolean(detail))
+        if (details.length > 0) {
+          return details.join("; ").slice(0, MAX_ERROR_DETAIL_LENGTH)
+        }
+      }
+    }
+  } catch {
+    // Fall back to a bounded response body below.
+  }
+
+  return (text.trim() || "No response body").slice(0, MAX_ERROR_DETAIL_LENGTH)
+}
+
+function retryAfterHeaderSeconds(value: string | null): number | undefined {
+  if (!value?.trim()) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds)
+
+  const retryAt = Date.parse(value)
+  return Number.isNaN(retryAt)
+    ? undefined
+    : Math.max(0, Math.ceil((retryAt - Date.now()) / 1_000))
+}
+
+function resetHeaderSeconds(value: string | null): number | undefined {
+  if (!value?.trim()) return undefined
+  const resetAt = Number(value)
+  if (!Number.isFinite(resetAt) || resetAt < 0) return undefined
+  return Math.max(0, Math.ceil(resetAt - Date.now() / 1_000))
+}
+
+export function retryAfterSeconds(response: Response): number {
+  const delays = [
+    retryAfterHeaderSeconds(response.headers.get("Retry-After")),
+    resetHeaderSeconds(response.headers.get("X-RateLimit-Reset")),
+  ].filter((value): value is number => value !== undefined)
+
+  return delays.length > 0 ? Math.max(...delays) : DEFAULT_RETRY_AFTER_SECONDS
+}
+
+function parseJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    throw new Error(`Intercom ${label} returned invalid JSON.`)
+  }
+}
+
+function recordValue(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Intercom ${label} response must be an object.`)
+  }
+  return value as Record<string, unknown>
+}
+
+function recordsValue<T>(
+  body: Record<string, unknown>,
+  key: string,
+  label: string
+): T[] {
+  const records = body[key]
+  if (!Array.isArray(records)) {
+    throw new Error(`Intercom ${label} response is missing ${key}.`)
+  }
+  return records as T[]
+}
+
+function nextCursor(body: Record<string, unknown>, label: string) {
+  if (body.pages == null) return undefined
+  const pages = recordValue(body.pages, `${label} pages`)
+  if (pages.next == null) return undefined
+  const next = recordValue(pages.next, `${label} next page`)
+  const cursor = next.starting_after
+  if (typeof cursor !== "string" || !cursor.trim()) {
+    throw new Error(`Intercom ${label} next page is missing starting_after.`)
+  }
+  return cursor
+}
+
+function displayName(value: {
+  name?: unknown
+  email?: unknown
+}): string | undefined {
+  const name = typeof value.name === "string" ? value.name.trim() : ""
+  if (name) return name
+  const email = typeof value.email === "string" ? value.email.trim() : ""
+  return email || undefined
+}
+
+function idNameMap(values: unknown[], label: string): Map<string, string> {
+  const result = new Map<string, string>()
+  for (const value of values) {
+    const item = recordValue(value, label)
+    const id =
+      typeof item.id === "string" || typeof item.id === "number"
+        ? String(item.id)
+        : undefined
+    const name = displayName(item)
+    if (id && name) result.set(id, name)
+  }
+  return result
+}
+
+export function createIntercomClient(
+  beforeRequest: BeforeRequest
+): IntercomClient {
+  const apiRoot = getIntercomApiRoot()
+
+  async function fetchJson(
+    path: string,
+    label: string,
+    init?: RequestInit
+  ): Promise<Record<string, unknown>> {
+    const headers = new Headers(init?.headers)
+    headers.set(
+      "Authorization",
+      `Bearer ${requiredEnv("INTERCOM_ACCESS_TOKEN")}`
+    )
+    headers.set("Accept", "application/json")
+    headers.set("Intercom-Version", INTERCOM_API_VERSION)
+    if (init?.body != null) headers.set("Content-Type", "application/json")
+
+    await beforeRequest()
+    const response = await fetch(new URL(path, `${apiRoot}/`), {
+      ...init,
+      headers,
+      redirect: "error",
+    })
+    const text = await response.text()
+
+    if (response.status === 429) {
+      throw new RateLimitError({ retryAfter: retryAfterSeconds(response) })
+    }
+    if (!response.ok) {
+      throw new IntercomApiError(
+        response.status,
+        `Intercom API error (${response.status}) while ${label}: ${errorDetail(text)}`
+      )
+    }
+
+    return recordValue(parseJson(text, label), label)
+  }
+
+  async function listContacts(
+    cursor?: string
+  ): Promise<IntercomPage<IntercomContact>> {
+    const url = new URL("/contacts", `${apiRoot}/`)
+    url.searchParams.set("per_page", String(INTERCOM_PAGE_SIZE))
+    if (cursor) url.searchParams.set("starting_after", cursor)
+    const body = await fetchJson(url.toString(), "listing contacts")
+    return {
+      records: recordsValue<IntercomContact>(body, "data", "contacts"),
+      nextCursor: nextCursor(body, "contacts"),
+    }
+  }
+
+  async function searchConversations(
+    since: number,
+    until: number,
+    cursor?: string
+  ): Promise<IntercomPage<IntercomConversation>> {
+    const pagination: { per_page: number; starting_after?: string } = {
+      per_page: INTERCOM_PAGE_SIZE,
+    }
+    if (cursor) pagination.starting_after = cursor
+
+    const body = await fetchJson(
+      "/conversations/search",
+      "searching conversations",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          query: {
+            operator: "AND",
+            value: [
+              { field: "updated_at", operator: ">", value: since },
+              { field: "updated_at", operator: "<", value: until },
+            ],
+          },
+          pagination,
+          // Search pagination is stateless. An immutable ordering minimizes
+          // movement between pages while the fixed time window is in flight.
+          sort: { field: "id", order: "ascending" },
+        }),
+      }
+    )
+    return {
+      records: recordsValue<IntercomConversation>(
+        body,
+        "conversations",
+        "conversation search"
+      ),
+      nextCursor: nextCursor(body, "conversation search"),
+    }
+  }
+
+  async function listConversations(
+    cursor?: string
+  ): Promise<IntercomPage<IntercomConversation>> {
+    const url = new URL("/conversations", `${apiRoot}/`)
+    url.searchParams.set("per_page", String(INTERCOM_PAGE_SIZE))
+    if (cursor) url.searchParams.set("starting_after", cursor)
+    const body = await fetchJson(url.toString(), "listing conversations")
+    return {
+      records: recordsValue<IntercomConversation>(
+        body,
+        "conversations",
+        "conversations"
+      ),
+      nextCursor: nextCursor(body, "conversations"),
+    }
+  }
+
+  async function searchTickets(
+    since: number,
+    until: number,
+    cursor?: string
+  ): Promise<IntercomPage<IntercomTicket>> {
+    const pagination: { per_page: number; starting_after?: string } = {
+      per_page: INTERCOM_PAGE_SIZE,
+    }
+    if (cursor) pagination.starting_after = cursor
+
+    const body = await fetchJson("/tickets/search", "searching tickets", {
+      method: "POST",
+      body: JSON.stringify({
+        query: {
+          operator: "AND",
+          value: [
+            { field: "updated_at", operator: ">", value: since },
+            { field: "updated_at", operator: "<", value: until },
+          ],
+        },
+        pagination,
+        sort: { field: "id", order: "ascending" },
+      }),
+    })
+    return {
+      records: recordsValue<IntercomTicket>(body, "tickets", "ticket search"),
+      nextCursor: nextCursor(body, "ticket search"),
+    }
+  }
+
+  async function listTickets(
+    cursor?: string
+  ): Promise<IntercomPage<IntercomTicket>> {
+    const pagination: { per_page: number; starting_after?: string } = {
+      per_page: INTERCOM_PAGE_SIZE,
+    }
+    if (cursor) pagination.starting_after = cursor
+
+    const body = await fetchJson("/tickets/search", "listing all tickets", {
+      method: "POST",
+      body: JSON.stringify({
+        // Ticket Search is the only collection read endpoint. Creation time
+        // is immutable, so this broad query keeps replacement membership
+        // steadier than an updated_at filter while the sweep is in flight.
+        query: { field: "created_at", operator: ">", value: 0 },
+        pagination,
+        sort: { field: "id", order: "ascending" },
+      }),
+    })
+    const totalCount = body.total_count
+    if (
+      typeof totalCount !== "number" ||
+      !Number.isSafeInteger(totalCount) ||
+      totalCount < 0
+    ) {
+      throw new Error(
+        "Intercom ticket reconciliation response is missing total_count."
+      )
+    }
+    return {
+      records: recordsValue<IntercomTicket>(
+        body,
+        "tickets",
+        "ticket reconciliation"
+      ),
+      nextCursor: nextCursor(body, "ticket reconciliation"),
+      totalCount,
+    }
+  }
+
+  async function fetchAdmins(): Promise<Map<string, string>> {
+    const body = await fetchJson("/admins", "listing admins")
+    return idNameMap(recordsValue(body, "admins", "admins"), "admin")
+  }
+
+  async function fetchTeams(): Promise<Map<string, string>> {
+    const body = await fetchJson("/teams", "listing teams")
+    return idNameMap(recordsValue(body, "teams", "teams"), "team")
+  }
+
+  async function fetchTags(): Promise<Map<string, string>> {
+    const body = await fetchJson("/tags", "listing tags")
+    return idNameMap(recordsValue(body, "data", "tags"), "tag")
+  }
+
+  async function scrollCompanies(
+    scrollParameter?: string
+  ): Promise<IntercomCompanyPage> {
+    const url = new URL("/companies/scroll", `${apiRoot}/`)
+    if (scrollParameter) url.searchParams.set("scroll_param", scrollParameter)
+    const body = await fetchJson(url.toString(), "listing companies")
+    const records = recordsValue<IntercomCompany>(body, "data", "companies")
+    const returned = body.scroll_param
+    const nextScrollParameter =
+      typeof returned === "string" && returned.trim()
+        ? returned.trim()
+        : scrollParameter
+
+    if (records.length > 0 && !nextScrollParameter) {
+      throw new Error(
+        "Intercom company scroll is missing its next scroll_param."
+      )
+    }
+    return { records, scrollParameter: nextScrollParameter }
+  }
+
+  return {
+    listContacts,
+    scrollCompanies,
+    searchConversations,
+    listConversations,
+    searchTickets,
+    listTickets,
+    async fetchContactDirectory() {
+      const [admins, tags] = await Promise.all([fetchAdmins(), fetchTags()])
+      return { admins, tags }
+    },
+    async fetchAssignmentDirectory() {
+      const [admins, teams] = await Promise.all([fetchAdmins(), fetchTeams()])
+      return { admins, teams }
+    },
+  }
+}

--- a/workers/intercom-sync/src/intercom.ts
+++ b/workers/intercom-sync/src/intercom.ts
@@ -343,6 +343,21 @@ function nextCursor(body: Record<string, unknown>, label: string) {
   return cursor
 }
 
+function requiredTotalCount(
+  body: Record<string, unknown>,
+  label: string
+): number {
+  const totalCount = body.total_count
+  if (
+    typeof totalCount !== "number" ||
+    !Number.isSafeInteger(totalCount) ||
+    totalCount < 0
+  ) {
+    throw new Error(`Intercom ${label} response is missing total_count.`)
+  }
+  return totalCount
+}
+
 function displayName(value: {
   name?: unknown
   email?: unknown
@@ -474,6 +489,7 @@ export function createIntercomClient(
         "conversations"
       ),
       nextCursor: nextCursor(body, "conversations"),
+      totalCount: requiredTotalCount(body, "conversation reconciliation"),
     }
   }
 
@@ -541,16 +557,6 @@ export function createIntercomClient(
         }),
       }
     )
-    const totalCount = body.total_count
-    if (
-      typeof totalCount !== "number" ||
-      !Number.isSafeInteger(totalCount) ||
-      totalCount < 0
-    ) {
-      throw new Error(
-        "Intercom ticket reconciliation response is missing total_count."
-      )
-    }
     return {
       records: recordsValue<IntercomTicket>(
         body,
@@ -558,7 +564,7 @@ export function createIntercomClient(
         "ticket reconciliation"
       ),
       nextCursor: nextCursor(body, "ticket reconciliation"),
-      totalCount,
+      totalCount: requiredTotalCount(body, "ticket reconciliation"),
     }
   }
 

--- a/workers/intercom-sync/src/pagination.ts
+++ b/workers/intercom-sync/src/pagination.ts
@@ -1,0 +1,101 @@
+// Bounded state for Intercom endpoints that use starting_after cursors.
+// Resource modules own their schedules and time windows; this file only
+// prevents a malformed cursor cycle from running forever.
+
+export type CursorSyncState = {
+  after: string
+  recentCursors: string[]
+  pageCount: number
+}
+
+export type PaginationGuardState = {
+  recentPageKeys: string[]
+  pageCount: number
+}
+
+export const MAX_CURSOR_HISTORY = 128
+export const MAX_CURSOR_PAGES = 10_000
+
+export function validatedRecentCursors(value: string[] | undefined): string[] {
+  if (value === undefined) return []
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_CURSOR_HISTORY ||
+    value.some((cursor) => typeof cursor !== "string" || !cursor.trim())
+  ) {
+    throw new Error(
+      "Intercom pagination recentCursors must contain a bounded cursor history."
+    )
+  }
+  return value
+}
+
+export function validatedPageCount(value: number | undefined): number {
+  if (value === undefined) return 0
+  if (!Number.isSafeInteger(value) || value < 0 || value >= MAX_CURSOR_PAGES) {
+    throw new Error(
+      "Intercom pagination pageCount is outside its safety bound."
+    )
+  }
+  return value
+}
+
+export function advancePageGuard(
+  state: { recentPageKeys?: string[]; pageCount?: number } | undefined,
+  pageKey: string,
+  resourceName: string
+): PaginationGuardState {
+  if (!pageKey.trim()) {
+    throw new Error(
+      `Intercom ${resourceName} pagination has an empty page key.`
+    )
+  }
+  const recentPageKeys = validatedRecentCursors(state?.recentPageKeys)
+  if (recentPageKeys.includes(pageKey)) {
+    throw new Error(`Intercom ${resourceName} pagination repeated a page.`)
+  }
+  const pageCount = validatedPageCount(state?.pageCount) + 1
+  if (pageCount >= MAX_CURSOR_PAGES) {
+    throw new Error(
+      `Intercom ${resourceName} pagination exceeded ${MAX_CURSOR_PAGES} pages.`
+    )
+  }
+  return {
+    recentPageKeys: [...recentPageKeys, pageKey].slice(-MAX_CURSOR_HISTORY),
+    pageCount,
+  }
+}
+
+export function nextCursorState(
+  state:
+    | { after?: string; recentCursors?: string[]; pageCount?: number }
+    | undefined,
+  nextCursor: string | undefined,
+  resourceName: string
+): CursorSyncState {
+  if (!nextCursor?.trim()) {
+    throw new Error(
+      `Intercom ${resourceName} pagination is missing starting_after.`
+    )
+  }
+
+  const seen = new Set(validatedRecentCursors(state?.recentCursors))
+  if (state?.after) seen.add(state.after)
+  if (seen.has(nextCursor)) {
+    throw new Error(`Intercom ${resourceName} pagination repeated cursor.`)
+  }
+
+  const pageCount = validatedPageCount(state?.pageCount) + 1
+  if (pageCount >= MAX_CURSOR_PAGES) {
+    throw new Error(
+      `Intercom ${resourceName} pagination exceeded ${MAX_CURSOR_PAGES} pages.`
+    )
+  }
+
+  seen.add(nextCursor)
+  return {
+    after: nextCursor,
+    recentCursors: [...seen].slice(-MAX_CURSOR_HISTORY),
+    pageCount,
+  }
+}

--- a/workers/intercom-sync/src/pagination.ts
+++ b/workers/intercom-sync/src/pagination.ts
@@ -16,6 +16,38 @@ export type PaginationGuardState = {
 export const MAX_CURSOR_HISTORY = 128
 export const MAX_CURSOR_PAGES = 10_000
 
+export function lastAscendingRecordId(
+  recordIds: string[],
+  previousRecordId: string | undefined,
+  resourceName: string
+): string | undefined {
+  let lastRecordId = previousRecordId
+  if (lastRecordId !== undefined && !lastRecordId.trim()) {
+    throw new Error(
+      `Intercom ${resourceName} pagination has an invalid record-order checkpoint.`
+    )
+  }
+
+  for (const recordId of recordIds) {
+    if (typeof recordId !== "string" || !recordId.trim()) {
+      throw new Error(
+        `Intercom ${resourceName} pagination returned an invalid record id.`
+      )
+    }
+    // Intercom models these API IDs as strings. If its service applies a
+    // different collation, fail closed instead of completing a replacement
+    // whose requested ordering cannot be verified.
+    if (lastRecordId !== undefined && recordId <= lastRecordId) {
+      throw new Error(
+        `Intercom ${resourceName} did not return records in strictly ascending id order.`
+      )
+    }
+    lastRecordId = recordId
+  }
+
+  return lastRecordId
+}
+
 export function validatedRecentCursors(value: string[] | undefined): string[] {
   if (value === undefined) return []
   if (

--- a/workers/intercom-sync/src/tickets.ts
+++ b/workers/intercom-sync/src/tickets.ts
@@ -317,7 +317,10 @@ export async function runTicketReconciliationPage(
       "Intercom ticket reconciliation cutoff must be after the Unix epoch."
     )
   }
-  const page = await client.listTickets(createdBefore, effectiveState?.after)
+  const page = await client.searchTicketsForReconciliation(
+    createdBefore,
+    effectiveState?.after
+  )
   const totalCount = expectedTicketCount(page.totalCount, effectiveState)
   const recentRecordIds = effectiveState?.recentRecordIds ?? []
   if (

--- a/workers/intercom-sync/src/tickets.ts
+++ b/workers/intercom-sync/src/tickets.ts
@@ -1,0 +1,356 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  type AssignmentDirectory,
+  type IntercomClient,
+  type IntercomTicket,
+} from "./intercom.js"
+import {
+  escapeMarkdown,
+  htmlToPlainText,
+  humanize,
+  nonEmpty,
+  optionalUnixSecondsToIso,
+  uniqueStrings,
+  unixSecondsToIso,
+} from "./helpers.js"
+import {
+  nextCursorState,
+  validatedPageCount,
+  validatedRecentCursors,
+  type CursorSyncState,
+} from "./pagination.js"
+
+export const INITIAL_TITLE = "Intercom Tickets"
+export const PRIMARY_KEY = "Ticket ID"
+
+export const ticketSchema = {
+  databaseIcon: notionIcon("ticket"),
+  properties: {
+    Title: Schema.title(),
+
+    State: Schema.select([]),
+
+    "State Category": Schema.select([
+      { name: "Submitted" },
+      { name: "In Progress" },
+      { name: "Waiting On Customer" },
+      { name: "Resolved" },
+    ]),
+
+    "Ticket Type": Schema.select([]),
+
+    Category: Schema.select([
+      { name: "Customer" },
+      { name: "Back Office" },
+      { name: "Tracker" },
+    ]),
+
+    Contacts: Schema.relation("contacts", {
+      twoWay: true,
+      relatedPropertyName: "Tickets",
+    }),
+
+    Assignee: Schema.richText(),
+
+    Team: Schema.richText(),
+
+    Updated: Schema.date(),
+
+    Open: Schema.checkbox(),
+
+    "Snoozed Until": Schema.date(),
+
+    "Shared with Customer": Schema.checkbox(),
+
+    Created: Schema.date(),
+
+    "Inbox Ticket ID": Schema.richText(),
+
+    "Ticket ID": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+export type TicketIncrementalState = {
+  since: number
+  until?: number
+  after?: string
+  recentCursors?: string[]
+  pageCount?: number
+}
+
+export type TicketReconciliationState = CursorSyncState & {
+  expectedTotalCount: number
+  seenCount: number
+  recentRecordIds: string[]
+}
+
+export const INITIAL_TICKET_WATERMARK = 0
+export const TICKET_CONSISTENCY_BUFFER_SECONDS = 60
+export const TICKET_WATERMARK_OVERLAP_SECONDS = 5 * 60
+const MAX_RECENT_TICKET_IDS = 300
+
+function ticketId(ticket: IntercomTicket): string {
+  const id = nonEmpty(ticket.id)
+  if (!id) throw new Error("Intercom ticket is missing its id.")
+  return id
+}
+
+function attributeText(value: unknown): string | undefined {
+  if (typeof value === "string") return nonEmpty(value)
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  if (typeof value === "boolean") return String(value)
+  return undefined
+}
+
+function ticketTitle(ticket: IntercomTicket): string {
+  const title = attributeText(ticket.ticket_attributes?._default_title_)
+  if (title) return title
+  const type = nonEmpty(ticket.ticket_type?.name) ?? "Ticket"
+  const visibleId = nonEmpty(ticket.ticket_id) ?? ticketId(ticket)
+  return `${type} #${visibleId}`
+}
+
+export function ticketPageContent(ticket: IntercomTicket): string {
+  const description = htmlToPlainText(
+    attributeText(ticket.ticket_attributes?._default_description_)
+  )
+  return description ? `## Description\n\n${escapeMarkdown(description)}` : ""
+}
+
+function lookupName(
+  lookup: Map<string, string>,
+  id: string | number | null | undefined,
+  kind: "admin" | "team"
+): string | undefined {
+  if (id == null) return undefined
+  const normalized = String(id).trim()
+  if (!normalized || normalized === "0") return undefined
+  return lookup.get(normalized) ?? `Unknown ${kind} (${normalized})`
+}
+
+function contactIds(ticket: IntercomTicket): string[] {
+  return uniqueStrings(
+    (ticket.contacts?.contacts ?? []).map((contact) => contact.id ?? undefined)
+  )
+}
+
+export function ticketToChange(
+  ticket: IntercomTicket,
+  directory: AssignmentDirectory
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof ticketSchema.properties> {
+  const id = ticketId(ticket)
+  const updated = unixSecondsToIso(ticket.updated_at, "Ticket updated_at")
+  const created = unixSecondsToIso(ticket.created_at, "Ticket created_at")
+  const state =
+    nonEmpty(ticket.ticket_state?.internal_label) ??
+    nonEmpty(ticket.ticket_state?.external_label)
+  const stateCategory = nonEmpty(ticket.ticket_state?.category)
+  const type = nonEmpty(ticket.ticket_type?.name)
+  const category = nonEmpty(ticket.category)
+  const assignee = lookupName(
+    directory.admins,
+    ticket.admin_assignee_id,
+    "admin"
+  )
+  const team = lookupName(directory.teams, ticket.team_assignee_id, "team")
+  const snoozedUntil = optionalUnixSecondsToIso(
+    ticket.snoozed_until,
+    "Ticket snoozed_until"
+  )
+  const inboxTicketId = nonEmpty(ticket.ticket_id)
+
+  return {
+    type: "upsert",
+    key: id,
+    upstreamUpdatedAt: updated,
+    pageContentMarkdown: ticketPageContent(ticket),
+    properties: {
+      Title: Builder.title(ticketTitle(ticket)),
+      State: state ? Builder.select(state) : [],
+      "State Category": stateCategory
+        ? Builder.select(humanize(stateCategory))
+        : [],
+      "Ticket Type": type ? Builder.select(type) : [],
+      Category: category ? Builder.select(humanize(category)) : [],
+      Contacts: contactIds(ticket).map((contactId) =>
+        Builder.relation(contactId)
+      ),
+      Assignee: assignee ? Builder.richText(assignee) : [],
+      Team: team ? Builder.richText(team) : [],
+      Updated: Builder.dateTime(updated),
+      Open: Builder.checkbox(ticket.open === true),
+      "Snoozed Until": snoozedUntil ? Builder.dateTime(snoozedUntil) : [],
+      "Shared with Customer": Builder.checkbox(ticket.is_shared === true),
+      Created: Builder.dateTime(created),
+      "Inbox Ticket ID": inboxTicketId ? Builder.richText(inboxTicketId) : [],
+      "Ticket ID": Builder.richText(id),
+    },
+  }
+}
+
+function unixSeconds(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(
+      `${label} must be a non-negative Unix timestamp in seconds.`
+    )
+  }
+  return value
+}
+
+export function ticketIncrementalWindow(
+  state: TicketIncrementalState | undefined,
+  now: () => Date = () => new Date()
+): { since: number; until: number } {
+  const since = unixSeconds(
+    state?.since ?? INITIAL_TICKET_WATERMARK,
+    "Intercom ticket state.since"
+  )
+  if (state?.after && state.until === undefined) {
+    throw new Error(
+      "Intercom paginated ticket state is missing its pinned until."
+    )
+  }
+  if (!state?.after && state?.until !== undefined) {
+    throw new Error(
+      "Intercom ticket state has until without a pagination cursor."
+    )
+  }
+  validatedRecentCursors(state?.recentCursors)
+  validatedPageCount(state?.pageCount)
+
+  const nowSeconds = Math.floor(now().getTime() / 1_000)
+  if (!Number.isSafeInteger(nowSeconds) || nowSeconds < 0) {
+    throw new Error("Intercom ticket sync clock is invalid.")
+  }
+  const until = unixSeconds(
+    state?.until ??
+      Math.max(since, nowSeconds - TICKET_CONSISTENCY_BUFFER_SECONDS),
+    "Intercom ticket state.until"
+  )
+  if (until < since) {
+    throw new Error("Intercom ticket sync window ends before it starts.")
+  }
+  return { since, until }
+}
+
+export function nextTicketWatermark(until: number): number {
+  return Math.max(
+    INITIAL_TICKET_WATERMARK,
+    unixSeconds(until, "Intercom ticket watermark") -
+      TICKET_WATERMARK_OVERLAP_SECONDS
+  )
+}
+
+export async function runTicketIncrementalPage(
+  client: IntercomClient,
+  directory: AssignmentDirectory,
+  state: TicketIncrementalState | undefined,
+  now: () => Date = () => new Date()
+) {
+  const { since, until } = ticketIncrementalWindow(state, now)
+  const page = await client.searchTickets(since, until, state?.after)
+  const changes = page.records.map((ticket) =>
+    ticketToChange(ticket, directory)
+  )
+
+  if (page.nextCursor) {
+    return {
+      changes,
+      hasMore: true as const,
+      nextState: {
+        since,
+        until,
+        ...nextCursorState(state, page.nextCursor, "ticket search"),
+      },
+    }
+  }
+  return {
+    changes,
+    hasMore: false as const,
+    nextState: { since: nextTicketWatermark(until) },
+  }
+}
+
+function expectedTicketCount(
+  value: number | undefined,
+  state: TicketReconciliationState | undefined
+): number {
+  if (!Number.isSafeInteger(value) || value == null || value < 0) {
+    throw new Error(
+      "Intercom ticket reconciliation has an invalid total_count."
+    )
+  }
+  if (state && state.expectedTotalCount !== value) {
+    throw new Error(
+      "Intercom ticket total changed during replacement; retry the full sweep."
+    )
+  }
+  return value
+}
+
+export async function runTicketReconciliationPage(
+  client: IntercomClient,
+  directory: AssignmentDirectory,
+  state: TicketReconciliationState | undefined
+) {
+  const page = await client.listTickets(state?.after)
+  const totalCount = expectedTicketCount(page.totalCount, state)
+  const recentRecordIds = state?.recentRecordIds ?? []
+  if (
+    !Array.isArray(recentRecordIds) ||
+    recentRecordIds.length > MAX_RECENT_TICKET_IDS ||
+    recentRecordIds.some((id) => typeof id !== "string" || !id.trim())
+  ) {
+    throw new Error(
+      "Intercom ticket reconciliation has invalid recent record state."
+    )
+  }
+  const recordIds = page.records.map(ticketId)
+  const seenRecordIds = new Set(recentRecordIds)
+  for (const id of recordIds) {
+    if (seenRecordIds.has(id)) {
+      throw new Error("Intercom ticket reconciliation repeated a record.")
+    }
+    seenRecordIds.add(id)
+  }
+
+  const changes = page.records.map((ticket) =>
+    ticketToChange(ticket, directory)
+  )
+  const seenCount = (state?.seenCount ?? 0) + page.records.length
+  if (seenCount > totalCount) {
+    throw new Error(
+      "Intercom ticket reconciliation returned more records than total_count."
+    )
+  }
+
+  if (page.nextCursor) {
+    const lastRecord = page.records.at(-1)
+    if (!lastRecord) {
+      throw new Error(
+        "Intercom ticket reconciliation returned a cursor without records."
+      )
+    }
+    return {
+      changes,
+      hasMore: true as const,
+      nextState: {
+        ...nextCursorState(state, page.nextCursor, "ticket reconciliation"),
+        expectedTotalCount: totalCount,
+        seenCount,
+        recentRecordIds: [...recentRecordIds, ...recordIds].slice(
+          -MAX_RECENT_TICKET_IDS
+        ),
+      },
+    }
+  }
+  if (seenCount !== totalCount) {
+    throw new Error(
+      "Intercom ticket replacement ended before total_count was reached."
+    )
+  }
+  return { changes, hasMore: false as const }
+}

--- a/workers/intercom-sync/src/tickets.ts
+++ b/workers/intercom-sync/src/tickets.ts
@@ -82,6 +82,7 @@ export type TicketIncrementalState = {
 }
 
 export type TicketReconciliationState = CursorSyncState & {
+  createdBefore?: number
   expectedTotalCount: number
   seenCount: number
   recentRecordIds: string[]
@@ -294,11 +295,31 @@ function expectedTicketCount(
 export async function runTicketReconciliationPage(
   client: IntercomClient,
   directory: AssignmentDirectory,
-  state: TicketReconciliationState | undefined
+  state: TicketReconciliationState | undefined,
+  now: () => Date = () => new Date()
 ) {
-  const page = await client.listTickets(state?.after)
-  const totalCount = expectedTicketCount(page.totalCount, state)
-  const recentRecordIds = state?.recentRecordIds ?? []
+  // Deployments preserve continuation state. A run started by a version before
+  // createdBefore existed safely restarts from page one; keyed upserts make
+  // replay harmless and a complete restart preserves replacement semantics.
+  const effectiveState =
+    state?.after && state.createdBefore == null ? undefined : state
+  const nowSeconds = Math.floor(now().getTime() / 1_000)
+  // Intercom documents its Ticket Search `<` operator as inclusive. Keep the
+  // cutoff behind the same indexing buffer as incremental syncs so tickets
+  // created during this stateless sweep cannot join its membership.
+  const createdBefore = unixSeconds(
+    effectiveState?.createdBefore ??
+      Math.max(1, nowSeconds - TICKET_CONSISTENCY_BUFFER_SECONDS),
+    "Intercom ticket reconciliation state.createdBefore"
+  )
+  if (createdBefore === 0) {
+    throw new Error(
+      "Intercom ticket reconciliation cutoff must be after the Unix epoch."
+    )
+  }
+  const page = await client.listTickets(createdBefore, effectiveState?.after)
+  const totalCount = expectedTicketCount(page.totalCount, effectiveState)
+  const recentRecordIds = effectiveState?.recentRecordIds ?? []
   if (
     !Array.isArray(recentRecordIds) ||
     recentRecordIds.length > MAX_RECENT_TICKET_IDS ||
@@ -320,7 +341,7 @@ export async function runTicketReconciliationPage(
   const changes = page.records.map((ticket) =>
     ticketToChange(ticket, directory)
   )
-  const seenCount = (state?.seenCount ?? 0) + page.records.length
+  const seenCount = (effectiveState?.seenCount ?? 0) + page.records.length
   if (seenCount > totalCount) {
     throw new Error(
       "Intercom ticket reconciliation returned more records than total_count."
@@ -338,7 +359,12 @@ export async function runTicketReconciliationPage(
       changes,
       hasMore: true as const,
       nextState: {
-        ...nextCursorState(state, page.nextCursor, "ticket reconciliation"),
+        ...nextCursorState(
+          effectiveState,
+          page.nextCursor,
+          "ticket reconciliation"
+        ),
+        createdBefore,
         expectedTotalCount: totalCount,
         seenCount,
         recentRecordIds: [...recentRecordIds, ...recordIds].slice(

--- a/workers/intercom-sync/src/tickets.ts
+++ b/workers/intercom-sync/src/tickets.ts
@@ -17,6 +17,7 @@ import {
   unixSecondsToIso,
 } from "./helpers.js"
 import {
+  lastAscendingRecordId,
   nextCursorState,
   validatedPageCount,
   validatedRecentCursors,
@@ -79,6 +80,7 @@ export type TicketIncrementalState = {
   after?: string
   recentCursors?: string[]
   pageCount?: number
+  lastRecordId?: string
 }
 
 export type TicketReconciliationState = CursorSyncState & {
@@ -86,6 +88,7 @@ export type TicketReconciliationState = CursorSyncState & {
   expectedTotalCount: number
   seenCount: number
   recentRecordIds: string[]
+  lastRecordId?: string
 }
 
 export const INITIAL_TICKET_WATERMARK = 0
@@ -251,20 +254,36 @@ export async function runTicketIncrementalPage(
   state: TicketIncrementalState | undefined,
   now: () => Date = () => new Date()
 ) {
-  const { since, until } = ticketIncrementalWindow(state, now)
-  const page = await client.searchTickets(since, until, state?.after)
+  const effectiveState =
+    state?.after && state.lastRecordId === undefined
+      ? { since: state.since }
+      : state
+  const { since, until } = ticketIncrementalWindow(effectiveState, now)
+  const page = await client.searchTickets(since, until, effectiveState?.after)
+  const recordIds = page.records.map(ticketId)
+  const lastRecordId = lastAscendingRecordId(
+    recordIds,
+    effectiveState?.lastRecordId,
+    "ticket search"
+  )
   const changes = page.records.map((ticket) =>
     ticketToChange(ticket, directory)
   )
 
   if (page.nextCursor) {
+    if (recordIds.length === 0 || lastRecordId === undefined) {
+      throw new Error(
+        "Intercom ticket search returned a cursor without records."
+      )
+    }
     return {
       changes,
       hasMore: true as const,
       nextState: {
         since,
         until,
-        ...nextCursorState(state, page.nextCursor, "ticket search"),
+        ...nextCursorState(effectiveState, page.nextCursor, "ticket search"),
+        lastRecordId,
       },
     }
   }
@@ -298,11 +317,15 @@ export async function runTicketReconciliationPage(
   state: TicketReconciliationState | undefined,
   now: () => Date = () => new Date()
 ) {
-  // Deployments preserve continuation state. A run started by a version before
-  // createdBefore existed safely restarts from page one; keyed upserts make
-  // replay harmless and a complete restart preserves replacement semantics.
+  // Deployments preserve continuation state. A run started before the pinned
+  // membership or record-order guards existed safely restarts from page one;
+  // keyed upserts make replay harmless and a complete restart preserves
+  // replacement semantics.
   const effectiveState =
-    state?.after && state.createdBefore == null ? undefined : state
+    state?.after &&
+    (state.createdBefore == null || state.lastRecordId === undefined)
+      ? undefined
+      : state
   const nowSeconds = Math.floor(now().getTime() / 1_000)
   // Intercom documents its Ticket Search `<` operator as inclusive. Keep the
   // cutoff behind the same indexing buffer as incremental syncs so tickets
@@ -333,6 +356,11 @@ export async function runTicketReconciliationPage(
     )
   }
   const recordIds = page.records.map(ticketId)
+  const lastRecordId = lastAscendingRecordId(
+    recordIds,
+    effectiveState?.lastRecordId,
+    "ticket reconciliation"
+  )
   const seenRecordIds = new Set(recentRecordIds)
   for (const id of recordIds) {
     if (seenRecordIds.has(id)) {
@@ -352,8 +380,7 @@ export async function runTicketReconciliationPage(
   }
 
   if (page.nextCursor) {
-    const lastRecord = page.records.at(-1)
-    if (!lastRecord) {
+    if (recordIds.length === 0 || lastRecordId === undefined) {
       throw new Error(
         "Intercom ticket reconciliation returned a cursor without records."
       )
@@ -370,6 +397,7 @@ export async function runTicketReconciliationPage(
         createdBefore,
         expectedTotalCount: totalCount,
         seenCount,
+        lastRecordId,
         recentRecordIds: [...recentRecordIds, ...recordIds].slice(
           -MAX_RECENT_TICKET_IDS
         ),

--- a/workers/intercom-sync/test.ts
+++ b/workers/intercom-sync/test.ts
@@ -22,6 +22,7 @@ import {
   nextConversationWatermark,
   runConversationIncrementalPage,
   runConversationReconciliationPage,
+  type ConversationReconciliationState,
 } from "./src/conversations.js"
 import {
   escapeMarkdown,
@@ -51,6 +52,7 @@ import {
 import {
   MAX_CURSOR_HISTORY,
   MAX_CURSOR_PAGES,
+  lastAscendingRecordId,
   nextCursorState,
 } from "./src/pagination.js"
 import {
@@ -782,6 +784,34 @@ test("cursor state keeps bounded history and enforces a maximum page count", () 
   )
 })
 
+test("search ordering checkpoints immutable IDs across pages", () => {
+  assert.equal(
+    lastAscendingRecordId(
+      ["conversation-1", "conversation-2"],
+      undefined,
+      "search"
+    ),
+    "conversation-2"
+  )
+  assert.equal(
+    lastAscendingRecordId(["conversation-3"], "conversation-2", "search"),
+    "conversation-3"
+  )
+  assert.throws(
+    () => lastAscendingRecordId(["conversation-2"], "conversation-2", "search"),
+    /strictly ascending/
+  )
+  assert.throws(
+    () =>
+      lastAscendingRecordId(
+        ["conversation-3", "conversation-2"],
+        undefined,
+        "search"
+      ),
+    /strictly ascending/
+  )
+})
+
 type FakeClientCalls = {
   contacts: Array<string | undefined>
   searches: Array<{ since: number; until: number; cursor?: string }>
@@ -1059,14 +1089,76 @@ test("conversation incremental pages pin bounds and checkpoint with overlap", as
     { since: 0, until: 1_940, cursor: undefined },
     { since: 0, until: 1_940, cursor: "search-next" },
   ])
-  assert.equal(first.hasMore, true)
+  if (!first.hasMore) assert.fail("Expected another conversation page")
+  assert.equal(first.nextState.lastRecordId, fullConversation.id)
   assert.equal(second.hasMore, false)
   assert.deepEqual(second.nextState, {
     since: 1_940 - WATERMARK_OVERLAP_SECONDS,
   })
+
+  const outOfOrder = fakeClient(
+    {
+      searches: [{ records: [minimalConversation, fullConversation] }],
+    },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runConversationIncrementalPage(
+        outOfOrder,
+        assignmentDirectory,
+        undefined,
+        () => new Date(2_000_000)
+      ),
+    /strictly ascending/
+  )
+
+  const emptyPage = fakeClient(
+    {
+      searches: [{ records: [], nextCursor: "empty-page" }],
+    },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runConversationIncrementalPage(
+        emptyPage,
+        assignmentDirectory,
+        undefined,
+        () => new Date(2_000_000)
+      ),
+    /cursor without records/
+  )
 })
 
-test("conversation reconciliation uses canonical listing and replace termination", async () => {
+test("incremental searches restart legacy cursor state before checking order", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    { searches: [{ records: [minimalConversation] }] },
+    calls
+  )
+  await runConversationIncrementalPage(
+    client,
+    assignmentDirectory,
+    {
+      since: 500,
+      until: 700,
+      after: "legacy-cursor",
+      recentCursors: ["legacy-cursor"],
+      pageCount: 1,
+    },
+    () => new Date(1_000_000)
+  )
+  assert.deepEqual(calls.searches, [
+    { since: 500, until: 940, cursor: undefined },
+  ])
+})
+
+test("conversation replacement pins total count before allowing deletion", async () => {
   const calls: FakeClientCalls = {
     contacts: [],
     searches: [],
@@ -1075,8 +1167,12 @@ test("conversation reconciliation uses canonical listing and replace termination
   const client = fakeClient(
     {
       conversations: [
-        { records: [fullConversation], nextCursor: "reconcile-next" },
-        { records: [] },
+        {
+          records: [fullConversation],
+          nextCursor: "reconcile-next",
+          totalCount: 1,
+        },
+        { records: [], totalCount: 1 },
       ],
     },
     calls
@@ -1092,8 +1188,94 @@ test("conversation reconciliation uses canonical listing and replace termination
     first.nextState
   )
   assert.deepEqual(calls.conversations, [undefined, "reconcile-next"])
-  assert.equal(first.hasMore, true)
+  if (!first.hasMore) assert.fail("Expected another reconciliation page")
+  assert.equal(first.nextState.expectedTotalCount, 1)
+  assert.equal(first.nextState.seenCount, 1)
+  assert.deepEqual(first.nextState.recentRecordIds, [fullConversation.id])
   assert.deepEqual(second, { changes: [], hasMore: false })
+
+  const changedTotal = fakeClient(
+    { conversations: [{ records: [], totalCount: 2 }] },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runConversationReconciliationPage(
+        changedTotal,
+        assignmentDirectory,
+        first.nextState
+      ),
+    /total changed/
+  )
+
+  const prematureEnd = fakeClient(
+    { conversations: [{ records: [], totalCount: 1 }] },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runConversationReconciliationPage(prematureEnd, assignmentDirectory, {
+        ...first.nextState,
+        seenCount: 0,
+        recentRecordIds: [],
+      }),
+    /before total_count was reached/
+  )
+
+  const repeatedRecord = fakeClient(
+    { conversations: [{ records: [fullConversation], totalCount: 1 }] },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runConversationReconciliationPage(
+        repeatedRecord,
+        assignmentDirectory,
+        first.nextState
+      ),
+    /repeated a record/
+  )
+
+  const emptyPage = fakeClient(
+    {
+      conversations: [{ records: [], nextCursor: "empty-page", totalCount: 0 }],
+    },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runConversationReconciliationPage(
+        emptyPage,
+        assignmentDirectory,
+        undefined
+      ),
+    /cursor without records/
+  )
+})
+
+test("conversation replacement restarts continuation state without guards", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      conversations: [{ records: [minimalConversation], totalCount: 1 }],
+    },
+    calls
+  )
+  const result = await runConversationReconciliationPage(
+    client,
+    assignmentDirectory,
+    {
+      after: "legacy-cursor",
+      recentCursors: ["legacy-cursor"],
+      pageCount: 3,
+    } as unknown as ConversationReconciliationState
+  )
+  assert.deepEqual(calls.conversations, [undefined])
+  assert.equal(result.hasMore, false)
 })
 
 test("ticket incremental pages pin bounds and checkpoint with overlap", async () => {
@@ -1127,7 +1309,8 @@ test("ticket incremental pages pin bounds and checkpoint with overlap", async ()
     { since: 0, until: 1_940, cursor: undefined },
     { since: 0, until: 1_940, cursor: "ticket-next" },
   ])
-  assert.equal(first.hasMore, true)
+  if (!first.hasMore) assert.fail("Expected another ticket page")
+  assert.equal(first.nextState.lastRecordId, fullTicket.id)
   assert.deepEqual(second.nextState, {
     since: 1_940 - TICKET_WATERMARK_OVERLAP_SECONDS,
   })
@@ -1166,6 +1349,7 @@ test("ticket replacement pins total count before allowing reconciliation", async
   ])
   assert.equal(first.nextState.createdBefore, 1_940)
   assert.equal(first.nextState.expectedTotalCount, 2)
+  assert.equal(first.nextState.lastRecordId, fullTicket.id)
   assert.deepEqual(second.hasMore, false)
 
   const changedTotal = fakeClient(
@@ -1182,7 +1366,7 @@ test("ticket replacement pins total count before allowing reconciliation", async
     /total changed/
   )
 
-  const overlapping = fakeClient(
+  const outOfOrder = fakeClient(
     {
       tickets: [{ records: [minimalTicket, fullTicket], totalCount: 2 }],
     },
@@ -1191,11 +1375,11 @@ test("ticket replacement pins total count before allowing reconciliation", async
   await assert.rejects(
     () =>
       runTicketReconciliationPage(
-        overlapping,
+        outOfOrder,
         assignmentDirectory,
         first.nextState
       ),
-    /repeated a record/
+    /strictly ascending/
   )
 })
 
@@ -1300,6 +1484,24 @@ test("client uses regional host, auth, version, page size, and safe redirects", 
   assert.equal(capturedInit?.redirect, "error")
   assert.equal(beforeRequests, 1)
   assert.equal(page.nextCursor, "next-contact")
+})
+
+test("conversation listing requires the reconciliation total count", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  globalThis.fetch = async () =>
+    jsonResponse({
+      conversations: [minimalConversation],
+      total_count: 1,
+      pages: { next: null },
+    })
+
+  const client = createIntercomClient(async () => {})
+  const page = await client.listConversations()
+  assert.equal(page.totalCount, 1)
+
+  globalThis.fetch = async () =>
+    jsonResponse({ conversations: [], pages: { next: null } })
+  await assert.rejects(() => client.listConversations(), /missing total_count/)
 })
 
 test("conversation search sends pinned bounds, immutable sort, and cursor", async () => {

--- a/workers/intercom-sync/test.ts
+++ b/workers/intercom-sync/test.ts
@@ -6,7 +6,11 @@ import { afterEach, test } from "node:test"
 
 import { RateLimitError } from "@notionhq/workers"
 
-import { companyToChange, runCompaniesPage } from "./src/companies.js"
+import {
+  COMPANY_SCROLL_RESTART_AFTER_MS,
+  companyToChange,
+  runCompaniesPage,
+} from "./src/companies.js"
 import { contactToChange, runContactsPage } from "./src/contacts.js"
 import {
   CONSISTENCY_BUFFER_SECONDS,
@@ -30,6 +34,7 @@ import worker, { createCycleCache } from "./src/index.js"
 import {
   INTERCOM_API_VERSION,
   INTERCOM_PAGE_SIZE,
+  INTERCOM_TICKET_PAGE_SIZE,
   IntercomApiError,
   createIntercomClient,
   getIntercomApiRoot,
@@ -335,6 +340,7 @@ test("minimal contact uses a stable title and explicitly clears nullable fields"
     "Companies",
     "Country",
     "Tags",
+    "Incomplete Associations",
     "Last Seen",
     "Signed Up",
     "Last Contacted",
@@ -344,6 +350,64 @@ test("minimal contact uses a stable title and explicitly clears nullable fields"
   ] as const) {
     assertEmpty(change.properties[property])
   }
+})
+
+test("contacts identify association lists that Intercom truncated", () => {
+  const both = contactToChange(
+    {
+      ...fullContact,
+      companies: { ...(fullContact.companies ?? {}), has_more: true },
+      tags: { ...(fullContact.tags ?? {}), has_more: true },
+    },
+    contactDirectory
+  )
+  assertPropertyContains(
+    both.properties["Incomplete Associations"],
+    "Companies"
+  )
+  assertPropertyContains(both.properties["Incomplete Associations"], "Tags")
+
+  const tagsOnly = contactToChange(
+    {
+      ...fullContact,
+      companies: { ...(fullContact.companies ?? {}), has_more: false },
+      tags: { ...(fullContact.tags ?? {}), has_more: true },
+    },
+    contactDirectory
+  )
+  assert.doesNotMatch(
+    propertyText(tagsOnly.properties["Incomplete Associations"]),
+    /Companies/
+  )
+  assertPropertyContains(tagsOnly.properties["Incomplete Associations"], "Tags")
+
+  const countMismatch = contactToChange(
+    {
+      ...minimalContact,
+      companies: { data: [{ id: "company-acme" }], total_count: 2 },
+    },
+    contactDirectory
+  )
+  assertPropertyContains(
+    countMismatch.properties["Incomplete Associations"],
+    "Companies"
+  )
+
+  const metadataMissing = contactToChange(
+    {
+      ...minimalContact,
+      tags: {
+        data: Array.from({ length: 10 }, (_, index) => ({
+          id: `tag-${index}`,
+        })),
+      },
+    },
+    contactDirectory
+  )
+  assertPropertyContains(
+    metadataMissing.properties["Incomplete Associations"],
+    "Tags"
+  )
 })
 
 test("contact title fallbacks and unknown lookup values stay diagnosable", () => {
@@ -724,7 +788,7 @@ type FakeClientCalls = {
   conversations: Array<string | undefined>
   companyScrolls?: Array<string | undefined>
   ticketSearches?: Array<{ since: number; until: number; cursor?: string }>
-  tickets?: Array<string | undefined>
+  tickets?: Array<{ createdBefore: number; cursor?: string }>
 }
 
 function fakeClient(
@@ -763,8 +827,8 @@ function fakeClient(
       if (!page) throw new Error("Missing fake ticket search page")
       return page
     },
-    async listTickets(cursor) {
-      ;(calls.tickets ??= []).push(cursor)
+    async listTickets(createdBefore, cursor) {
+      ;(calls.tickets ??= []).push({ createdBefore, cursor })
       const page = pages.tickets?.shift()
       if (!page) throw new Error("Missing fake ticket page")
       return page
@@ -866,7 +930,10 @@ test("company replacement safely restarts an expired scroll session", async () =
     async scrollCompanies(scrollParameter) {
       calls.push(scrollParameter)
       if (calls.length === 1) {
-        throw new IntercomApiError(500, "expired company scroll")
+        throw new IntercomApiError(
+          500,
+          "Request failed due to an internal network error. Please restart the scroll operation."
+        )
       }
       return { records: [fullCompany], scrollParameter: "fresh-scroll" }
     },
@@ -881,6 +948,84 @@ test("company replacement safely restarts an expired scroll session", async () =
   assert.deepEqual(calls, ["expired-scroll", undefined])
   assert.equal(result.nextState.restartCount, 1)
   assert.equal(result.nextState.pageCount, 1)
+
+  let genericAttempts = 0
+  const genericFailure: IntercomClient = {
+    ...base,
+    async scrollCompanies() {
+      genericAttempts++
+      throw new IntercomApiError(500, "Intercom service unavailable")
+    },
+  }
+  await assert.rejects(
+    () =>
+      runCompaniesPage(genericFailure, {
+        scrollParameter: "active-scroll",
+        recentPageKeys: ["old:first:1"],
+        pageCount: 1,
+      }),
+    /service unavailable/
+  )
+  assert.equal(genericAttempts, 1)
+})
+
+test("company replacement respects active scrolls, restarts stale state, and fails closed", async () => {
+  const calls: Array<string | undefined> = []
+  const base = fakeClient({}, { contacts: [], searches: [], conversations: [] })
+  const client: IntercomClient = {
+    ...base,
+    async scrollCompanies(scrollParameter) {
+      calls.push(scrollParameter)
+      return { records: [fullCompany], scrollParameter: "fresh-scroll" }
+    },
+  }
+  const staleState = {
+    scrollParameter: "expired-scroll",
+    recentPageKeys: ["old:first:1"],
+    pageCount: 4,
+    restartCount: 0,
+    lastRequestAt: 1_000,
+  }
+  const fresh = await runCompaniesPage(
+    client,
+    staleState,
+    () => new Date(1_000 + COMPANY_SCROLL_RESTART_AFTER_MS - 1)
+  )
+  if (!fresh.hasMore) assert.fail("Expected active company pagination")
+  assert.deepEqual(calls, ["expired-scroll"])
+  assert.equal(fresh.nextState.restartCount, 0)
+
+  const result = await runCompaniesPage(
+    client,
+    staleState,
+    () => new Date(1_000 + COMPANY_SCROLL_RESTART_AFTER_MS)
+  )
+  if (!result.hasMore) assert.fail("Expected restarted company pagination")
+  assert.deepEqual(calls, ["expired-scroll", undefined])
+  assert.equal(result.nextState.restartCount, 1)
+  assert.equal(result.nextState.pageCount, 1)
+
+  await assert.rejects(
+    () =>
+      runCompaniesPage(
+        client,
+        { ...staleState, restartCount: 2 },
+        () => new Date(1_000 + COMPANY_SCROLL_RESTART_AFTER_MS)
+      ),
+    /repeatedly expired/
+  )
+  assert.deepEqual(calls, ["expired-scroll", undefined])
+
+  await assert.rejects(
+    () =>
+      runCompaniesPage(
+        client,
+        { ...staleState, lastRequestAt: 100_000 },
+        () => new Date(99_999)
+      ),
+    /invalid timestamp/
+  )
+  assert.deepEqual(calls, ["expired-scroll", undefined])
 })
 
 test("conversation incremental pages pin bounds and checkpoint with overlap", async () => {
@@ -1006,7 +1151,8 @@ test("ticket replacement pins total count before allowing reconciliation", async
   const first = await runTicketReconciliationPage(
     client,
     assignmentDirectory,
-    undefined
+    undefined,
+    () => new Date(2_000_000)
   )
   if (!first.hasMore) assert.fail("Expected another ticket page")
   const second = await runTicketReconciliationPage(
@@ -1014,7 +1160,11 @@ test("ticket replacement pins total count before allowing reconciliation", async
     assignmentDirectory,
     first.nextState
   )
-  assert.deepEqual(calls.tickets, [undefined, "ticket-all-next"])
+  assert.deepEqual(calls.tickets, [
+    { createdBefore: 1_940, cursor: undefined },
+    { createdBefore: 1_940, cursor: "ticket-all-next" },
+  ])
+  assert.equal(first.nextState.createdBefore, 1_940)
   assert.equal(first.nextState.expectedTotalCount, 2)
   assert.deepEqual(second.hasMore, false)
 
@@ -1047,6 +1197,35 @@ test("ticket replacement pins total count before allowing reconciliation", async
       ),
     /repeated a record/
   )
+})
+
+test("ticket replacement safely restarts continuation state from older deployments", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      tickets: [{ records: [minimalTicket], totalCount: 1 }],
+    },
+    calls
+  )
+  const result = await runTicketReconciliationPage(
+    client,
+    assignmentDirectory,
+    {
+      after: "legacy-cursor",
+      recentCursors: ["legacy-cursor"],
+      pageCount: 3,
+      expectedTotalCount: 3,
+      seenCount: 2,
+      recentRecordIds: ["old-ticket"],
+    },
+    () => new Date(3_000_000)
+  )
+  assert.deepEqual(calls.tickets, [{ createdBefore: 2_940, cursor: undefined }])
+  assert.deepEqual(result.hasMore, false)
 })
 
 test("cycle cache shares pending work, evicts terminal data, and retries errors", async () => {
@@ -1163,7 +1342,7 @@ test("ticket search sends pinned bounds and replacement uses immutable membershi
   }
   const client = createIntercomClient(async () => {})
   await client.searchTickets(100, 200, "ticket-cursor")
-  await client.listTickets("all-ticket-cursor")
+  await client.listTickets(300, "all-ticket-cursor")
 
   assert.equal(new URL(requests[0].url).pathname, "/tickets/search")
   assert.deepEqual(requests[0].body, {
@@ -1174,12 +1353,24 @@ test("ticket search sends pinned bounds and replacement uses immutable membershi
         { field: "updated_at", operator: "<", value: 200 },
       ],
     },
-    pagination: { per_page: 150, starting_after: "ticket-cursor" },
+    pagination: {
+      per_page: INTERCOM_TICKET_PAGE_SIZE,
+      starting_after: "ticket-cursor",
+    },
     sort: { field: "id", order: "ascending" },
   })
   assert.deepEqual(requests[1].body, {
-    query: { field: "created_at", operator: ">", value: 0 },
-    pagination: { per_page: 150, starting_after: "all-ticket-cursor" },
+    query: {
+      operator: "AND",
+      value: [
+        { field: "created_at", operator: ">", value: 0 },
+        { field: "created_at", operator: "<", value: 300 },
+      ],
+    },
+    pagination: {
+      per_page: INTERCOM_TICKET_PAGE_SIZE,
+      starting_after: "all-ticket-cursor",
+    },
     sort: { field: "id", order: "ascending" },
   })
 })
@@ -1336,13 +1527,13 @@ test("worker manifest exposes one connected four-database support bundle", () =>
       "replace",
       { type: "interval", intervalMs: 60 * 60_000 },
       "incremental",
-      { type: "interval", intervalMs: 2 * 60_000 },
+      { type: "interval", intervalMs: 5 * 60_000 },
       "replace",
-      { type: "interval", intervalMs: 24 * 60 * 60_000 },
+      { type: "manual" },
       "incremental",
-      { type: "interval", intervalMs: 2 * 60_000 },
+      { type: "interval", intervalMs: 5 * 60_000 },
       "replace",
-      { type: "interval", intervalMs: 24 * 60 * 60_000 },
+      { type: "manual" },
     ]
   )
   assert.deepEqual(worker.manifest.pacers, [

--- a/workers/intercom-sync/test.ts
+++ b/workers/intercom-sync/test.ts
@@ -827,7 +827,7 @@ function fakeClient(
       if (!page) throw new Error("Missing fake ticket search page")
       return page
     },
-    async listTickets(createdBefore, cursor) {
+    async searchTicketsForReconciliation(createdBefore, cursor) {
       ;(calls.tickets ??= []).push({ createdBefore, cursor })
       const page = pages.tickets?.shift()
       if (!page) throw new Error("Missing fake ticket page")
@@ -1342,7 +1342,7 @@ test("ticket search sends pinned bounds and replacement uses immutable membershi
   }
   const client = createIntercomClient(async () => {})
   await client.searchTickets(100, 200, "ticket-cursor")
-  await client.listTickets(300, "all-ticket-cursor")
+  await client.searchTicketsForReconciliation(300, "all-ticket-cursor")
 
   assert.equal(new URL(requests[0].url).pathname, "/tickets/search")
   assert.deepEqual(requests[0].body, {

--- a/workers/intercom-sync/test.ts
+++ b/workers/intercom-sync/test.ts
@@ -1,0 +1,1371 @@
+// Deterministic offline tests for the Intercom sync. No live Intercom or
+// Notion connection is made; all HTTP behavior uses mocked responses.
+
+import assert from "node:assert/strict"
+import { afterEach, test } from "node:test"
+
+import { RateLimitError } from "@notionhq/workers"
+
+import { companyToChange, runCompaniesPage } from "./src/companies.js"
+import { contactToChange, runContactsPage } from "./src/contacts.js"
+import {
+  CONSISTENCY_BUFFER_SECONDS,
+  WATERMARK_OVERLAP_SECONDS,
+  conversationPageContent,
+  conversationIncrementalWindow,
+  conversationTitle,
+  conversationToChange,
+  nextConversationWatermark,
+  runConversationIncrementalPage,
+  runConversationReconciliationPage,
+} from "./src/conversations.js"
+import {
+  escapeMarkdown,
+  htmlToPlainText,
+  optionalUnixSecondsToIso,
+  secondsToMinutes,
+  unixSecondsToIso,
+} from "./src/helpers.js"
+import worker, { createCycleCache } from "./src/index.js"
+import {
+  INTERCOM_API_VERSION,
+  INTERCOM_PAGE_SIZE,
+  IntercomApiError,
+  createIntercomClient,
+  getIntercomApiRoot,
+  retryAfterSeconds,
+  type AssignmentDirectory,
+  type ContactDirectory,
+  type IntercomClient,
+  type IntercomCompany,
+  type IntercomContact,
+  type IntercomConversation,
+  type IntercomPage,
+  type IntercomTicket,
+} from "./src/intercom.js"
+import {
+  MAX_CURSOR_HISTORY,
+  MAX_CURSOR_PAGES,
+  nextCursorState,
+} from "./src/pagination.js"
+import {
+  TICKET_CONSISTENCY_BUFFER_SECONDS,
+  TICKET_WATERMARK_OVERLAP_SECONDS,
+  nextTicketWatermark,
+  runTicketIncrementalPage,
+  runTicketReconciliationPage,
+  ticketIncrementalWindow,
+  ticketPageContent,
+  ticketToChange,
+} from "./src/tickets.js"
+
+const originalFetch = globalThis.fetch
+const originalToken = process.env.INTERCOM_ACCESS_TOKEN
+const originalRegion = process.env.INTERCOM_REGION
+const originalDateNow = Date.now
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  Date.now = originalDateNow
+  if (originalToken === undefined) delete process.env.INTERCOM_ACCESS_TOKEN
+  else process.env.INTERCOM_ACCESS_TOKEN = originalToken
+  if (originalRegion === undefined) delete process.env.INTERCOM_REGION
+  else process.env.INTERCOM_REGION = originalRegion
+})
+
+function propertyText(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function assertPropertyContains(value: unknown, expected: string | number) {
+  assert.ok(propertyText(value).includes(String(expected)))
+}
+
+function assertEmpty(value: unknown) {
+  assert.deepEqual(value, [])
+}
+
+const contactDirectory: ContactDirectory = {
+  admins: new Map([
+    ["10", "Ada Lovelace"],
+    ["11", "Grace Hopper"],
+  ]),
+  tags: new Map([
+    ["tag-vip", "VIP"],
+    ["tag-beta", "Beta"],
+  ]),
+}
+
+const assignmentDirectory: AssignmentDirectory = {
+  admins: new Map([["10", "Ada Lovelace"]]),
+  teams: new Map([["20", "Support East"]]),
+}
+
+const fullContact: IntercomContact = {
+  id: "contact-1",
+  external_id: "customer-42",
+  workspace_id: "workspace-1",
+  role: "user",
+  email: "customer@example.com",
+  phone: "+1 415 555 0100",
+  name: "Pat Customer",
+  owner_id: 10,
+  has_hard_bounced: true,
+  marked_email_as_spam: true,
+  unsubscribed_from_emails: true,
+  created_at: 1_700_000_000,
+  updated_at: 1_700_003_600,
+  signed_up_at: 1_699_000_000,
+  last_seen_at: 1_700_002_000,
+  last_replied_at: 1_700_002_200,
+  last_contacted_at: 1_700_002_100,
+  tags: {
+    data: [
+      { id: "tag-vip" },
+      { id: "tag-beta", name: "Early access" },
+      { id: "tag-vip" },
+    ],
+    total_count: 3,
+  },
+  companies: {
+    data: [
+      { id: "company-acme" },
+      { id: "company-globex", name: "Globex International" },
+    ],
+    total_count: 2,
+  },
+  location: { country: "Ireland", region: "Leinster", city: "Dublin" },
+}
+
+const minimalContact: IntercomContact = {
+  id: "contact-minimal",
+  external_id: null,
+  role: null,
+  email: null,
+  phone: null,
+  name: null,
+  owner_id: null,
+  has_hard_bounced: false,
+  marked_email_as_spam: false,
+  unsubscribed_from_emails: false,
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_001,
+  signed_up_at: 0,
+  last_seen_at: null,
+  last_replied_at: null,
+  last_contacted_at: null,
+  tags: null,
+  companies: null,
+  location: null,
+}
+
+const fullCompany: IntercomCompany = {
+  id: "company-acme",
+  name: "Acme",
+  company_id: "acme-external",
+  created_at: 1_699_000_000,
+  updated_at: 1_700_003_600,
+  remote_created_at: 1_698_000_000,
+  last_request_at: 1_700_002_000,
+  size: 250,
+  website: "acme.example",
+  industry: "financial_services",
+  monthly_spend: 12_500,
+  session_count: 4_200,
+  user_count: 150,
+  plan: { id: "plan-1", name: "Enterprise" },
+  tags: { tags: [{ id: "tag-vip", name: "VIP" }] },
+  segments: { segments: [{ id: "segment-1", name: "High touch" }] },
+}
+
+const minimalCompany: IntercomCompany = {
+  id: "company-minimal",
+  name: null,
+  company_id: null,
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_001,
+}
+
+const fullConversation: IntercomConversation = {
+  id: "conversation-1",
+  title: "Billing question",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_003_600,
+  waiting_since: 1_700_003_000,
+  snoozed_until: 1_700_007_200,
+  state: "open",
+  read: false,
+  priority: "priority",
+  admin_assignee_id: 10,
+  team_assignee_id: 20,
+  company: { id: "company-acme", name: "Acme" },
+  tags: {
+    tags: [
+      { id: "tag-vip", name: "VIP" },
+      { id: "tag-billing", name: "Billing" },
+      { id: "tag-vip", name: "VIP" },
+    ],
+  },
+  source: {
+    type: "email",
+    subject: "Invoice question",
+    body: "<p>Hello &amp; thanks.</p><script>hidden()</script><p>Can you <strong>help</strong>?</p>",
+    redacted: false,
+  },
+  contacts: {
+    contacts: [{ id: "contact-1" }, { id: "contact-2" }, { id: "contact-1" }],
+  },
+  conversation_rating: { rating: 2, remark: "Needed *more* detail." },
+  sla_applied: { sla_name: "Premium support", sla_status: "missed" },
+  statistics: {
+    time_to_admin_reply: 90,
+    median_time_to_reply: 120,
+    handling_time: 600,
+    adjusted_handling_time: 540,
+    last_contact_reply_at: 1_700_003_200,
+    count_reopens: 1,
+    count_assignments: 2,
+    count_conversation_parts: 8,
+  },
+  ai_agent: { resolution_state: "confirmed_resolution" },
+  ai_agent_participated: true,
+}
+
+const minimalConversation: IntercomConversation = {
+  id: "conversation-minimal",
+  title: null,
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_001,
+  waiting_since: 0,
+  snoozed_until: null,
+  state: null,
+  read: true,
+  priority: "not_priority",
+  admin_assignee_id: null,
+  team_assignee_id: null,
+  company: null,
+  tags: null,
+  source: null,
+  contacts: null,
+  conversation_rating: null,
+  sla_applied: null,
+  statistics: null,
+  ai_agent: null,
+  ai_agent_participated: false,
+}
+
+const fullTicket: IntercomTicket = {
+  id: "ticket-api-1",
+  ticket_id: "1042",
+  category: "Customer",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_003_600,
+  open: true,
+  snoozed_until: 1_700_007_200,
+  is_shared: true,
+  admin_assignee_id: 10,
+  team_assignee_id: 20,
+  ticket_attributes: {
+    _default_title_: "Refund request",
+    _default_description_: "<p>Please refund <strong>order 42</strong>.</p>",
+    workspace_specific_secret: "not copied",
+  },
+  ticket_state: {
+    id: "state-1",
+    category: "waiting_on_customer",
+    internal_label: "Waiting for customer",
+  },
+  ticket_type: { id: "type-1", name: "Refund" },
+  contacts: { contacts: [{ id: "contact-1" }, { id: "contact-1" }] },
+}
+
+const minimalTicket: IntercomTicket = {
+  id: "ticket-api-minimal",
+  ticket_id: null,
+  category: null,
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_001,
+  open: false,
+  snoozed_until: null,
+  is_shared: false,
+  admin_assignee_id: "0",
+  team_assignee_id: 0,
+  ticket_attributes: null,
+  ticket_state: null,
+  ticket_type: null,
+  contacts: null,
+}
+
+test("full contact maps actionable fields and company relations", () => {
+  const change = contactToChange(fullContact, contactDirectory)
+  assert.equal(change.type, "upsert")
+  assert.equal(change.key, fullContact.id)
+  assert.equal(change.upstreamUpdatedAt, "2023-11-14T23:13:20.000Z")
+  assertPropertyContains(change.properties.Name, "Pat Customer")
+  assertPropertyContains(change.properties.Role, "User")
+  assertPropertyContains(change.properties.Owner, "Ada Lovelace")
+  assertPropertyContains(change.properties.Email, "customer@example.com")
+  assertPropertyContains(change.properties.Phone, "+1 415 555 0100")
+  assertPropertyContains(change.properties.Companies, "company-acme")
+  assertPropertyContains(change.properties.Companies, "company-globex")
+  assertPropertyContains(change.properties.Tags, "VIP")
+  assertPropertyContains(change.properties.Tags, "Early access")
+  assertPropertyContains(change.properties.Country, "Ireland")
+  assertPropertyContains(
+    change.properties["Email Restrictions"],
+    "Unsubscribed"
+  )
+  assertPropertyContains(change.properties["Email Restrictions"], "Marked spam")
+  assertPropertyContains(
+    change.properties["Email Restrictions"],
+    "Hard bounced"
+  )
+  assertPropertyContains(change.properties["Contact ID"], "contact-1")
+  assertPropertyContains(change.properties["External ID"], "customer-42")
+})
+
+test("minimal contact uses a stable title and explicitly clears nullable fields", () => {
+  const change = contactToChange(minimalContact, contactDirectory)
+  assertPropertyContains(change.properties.Name, "Contact contact-minimal")
+  for (const property of [
+    "Role",
+    "Owner",
+    "Email",
+    "Phone",
+    "Companies",
+    "Country",
+    "Tags",
+    "Last Seen",
+    "Signed Up",
+    "Last Contacted",
+    "Last Replied",
+    "Email Restrictions",
+    "External ID",
+  ] as const) {
+    assertEmpty(change.properties[property])
+  }
+})
+
+test("contact title fallbacks and unknown lookup values stay diagnosable", () => {
+  const emailTitle = contactToChange(
+    { ...minimalContact, email: "fallback@example.com" },
+    contactDirectory
+  )
+  assertPropertyContains(emailTitle.properties.Name, "fallback@example.com")
+
+  const unknown = contactToChange(
+    {
+      ...minimalContact,
+      owner_id: 404,
+      tags: { data: [{ id: "missing-tag" }] },
+      companies: { data: [{ id: "missing-company" }] },
+    },
+    contactDirectory
+  )
+  assertPropertyContains(unknown.properties.Owner, "Unknown admin (404)")
+  assertPropertyContains(unknown.properties.Tags, "Unknown tag (missing-tag)")
+  assertPropertyContains(unknown.properties.Companies, "missing-company")
+})
+
+test("company transform maps account value and engagement context", () => {
+  const change = companyToChange(fullCompany)
+  assert.equal(change.key, "company-acme")
+  assert.equal(change.upstreamUpdatedAt, "2023-11-14T23:13:20.000Z")
+  assertPropertyContains(change.properties.Name, "Acme")
+  assertPropertyContains(change.properties.Plan, "Enterprise")
+  assertPropertyContains(change.properties.Industry, "Financial Services")
+  assertPropertyContains(change.properties.Website, "https://acme.example/")
+  assertPropertyContains(change.properties.Employees, 250)
+  assertPropertyContains(change.properties.Users, 150)
+  assertPropertyContains(change.properties.Sessions, 4200)
+  assertPropertyContains(change.properties["Monthly Spend"], 12500)
+  assertPropertyContains(change.properties.Tags, "VIP")
+  assertPropertyContains(change.properties.Segments, "High touch")
+  assertPropertyContains(
+    change.properties["External Company ID"],
+    "acme-external"
+  )
+})
+
+test("minimal company has a stable title and clears optional values", () => {
+  const change = companyToChange(minimalCompany)
+  assertPropertyContains(change.properties.Name, "Company company-minimal")
+  for (const property of [
+    "Plan",
+    "Industry",
+    "Website",
+    "Employees",
+    "Users",
+    "Sessions",
+    "Monthly Spend",
+    "Last Active",
+    "Tags",
+    "Segments",
+    "Created at Source",
+    "External Company ID",
+  ] as const) {
+    assertEmpty(change.properties[property])
+  }
+})
+
+test("full conversation maps triage, relation, SLA, CSAT, and response fields", () => {
+  const change = conversationToChange(fullConversation, assignmentDirectory)
+  assert.equal(change.key, fullConversation.id)
+  assert.equal(change.upstreamUpdatedAt, "2023-11-14T23:13:20.000Z")
+  assertPropertyContains(change.properties.Title, "Billing question")
+  assertPropertyContains(change.properties.State, "Open")
+  assertPropertyContains(change.properties.Priority, "Yes")
+  assertPropertyContains(change.properties.Unread, "Yes")
+  assert.equal(
+    propertyText(change.properties.Contacts),
+    '[{"type":"primaryKey","value":"contact-1"},{"type":"primaryKey","value":"contact-2"}]'
+  )
+  assertPropertyContains(change.properties.Assignee, "Ada Lovelace")
+  assertPropertyContains(change.properties.Team, "Support East")
+  assertPropertyContains(change.properties.Channel, "Email")
+  assertPropertyContains(change.properties.Tags, "VIP")
+  assertPropertyContains(change.properties.Tags, "Billing")
+  assertPropertyContains(change.properties["SLA Status"], "Missed")
+  assertPropertyContains(change.properties.Rating, 2)
+  assertPropertyContains(change.properties.Company, "company-acme")
+  assertPropertyContains(change.properties["First Reply (min)"], 1.5)
+  assertPropertyContains(change.properties["Median Reply (min)"], 2)
+  assertPropertyContains(change.properties["Handling Time (min)"], 9)
+  assertPropertyContains(change.properties["Last Contact Reply"], "2023-11")
+  assertPropertyContains(change.properties.Reopens, 1)
+  assertPropertyContains(change.properties["AI Resolution"], "Confirmed")
+  assertPropertyContains(change.properties["Conversation ID"], "conversation-1")
+  assert.ok((change.pageContentMarkdown ?? "").includes("Hello & thanks\\."))
+  assert.ok(
+    (change.pageContentMarkdown ?? "").includes("Needed \\*more\\* detail\\.")
+  )
+  assert.doesNotMatch(change.pageContentMarkdown ?? "", /<p>|hidden\(\)/)
+})
+
+test("minimal conversation clears optional values and preserves false checkboxes", () => {
+  const change = conversationToChange(minimalConversation, assignmentDirectory)
+  assertPropertyContains(
+    change.properties.Title,
+    "Conversation conversation-minimal"
+  )
+  for (const property of [
+    "State",
+    "Contacts",
+    "Assignee",
+    "Team",
+    "Waiting Since",
+    "Channel",
+    "Tags",
+    "SLA Status",
+    "Rating",
+    "Company",
+    "First Reply (min)",
+    "Median Reply (min)",
+    "Handling Time (min)",
+    "Last Contact Reply",
+    "Reopens",
+    "AI Resolution",
+    "Snoozed Until",
+  ] as const) {
+    assertEmpty(change.properties[property])
+  }
+  assertPropertyContains(change.properties.Priority, "No")
+  assertPropertyContains(change.properties.Unread, "No")
+  assert.equal(change.pageContentMarkdown, "")
+})
+
+test("conversation title fallback order skips redacted bodies", () => {
+  assert.equal(
+    conversationTitle({
+      ...minimalConversation,
+      source: { subject: "  Subject fallback  ", body: "Body fallback" },
+    }),
+    "Subject fallback"
+  )
+  assert.equal(
+    conversationTitle({
+      ...minimalConversation,
+      source: { subject: null, body: "<p>Body fallback</p>" },
+    }),
+    "Body fallback"
+  )
+  assert.equal(
+    conversationTitle({
+      ...minimalConversation,
+      source: { body: "Sensitive body", redacted: true },
+    }),
+    "Conversation conversation-minimal"
+  )
+  assert.match(
+    conversationPageContent({
+      ...minimalConversation,
+      source: { body: "Sensitive body", redacted: true },
+    }),
+    /redacted in Intercom/
+  )
+})
+
+test("unknown conversation assignments are not silently discarded", () => {
+  const change = conversationToChange(
+    {
+      ...minimalConversation,
+      admin_assignee_id: 404,
+      team_assignee_id: 405,
+    },
+    assignmentDirectory
+  )
+  assertPropertyContains(change.properties.Assignee, "Unknown admin (404)")
+  assertPropertyContains(change.properties.Team, "Unknown team (405)")
+
+  const unassigned = conversationToChange(
+    {
+      ...minimalConversation,
+      admin_assignee_id: 0,
+      team_assignee_id: "0",
+    },
+    assignmentDirectory
+  )
+  assertEmpty(unassigned.properties.Assignee)
+  assertEmpty(unassigned.properties.Team)
+})
+
+test("ticket transform maps workflow context without copying arbitrary attributes", () => {
+  const change = ticketToChange(fullTicket, assignmentDirectory)
+  assert.equal(change.key, "ticket-api-1")
+  assertPropertyContains(change.properties.Title, "Refund request")
+  assertPropertyContains(change.properties.State, "Waiting for customer")
+  assertPropertyContains(
+    change.properties["State Category"],
+    "Waiting On Customer"
+  )
+  assertPropertyContains(change.properties["Ticket Type"], "Refund")
+  assertPropertyContains(change.properties.Category, "Customer")
+  assertPropertyContains(change.properties.Contacts, "contact-1")
+  assertPropertyContains(change.properties.Assignee, "Ada Lovelace")
+  assertPropertyContains(change.properties.Team, "Support East")
+  assertPropertyContains(change.properties.Open, "Yes")
+  assertPropertyContains(change.properties["Shared with Customer"], "Yes")
+  assertPropertyContains(change.properties["Inbox Ticket ID"], "1042")
+  assertPropertyContains(change.properties["Ticket ID"], "ticket-api-1")
+  assert.match(change.pageContentMarkdown ?? "", /Please refund/)
+  assert.doesNotMatch(change.pageContentMarkdown ?? "", /workspace_specific/)
+})
+
+test("minimal ticket uses API id, clears nullable values, and treats zero as unassigned", () => {
+  const change = ticketToChange(minimalTicket, assignmentDirectory)
+  assertPropertyContains(change.properties.Title, "Ticket #ticket-api-minimal")
+  for (const property of [
+    "State",
+    "State Category",
+    "Ticket Type",
+    "Category",
+    "Contacts",
+    "Assignee",
+    "Team",
+    "Snoozed Until",
+    "Inbox Ticket ID",
+  ] as const) {
+    assertEmpty(change.properties[property])
+  }
+  assertPropertyContains(change.properties.Open, "No")
+  assertPropertyContains(change.properties["Shared with Customer"], "No")
+  assert.equal(ticketPageContent(minimalTicket), "")
+})
+
+test("HTML conversion decodes entities, drops hidden content, and bounds output", () => {
+  assert.equal(
+    htmlToPlainText(
+      "<p>Hello&nbsp;world</p><style>.secret{}</style><ul><li>One</li><li>Two &#x1F642;</li></ul>"
+    ),
+    "Hello world\n• One\n• Two 🙂"
+  )
+  assert.ok(htmlToPlainText(`<p>${"x".repeat(30_000)}</p>`).length <= 20_000)
+  assert.equal(
+    htmlToPlainText(`<script>${"secret".repeat(20_000)}</script><p>Safe</p>`),
+    "Safe"
+  )
+  assert.equal(
+    escapeMarkdown("# [link](x) *important*"),
+    "\\# \\[link\\]\\(x\\) \\*important\\*"
+  )
+})
+
+test("timestamp and duration helpers validate edge cases", () => {
+  assert.equal(unixSecondsToIso(0, "epoch"), "1970-01-01T00:00:00.000Z")
+  assert.equal(optionalUnixSecondsToIso(0, "optional"), undefined)
+  assert.equal(secondsToMinutes(0), 0)
+  assert.equal(secondsToMinutes(61), 1.02)
+  assert.equal(secondsToMinutes(-1), undefined)
+  assert.throws(() => unixSecondsToIso(-1, "invalid"), /non-negative/)
+  assert.throws(() => unixSecondsToIso(1.5, "invalid"), /non-negative/)
+  assert.throws(
+    () => contactToChange({ ...minimalContact, id: " " }, contactDirectory),
+    /contact is missing its id/
+  )
+  assert.throws(
+    () =>
+      conversationToChange(
+        { ...minimalConversation, id: "" },
+        assignmentDirectory
+      ),
+    /conversation is missing its id/
+  )
+})
+
+test("incremental windows keep a buffer and advance with overlap", () => {
+  const now = () => new Date(1_000_000)
+  assert.deepEqual(conversationIncrementalWindow(undefined, now), {
+    since: 0,
+    until: 1_000 - CONSISTENCY_BUFFER_SECONDS,
+  })
+  assert.equal(
+    nextConversationWatermark(10_000),
+    10_000 - WATERMARK_OVERLAP_SECONDS
+  )
+  assert.equal(nextConversationWatermark(100), 0)
+  assert.deepEqual(
+    conversationIncrementalWindow(
+      {
+        since: 500,
+        until: 700,
+        after: "cursor",
+        recentCursors: ["cursor"],
+        pageCount: 1,
+      },
+      () => new Date(2_000_000)
+    ),
+    { since: 500, until: 700 }
+  )
+})
+
+test("ticket windows pin pagination and replay an overlap", () => {
+  const now = () => new Date(1_000_000)
+  assert.deepEqual(ticketIncrementalWindow(undefined, now), {
+    since: 0,
+    until: 1_000 - TICKET_CONSISTENCY_BUFFER_SECONDS,
+  })
+  assert.equal(
+    nextTicketWatermark(10_000),
+    10_000 - TICKET_WATERMARK_OVERLAP_SECONDS
+  )
+  assert.deepEqual(
+    ticketIncrementalWindow(
+      {
+        since: 500,
+        until: 700,
+        after: "ticket-cursor",
+        recentCursors: ["ticket-cursor"],
+        pageCount: 1,
+      },
+      () => new Date(2_000_000)
+    ),
+    { since: 500, until: 700 }
+  )
+})
+
+test("incremental state rejects malformed windows before API calls", () => {
+  assert.throws(
+    () => conversationIncrementalWindow({ since: 1, after: "cursor" }),
+    /missing its pinned until/
+  )
+  assert.throws(
+    () => conversationIncrementalWindow({ since: 1, until: 2 }),
+    /until without a pagination cursor/
+  )
+  assert.throws(
+    () => conversationIncrementalWindow({ since: -1 }),
+    /non-negative/
+  )
+  assert.throws(
+    () =>
+      conversationIncrementalWindow({ since: 10, until: 5, after: "cursor" }),
+    /ends before it starts/
+  )
+})
+
+test("cursor state rejects immediate and longer pagination loops", () => {
+  const first = nextCursorState(undefined, "A", "contacts")
+  const second = nextCursorState(first, "B", "contacts")
+  assert.deepEqual(second, {
+    after: "B",
+    recentCursors: ["A", "B"],
+    pageCount: 2,
+  })
+  assert.throws(() => nextCursorState(second, "A", "contacts"), /repeated/)
+  assert.throws(() => nextCursorState(undefined, "", "contacts"), /missing/)
+})
+
+test("cursor state keeps bounded history and enforces a maximum page count", () => {
+  let state = nextCursorState(undefined, "cursor-0", "contacts")
+  for (let index = 1; index < MAX_CURSOR_HISTORY + 20; index++) {
+    state = nextCursorState(state, `cursor-${index}`, "contacts")
+  }
+  assert.equal(state.recentCursors.length, MAX_CURSOR_HISTORY)
+  assert.equal(state.recentCursors[0], "cursor-20")
+  assert.equal(state.pageCount, MAX_CURSOR_HISTORY + 20)
+  assert.throws(
+    () =>
+      nextCursorState(
+        {
+          after: "last",
+          recentCursors: ["last"],
+          pageCount: MAX_CURSOR_PAGES - 1,
+        },
+        "one-too-many",
+        "contacts"
+      ),
+    /exceeded 10000 pages/
+  )
+})
+
+type FakeClientCalls = {
+  contacts: Array<string | undefined>
+  searches: Array<{ since: number; until: number; cursor?: string }>
+  conversations: Array<string | undefined>
+  companyScrolls?: Array<string | undefined>
+  ticketSearches?: Array<{ since: number; until: number; cursor?: string }>
+  tickets?: Array<string | undefined>
+}
+
+function fakeClient(
+  pages: {
+    contacts?: Array<IntercomPage<IntercomContact>>
+    companies?: Array<{ records: IntercomCompany[]; scrollParameter?: string }>
+    searches?: Array<IntercomPage<IntercomConversation>>
+    conversations?: Array<IntercomPage<IntercomConversation>>
+    ticketSearches?: Array<IntercomPage<IntercomTicket>>
+    tickets?: Array<IntercomPage<IntercomTicket>>
+  },
+  calls: FakeClientCalls
+): IntercomClient {
+  return {
+    async listContacts(cursor) {
+      calls.contacts.push(cursor)
+      const page = pages.contacts?.shift()
+      if (!page) throw new Error("Missing fake contact page")
+      return page
+    },
+    async scrollCompanies(scrollParameter) {
+      ;(calls.companyScrolls ??= []).push(scrollParameter)
+      const page = pages.companies?.shift()
+      if (!page) throw new Error("Missing fake company page")
+      return page
+    },
+    async searchConversations(since, until, cursor) {
+      calls.searches.push({ since, until, cursor })
+      const page = pages.searches?.shift()
+      if (!page) throw new Error("Missing fake search page")
+      return page
+    },
+    async searchTickets(since, until, cursor) {
+      ;(calls.ticketSearches ??= []).push({ since, until, cursor })
+      const page = pages.ticketSearches?.shift()
+      if (!page) throw new Error("Missing fake ticket search page")
+      return page
+    },
+    async listTickets(cursor) {
+      ;(calls.tickets ??= []).push(cursor)
+      const page = pages.tickets?.shift()
+      if (!page) throw new Error("Missing fake ticket page")
+      return page
+    },
+    async listConversations(cursor) {
+      calls.conversations.push(cursor)
+      const page = pages.conversations?.shift()
+      if (!page) throw new Error("Missing fake conversation page")
+      return page
+    },
+    async fetchContactDirectory() {
+      return contactDirectory
+    },
+    async fetchAssignmentDirectory() {
+      return assignmentDirectory
+    },
+  }
+}
+
+test("contact replacement follows cursors and ends without continuation state", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      contacts: [
+        { records: [fullContact], nextCursor: "contacts-next" },
+        { records: [minimalContact] },
+      ],
+    },
+    calls
+  )
+  const first = await runContactsPage(client, contactDirectory, undefined)
+  const second = await runContactsPage(
+    client,
+    contactDirectory,
+    first.nextState
+  )
+  assert.equal(first.hasMore, true)
+  assert.equal(first.nextState.after, "contacts-next")
+  assert.deepEqual(calls.contacts, [undefined, "contacts-next"])
+  assert.deepEqual(second, {
+    changes: [contactToChange(minimalContact, contactDirectory)],
+    hasMore: false,
+  })
+})
+
+test("company replacement accepts a stable scroll token and guards repeated pages", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      companies: [
+        { records: [fullCompany], scrollParameter: "scroll-session" },
+        { records: [minimalCompany], scrollParameter: "scroll-session" },
+        { records: [], scrollParameter: "scroll-session" },
+      ],
+    },
+    calls
+  )
+  const first = await runCompaniesPage(client, undefined)
+  if (!first.hasMore) assert.fail("Expected another company page")
+  const second = await runCompaniesPage(client, first.nextState)
+  if (!second.hasMore) assert.fail("Expected a company terminal page")
+  const terminal = await runCompaniesPage(client, second.nextState)
+  assert.equal(first.hasMore, true)
+  assert.equal(second.nextState.pageCount, 2)
+  assert.deepEqual(calls.companyScrolls, [
+    undefined,
+    "scroll-session",
+    "scroll-session",
+  ])
+  assert.deepEqual(terminal, { changes: [], hasMore: false })
+
+  const repeated = fakeClient(
+    {
+      companies: [
+        { records: [fullCompany], scrollParameter: "scroll-session" },
+      ],
+    },
+    calls
+  )
+  await assert.rejects(
+    () => runCompaniesPage(repeated, first.nextState),
+    /repeated a page/
+  )
+})
+
+test("company replacement safely restarts an expired scroll session", async () => {
+  const calls: Array<string | undefined> = []
+  const base = fakeClient({}, { contacts: [], searches: [], conversations: [] })
+  const client: IntercomClient = {
+    ...base,
+    async scrollCompanies(scrollParameter) {
+      calls.push(scrollParameter)
+      if (calls.length === 1) {
+        throw new IntercomApiError(500, "expired company scroll")
+      }
+      return { records: [fullCompany], scrollParameter: "fresh-scroll" }
+    },
+  }
+  const result = await runCompaniesPage(client, {
+    scrollParameter: "expired-scroll",
+    recentPageKeys: ["old:first:1"],
+    pageCount: 4,
+    restartCount: 0,
+  })
+  if (!result.hasMore) assert.fail("Expected restarted company pagination")
+  assert.deepEqual(calls, ["expired-scroll", undefined])
+  assert.equal(result.nextState.restartCount, 1)
+  assert.equal(result.nextState.pageCount, 1)
+})
+
+test("conversation incremental pages pin bounds and checkpoint with overlap", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      searches: [
+        { records: [fullConversation], nextCursor: "search-next" },
+        { records: [minimalConversation] },
+      ],
+    },
+    calls
+  )
+  const first = await runConversationIncrementalPage(
+    client,
+    assignmentDirectory,
+    undefined,
+    () => new Date(2_000_000)
+  )
+  const second = await runConversationIncrementalPage(
+    client,
+    assignmentDirectory,
+    first.nextState,
+    () => new Date(9_000_000)
+  )
+  assert.deepEqual(calls.searches, [
+    { since: 0, until: 1_940, cursor: undefined },
+    { since: 0, until: 1_940, cursor: "search-next" },
+  ])
+  assert.equal(first.hasMore, true)
+  assert.equal(second.hasMore, false)
+  assert.deepEqual(second.nextState, {
+    since: 1_940 - WATERMARK_OVERLAP_SECONDS,
+  })
+})
+
+test("conversation reconciliation uses canonical listing and replace termination", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      conversations: [
+        { records: [fullConversation], nextCursor: "reconcile-next" },
+        { records: [] },
+      ],
+    },
+    calls
+  )
+  const first = await runConversationReconciliationPage(
+    client,
+    assignmentDirectory,
+    undefined
+  )
+  const second = await runConversationReconciliationPage(
+    client,
+    assignmentDirectory,
+    first.nextState
+  )
+  assert.deepEqual(calls.conversations, [undefined, "reconcile-next"])
+  assert.equal(first.hasMore, true)
+  assert.deepEqual(second, { changes: [], hasMore: false })
+})
+
+test("ticket incremental pages pin bounds and checkpoint with overlap", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      ticketSearches: [
+        { records: [fullTicket], nextCursor: "ticket-next" },
+        { records: [minimalTicket] },
+      ],
+    },
+    calls
+  )
+  const first = await runTicketIncrementalPage(
+    client,
+    assignmentDirectory,
+    undefined,
+    () => new Date(2_000_000)
+  )
+  const second = await runTicketIncrementalPage(
+    client,
+    assignmentDirectory,
+    first.nextState,
+    () => new Date(9_000_000)
+  )
+  assert.deepEqual(calls.ticketSearches, [
+    { since: 0, until: 1_940, cursor: undefined },
+    { since: 0, until: 1_940, cursor: "ticket-next" },
+  ])
+  assert.equal(first.hasMore, true)
+  assert.deepEqual(second.nextState, {
+    since: 1_940 - TICKET_WATERMARK_OVERLAP_SECONDS,
+  })
+})
+
+test("ticket replacement pins total count before allowing reconciliation", async () => {
+  const calls: FakeClientCalls = {
+    contacts: [],
+    searches: [],
+    conversations: [],
+  }
+  const client = fakeClient(
+    {
+      tickets: [
+        { records: [fullTicket], nextCursor: "ticket-all-next", totalCount: 2 },
+        { records: [minimalTicket], totalCount: 2 },
+      ],
+    },
+    calls
+  )
+  const first = await runTicketReconciliationPage(
+    client,
+    assignmentDirectory,
+    undefined
+  )
+  if (!first.hasMore) assert.fail("Expected another ticket page")
+  const second = await runTicketReconciliationPage(
+    client,
+    assignmentDirectory,
+    first.nextState
+  )
+  assert.deepEqual(calls.tickets, [undefined, "ticket-all-next"])
+  assert.equal(first.nextState.expectedTotalCount, 2)
+  assert.deepEqual(second.hasMore, false)
+
+  const changedTotal = fakeClient(
+    { tickets: [{ records: [], totalCount: 3 }] },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runTicketReconciliationPage(
+        changedTotal,
+        assignmentDirectory,
+        first.nextState
+      ),
+    /total changed/
+  )
+
+  const overlapping = fakeClient(
+    {
+      tickets: [{ records: [minimalTicket, fullTicket], totalCount: 2 }],
+    },
+    calls
+  )
+  await assert.rejects(
+    () =>
+      runTicketReconciliationPage(
+        overlapping,
+        assignmentDirectory,
+        first.nextState
+      ),
+    /repeated a record/
+  )
+})
+
+test("cycle cache shares pending work, evicts terminal data, and retries errors", async () => {
+  const cache = createCycleCache<number>()
+  let loads = 0
+  const load = async () => {
+    loads++
+    return 42
+  }
+  const [first, second] = await Promise.all([cache.get(load), cache.get(load)])
+  assert.equal(first, 42)
+  assert.equal(second, 42)
+  assert.equal(loads, 1)
+  cache.clear()
+  assert.equal(await cache.get(load), 42)
+  assert.equal(loads, 2)
+
+  const failing = createCycleCache<number>()
+  let attempts = 0
+  await assert.rejects(() =>
+    failing.get(async () => {
+      attempts++
+      throw new Error("temporary")
+    })
+  )
+  assert.equal(
+    await failing.get(async () => {
+      attempts++
+      return 7
+    }),
+    7
+  )
+  assert.equal(attempts, 2)
+})
+
+function jsonResponse(value: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+test("client uses regional host, auth, version, page size, and safe redirects", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  process.env.INTERCOM_REGION = "eu"
+  let beforeRequests = 0
+  let capturedUrl = ""
+  let capturedInit: RequestInit | undefined
+  globalThis.fetch = async (input, init) => {
+    capturedUrl = String(input)
+    capturedInit = init
+    return jsonResponse({
+      data: [minimalContact],
+      pages: { next: { starting_after: "next-contact" } },
+    })
+  }
+
+  const client = createIntercomClient(async () => {
+    beforeRequests++
+  })
+  const page = await client.listContacts("current-contact")
+  const url = new URL(capturedUrl)
+  const headers = new Headers(capturedInit?.headers)
+  assert.equal(url.origin, "https://api.eu.intercom.io")
+  assert.equal(url.pathname, "/contacts")
+  assert.equal(url.searchParams.get("per_page"), String(INTERCOM_PAGE_SIZE))
+  assert.equal(url.searchParams.get("starting_after"), "current-contact")
+  assert.equal(headers.get("Authorization"), "Bearer secret-token")
+  assert.equal(headers.get("Intercom-Version"), INTERCOM_API_VERSION)
+  assert.equal(headers.get("Accept"), "application/json")
+  assert.equal(capturedInit?.redirect, "error")
+  assert.equal(beforeRequests, 1)
+  assert.equal(page.nextCursor, "next-contact")
+})
+
+test("conversation search sends pinned bounds, immutable sort, and cursor", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  delete process.env.INTERCOM_REGION
+  let capturedInit: RequestInit | undefined
+  globalThis.fetch = async (_input, init) => {
+    capturedInit = init
+    return jsonResponse({ conversations: [], pages: { next: null } })
+  }
+  const client = createIntercomClient(async () => {})
+  await client.searchConversations(100, 200, "search-cursor")
+  assert.equal(capturedInit?.method, "POST")
+  assert.equal(
+    new Headers(capturedInit?.headers).get("Content-Type"),
+    "application/json"
+  )
+  assert.deepEqual(JSON.parse(String(capturedInit?.body)), {
+    query: {
+      operator: "AND",
+      value: [
+        { field: "updated_at", operator: ">", value: 100 },
+        { field: "updated_at", operator: "<", value: 200 },
+      ],
+    },
+    pagination: { per_page: 150, starting_after: "search-cursor" },
+    sort: { field: "id", order: "ascending" },
+  })
+})
+
+test("ticket search sends pinned bounds and replacement uses immutable membership", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  const requests: Array<{ url: string; body: unknown }> = []
+  globalThis.fetch = async (input, init) => {
+    requests.push({
+      url: String(input),
+      body: JSON.parse(String(init?.body)) as unknown,
+    })
+    return jsonResponse({ tickets: [], total_count: 0, pages: { next: null } })
+  }
+  const client = createIntercomClient(async () => {})
+  await client.searchTickets(100, 200, "ticket-cursor")
+  await client.listTickets("all-ticket-cursor")
+
+  assert.equal(new URL(requests[0].url).pathname, "/tickets/search")
+  assert.deepEqual(requests[0].body, {
+    query: {
+      operator: "AND",
+      value: [
+        { field: "updated_at", operator: ">", value: 100 },
+        { field: "updated_at", operator: "<", value: 200 },
+      ],
+    },
+    pagination: { per_page: 150, starting_after: "ticket-cursor" },
+    sort: { field: "id", order: "ascending" },
+  })
+  assert.deepEqual(requests[1].body, {
+    query: { field: "created_at", operator: ">", value: 0 },
+    pagination: { per_page: 150, starting_after: "all-ticket-cursor" },
+    sort: { field: "id", order: "ascending" },
+  })
+})
+
+test("client resolves contact and assignment directories without starting a company scroll", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  const paths: string[] = []
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input))
+    paths.push(`${url.pathname}${url.search}`)
+    if (url.pathname === "/admins") {
+      return jsonResponse({ admins: [{ id: "10", name: "Ada" }] })
+    }
+    if (url.pathname === "/teams") {
+      return jsonResponse({ teams: [{ id: "20", name: "Support" }] })
+    }
+    if (url.pathname === "/tags") {
+      return jsonResponse({ data: [{ id: "tag-1", name: "VIP" }] })
+    }
+    throw new Error(`Unexpected path ${url.pathname}`)
+  }
+
+  const client = createIntercomClient(async () => {})
+  const [contacts, assignments] = await Promise.all([
+    client.fetchContactDirectory(),
+    client.fetchAssignmentDirectory(),
+  ])
+  assert.equal(contacts.admins.get("10"), "Ada")
+  assert.equal(contacts.tags.get("tag-1"), "VIP")
+  assert.equal(assignments.admins.get("10"), "Ada")
+  assert.equal(assignments.teams.get("20"), "Support")
+  assert.ok(!paths.some((path) => path.startsWith("/companies/scroll")))
+})
+
+test("company client exposes one scroll page and requires a continuation token", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  globalThis.fetch = async (input) => {
+    const path = new URL(String(input)).pathname
+    if (path === "/companies/scroll") {
+      return jsonResponse({
+        data: [{ id: "company-1", name: "Acme" }],
+        scroll_param: "same-scroll",
+      })
+    }
+    throw new Error(`Unexpected path ${path}`)
+  }
+  const client = createIntercomClient(async () => {})
+  const page = await client.scrollCompanies()
+  assert.equal(page.records[0]?.id, "company-1")
+  assert.equal(page.scrollParameter, "same-scroll")
+
+  globalThis.fetch = async () =>
+    jsonResponse({ data: [{ id: "company-without-token" }] })
+  await assert.rejects(() => client.scrollCompanies(), /missing its next/)
+})
+
+test("client translates rate limits using the longest provider reset", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  Date.now = () => 1_000_000
+  globalThis.fetch = async () =>
+    new Response("", {
+      status: 429,
+      headers: { "Retry-After": "7", "X-RateLimit-Reset": "1020" },
+    })
+  const client = createIntercomClient(async () => {})
+  await assert.rejects(
+    () => client.listContacts(),
+    (error: unknown) =>
+      error instanceof RateLimitError && error.retryAfter === 20
+  )
+  assert.equal(retryAfterSeconds(new Response("", { status: 429 })), 10)
+})
+
+test("client rejects malformed pagination, JSON, and bounded API errors", async () => {
+  process.env.INTERCOM_ACCESS_TOKEN = "secret-token"
+  const client = createIntercomClient(async () => {})
+
+  globalThis.fetch = async () => jsonResponse({ data: [], pages: { next: {} } })
+  await assert.rejects(() => client.listContacts(), /missing starting_after/)
+
+  globalThis.fetch = async () => new Response("not-json")
+  await assert.rejects(() => client.listContacts(), /invalid JSON/)
+
+  globalThis.fetch = async () =>
+    new Response("x".repeat(2_000), { status: 500 })
+  await assert.rejects(
+    () => client.listContacts(),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message.includes("Intercom API error (500)") &&
+      error.message.length < 650
+  )
+})
+
+test("configuration allows only official regional hosts and requires a token", async () => {
+  delete process.env.INTERCOM_REGION
+  assert.equal(getIntercomApiRoot(), "https://api.intercom.io")
+  process.env.INTERCOM_REGION = "au"
+  assert.equal(getIntercomApiRoot(), "https://api.au.intercom.io")
+  process.env.INTERCOM_REGION = "custom"
+  assert.throws(() => createIntercomClient(async () => {}), /us, eu, au/)
+
+  delete process.env.INTERCOM_REGION
+  delete process.env.INTERCOM_ACCESS_TOKEN
+  const client = createIntercomClient(async () => {})
+  await assert.rejects(
+    () => client.listContacts(),
+    /INTERCOM_ACCESS_TOKEN is not set/
+  )
+})
+
+test("worker manifest exposes one connected four-database support bundle", () => {
+  assert.deepEqual(
+    worker.manifest.databases.map((database) => [
+      database.key,
+      database.config.primaryKeyProperty,
+    ]),
+    [
+      ["companies", "Company ID"],
+      ["contacts", "Contact ID"],
+      ["conversations", "Conversation ID"],
+      ["tickets", "Ticket ID"],
+    ]
+  )
+  const syncs = worker.manifest.capabilities.filter(
+    (capability) => capability._tag === "sync"
+  )
+  type SyncManifestConfig = {
+    mode?: string
+    schedule?: { type: string; intervalMs?: number }
+  }
+  const config = (key: string) =>
+    syncs.find((capability) => capability.key === key)?.config as
+      | SyncManifestConfig
+      | undefined
+  assert.deepEqual(
+    [
+      config("contactsSync")?.mode,
+      config("contactsSync")?.schedule,
+      config("companiesSync")?.mode,
+      config("companiesSync")?.schedule,
+      config("conversationsSync")?.mode,
+      config("conversationsSync")?.schedule,
+      config("conversationsReconciliation")?.mode,
+      config("conversationsReconciliation")?.schedule,
+      config("ticketsSync")?.mode,
+      config("ticketsSync")?.schedule,
+      config("ticketsReconciliation")?.mode,
+      config("ticketsReconciliation")?.schedule,
+    ],
+    [
+      "replace",
+      { type: "interval", intervalMs: 60 * 60_000 },
+      "replace",
+      { type: "interval", intervalMs: 60 * 60_000 },
+      "incremental",
+      { type: "interval", intervalMs: 2 * 60_000 },
+      "replace",
+      { type: "interval", intervalMs: 24 * 60 * 60_000 },
+      "incremental",
+      { type: "interval", intervalMs: 2 * 60_000 },
+      "replace",
+      { type: "interval", intervalMs: 24 * 60 * 60_000 },
+    ]
+  )
+  assert.deepEqual(worker.manifest.pacers, [
+    {
+      key: "intercom",
+      config: { allowedRequests: 1_000, intervalMs: 10_000 },
+    },
+  ])
+  const database = (key: string) =>
+    worker.manifest.databases.find((candidate) => candidate.key === key)?.config
+      .schema.properties
+  const assertRelation = (
+    databaseKey: string,
+    propertyName: string,
+    relatedDatabaseKey: string
+  ) => {
+    const relation = database(databaseKey)?.[propertyName]
+    assert.equal(relation?.type, "relation")
+    if (relation?.type !== "relation") assert.fail("Expected relation")
+    assert.equal(relation.relatedDatabaseKey, relatedDatabaseKey)
+  }
+  assertRelation("contacts", "Companies", "companies")
+  assertRelation("conversations", "Contacts", "contacts")
+  assertRelation("conversations", "Company", "companies")
+  assertRelation("tickets", "Contacts", "contacts")
+})

--- a/workers/intercom-sync/tsconfig.json
+++ b/workers/intercom-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/intercom-sync/tsconfig.test.json
+++ b/workers/intercom-sync/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

This adds a self-contained Intercom Worker sync that creates a connected support
workspace in Notion. One deployment maintains related **Companies**,
**Contacts**, **Conversations**, and optional **Tickets** databases, with safe
pagination, scheduling, reconciliation, and regional API support included.

Users can copy the whole `workers/intercom-sync` directory, preview it locally,
and deploy it without designing their own schemas or integration lifecycle.
Tickets stay in the same bundle and can remain disabled when the Intercom plan
does not support the API.

## What this enables

- Understand account health through plan, spend, usage, activity, segments,
  contacts, and support history.
- Triage Conversations with ownership, priority, SLA, CSAT, reply-time,
  handling-time, reopen, and AI-resolution context.
- Track structured Tickets by state, type, assignment, customer, and next step
  when the Intercom workspace supports the Tickets API.
- Move between related Companies, Contacts, Conversations, and Tickets directly
  in Notion.

## How it works

- Companies and Contacts refresh hourly with complete replacement sweeps.
- Conversations and Tickets receive incremental updates every five minutes,
  with a one-minute consistency buffer and five-minute overlap.
- Manual reconciliation repairs drift and removes records that Intercom deleted
  or no longer returns.
- The client supports Intercom's US, EU, and AU regions, shared request pacing,
  provider-aware rate-limit handling, and bounded pagination state.

## Safe to operate and extend

- The Worker reads only from Intercom. Intercom remains the system of record;
  managed properties in Notion are refreshed by later syncs.
- Conversation and Ticket Search pages must remain strictly ordered by immutable
  Intercom API ID. The Worker verifies that order across continuations and fails
  closed if the provider response does not match it.
- Conversation and Ticket reconciliation pin `total_count` and refuse to finish
  when counts change or a sweep ends early, so replacement deletion stays gated
  on a complete traversal.
- Company Scroll handling respects Intercom's single active-scroll limit,
  tracks expiry, bounds restarts, and fails before an incomplete replacement
  can remove Notion rows.
- Contacts expose **Incomplete Associations** when Intercom truncates embedded
  Company or Tag lists.
- Sensitive or incomplete fields—including full transcripts, internal notes,
  attachments, temporary file URLs, and arbitrary custom attributes—are not
  copied by default.
- Resource modules keep each schema, transform, state policy, and page executor
  together, with a concise code map and extension guidance in the README.

## Getting started

The `workers/intercom-sync/README.md` starts with a local, no-write preview and
then walks through a paused first deployment, dependency-ordered backfill,
optional Ticket setup, manual reconciliation, and safe redeployment.

## Verification

- `npm run verify`
- Intercom type-check and production build
- 42 deterministic offline tests
- Catalog validation, Markdown lint, formatting, and `git diff --check`
