### PR TITLE
feat(workers): add PagerDuty incident and service syncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ directory.
 - **Bring external data into Notion:** use a Worker sync for
   [GitHub](workers/github-sync/), [HubSpot](workers/hubspot-sync/),
   [Jira](workers/jira-sync/), [Linear](workers/linear-sync/),
-  [Salesforce](workers/salesforce-sync/), [Snowflake](workers/snowflake-sync/),
-  or [Zendesk](workers/zendesk-sync/).
+  [PagerDuty](workers/pagerduty-sync/), [Salesforce](workers/salesforce-sync/),
+  [Snowflake](workers/snowflake-sync/), or [Zendesk](workers/zendesk-sync/).
 - **Give a Notion agent a new tool:** connect it to
   [Airflow](workers/airflow/), [CloudWatch Logs](workers/cloudwatch-logs/),
   [Postgres](workers/postgres-query/), or one of the other Worker tools below.
@@ -51,16 +51,17 @@ and a **webhook** handles events from another service. See the complete
 
 ### Sync external data into Notion
 
-| Task                                                    | Worker                                      | Source     |
-| ------------------------------------------------------- | ------------------------------------------- | ---------- |
-| Learn the sync pattern with seeded, in-memory data      | [DuckDB sync](workers/duckdb-sync/)         | DuckDB     |
-| Sync issues and pull requests                           | [GitHub sync](workers/github-sync/)         | GitHub     |
-| Sync contacts, deals, and companies                     | [HubSpot sync](workers/hubspot-sync/)       | HubSpot    |
-| Sync issues, sprints, analytics, and projects           | [Jira sync](workers/jira-sync/)             | Jira Cloud |
-| Sync projects, issues, and initiatives                  | [Linear sync](workers/linear-sync/)         | Linear     |
-| Sync accounts and opportunities                         | [Salesforce sync](workers/salesforce-sync/) | Salesforce |
-| Sync the result of a warehouse query                    | [Snowflake sync](workers/snowflake-sync/)   | Snowflake  |
-| Sync tickets, users, organizations, and support metrics | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
+| Task                                                        | Worker                                      | Source     |
+| ----------------------------------------------------------- | ------------------------------------------- | ---------- |
+| Learn the sync pattern with seeded, in-memory data          | [DuckDB sync](workers/duckdb-sync/)         | DuckDB     |
+| Sync issues and pull requests                               | [GitHub sync](workers/github-sync/)         | GitHub     |
+| Sync contacts, deals, and companies                         | [HubSpot sync](workers/hubspot-sync/)       | HubSpot    |
+| Sync issues, sprints, analytics, and projects               | [Jira sync](workers/jira-sync/)             | Jira Cloud |
+| Sync projects, issues, and initiatives                      | [Linear sync](workers/linear-sync/)         | Linear     |
+| Monitor PagerDuty incidents and service readiness in Notion | [PagerDuty sync](workers/pagerduty-sync/)   | PagerDuty  |
+| Sync accounts and opportunities                             | [Salesforce sync](workers/salesforce-sync/) | Salesforce |
+| Sync the result of a warehouse query                        | [Snowflake sync](workers/snowflake-sync/)   | Snowflake  |
+| Sync tickets, users, organizations, and support metrics     | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
 
 ### Add tools to a Notion agent
 

--- a/catalog.json
+++ b/catalog.json
@@ -311,6 +311,25 @@
       }
     },
     {
+      "id": "pagerduty-sync",
+      "title": "PagerDuty sync",
+      "summary": "Sync active and recent PagerDuty incidents plus service readiness signals into related managed Notion databases for read-only operations awareness.",
+      "path": "workers/pagerduty-sync",
+      "kind": "worker-sync",
+      "status": "ready",
+      "language": "typescript",
+      "runtime": "node",
+      "integrations": ["notion-workers", "pagerduty"],
+      "entrypoints": ["src/index.ts"],
+      "commands": {
+        "install": "npm install",
+        "check": "npm run check",
+        "test": "npm test",
+        "build": "npm run build",
+        "deploy": "ntn workers deploy --name pagerduty-sync"
+      }
+    },
+    {
       "id": "postgres-query",
       "title": "Postgres query agent tool",
       "summary": "Let a Notion agent discover PostgreSQL tables and execute bounded, read-only SQL queries.",

--- a/workers/README.md
+++ b/workers/README.md
@@ -21,6 +21,7 @@ For local programs built directly on the Notion API, see the
 | [HubSpot sync](hubspot-sync/)       | CRM contacts, deals, and companies.                                                                                    |
 | [Jira sync](jira-sync/)             | Jira Cloud issues, current sprints, sprint analytics, and projects.                                                    |
 | [Linear sync](linear-sync/)         | Linear projects, issues, and initiatives.                                                                              |
+| [PagerDuty sync](pagerduty-sync/)   | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.     |
 | [Salesforce sync](salesforce-sync/) | Salesforce accounts and opportunities, with related account context.                                                   |
 | [Snowflake sync](snowflake-sync/)   | Rows returned by a configurable Snowflake query.                                                                       |
 | [Zendesk sync](zendesk-sync/)       | Tickets, organizations, users, CSAT responses, ticket metrics, and SLA policies.                                       |

--- a/workers/pagerduty-sync/.env.example
+++ b/workers/pagerduty-sync/.env.example
@@ -1,0 +1,16 @@
+# Required: create a read-only REST API key in PagerDuty under
+# Integrations > Developer Tools > API Access Keys.
+PAGERDUTY_API_TOKEN=
+
+# Optional: "us" (default) or "eu" for the account's service region.
+PAGERDUTY_REGION=us
+
+# Optional: creation-date history retained alongside all open incidents.
+# The cookbook accepts 1 to 180 days and subwindows each PagerDuty request.
+PAGERDUTY_INCIDENT_LOOKBACK_DAYS=90
+
+# Optional: comma-separated PagerDuty IDs. Service IDs scope both databases.
+# Team IDs scope incidents only; all selected services stay available as
+# relation targets. When both are set, the incident filters intersect.
+PAGERDUTY_SERVICE_IDS=
+PAGERDUTY_TEAM_IDS=

--- a/workers/pagerduty-sync/.gitignore
+++ b/workers/pagerduty-sync/.gitignore
@@ -1,0 +1,8 @@
+# Secrets and generated Worker state
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/workers/pagerduty-sync/README.md
+++ b/workers/pagerduty-sync/README.md
@@ -43,6 +43,20 @@ ntn workers sync trigger servicesSync --preview
 ntn workers sync trigger incidentsSync --preview
 ```
 
+A preview invokes one callback, while a normal sync cycle follows callbacks
+until `hasMore` is false. Every unscoped service discovery callback and the
+incident confirmation callback are validation-only, so an empty `changes`
+array is expected during those phases. Whenever `hasMore` is true, copy the
+preview's `nextContext` value and continue:
+
+```sh
+ntn workers sync trigger servicesSync --preview --context '<nextContext JSON>'
+```
+
+Repeat with each returned `nextContext` until `hasMore` is false. Use the same
+continuation flow for incidents to inspect the open, confirmation, and recent
+history phases.
+
 Then populate the service directory before its incident relations:
 
 ```sh
@@ -366,8 +380,18 @@ the same source data, so treat it as sensitive too.
 ### Pagination and consistency
 
 PagerDuty's list endpoints use offset pagination and expose at most 10,000
-records through an offset traversal. The worker protects completeness as
-follows:
+records through an offset traversal. One complete Worker cycle follows these
+phase flows:
+
+```text
+Incidents: open → open confirmation → recent window(s) → complete
+Services: discover → publish → complete
+Configured services: publish directly → complete
+```
+
+`src/sync-state.ts` contains pure transitions for these phases; the Workers
+runtime persists the returned `nextState` between callbacks. The worker protects
+completeness as follows:
 
 1. An incident cycle pins the recent-history upper boundary and the service/team
    scope before its first request. Recent-history incidents created later wait
@@ -457,15 +481,20 @@ closed.
 
 ```text
 src/
-├── index.ts       — registers both databases, schedules, snapshots, and pacer
+├── index.ts       — registers databases, syncs, and pacing; orchestrates callbacks
 ├── pagerduty.ts   — list/direct API reads, configuration, and validation
-├── sync-state.ts  — open/history phases, safe window splits, and offsets
+├── sync-state.ts  — incident/service phases, windows, and identity checks
 ├── incidents.ts   — incident schema and transform
 ├── services.ts    — service schema, coverage context, and transform
 └── helpers.ts     — labels, durations, support hours, and safe page formatting
 ```
 
 ### Extending the example
+
+The confirmation, overlap, and window-splitting state machine is specific to
+PagerDuty's live offset pagination. For a provider with stable cursors, start
+from the [Linear sync](../linear-sync/); for incremental change tracking plus a
+replacement repair path, start from the [Salesforce sync](../salesforce-sync/).
 
 Use this checklist when extending the recipe:
 
@@ -521,6 +550,10 @@ ntn workers exec incidentsSync --local
 ntn workers sync trigger servicesSync --preview
 ntn workers sync trigger incidentsSync --preview
 ```
+
+The `workers exec --local` commands validate local wiring and one callback. For
+a complete deployed preview, follow the `nextContext` continuation loop from
+the Quickstart until `hasMore` is false.
 
 For live verification, confirm that names are resolved, removed upstream values
 clear their prior Notion properties, source and conference links open safely,

--- a/workers/pagerduty-sync/README.md
+++ b/workers/pagerduty-sync/README.md
@@ -338,10 +338,14 @@ while the service database still follows only the service-ID scope. Omit the tea
 filter when the PagerDuty account does not have the `teams` ability.
 
 PagerDuty describes the maximum incident search range as six months. This
-recipe accepts a conservative 1–180 day rolling lookback. Duplicate IDs and
-surrounding whitespace are removed. Configuration is copied into serializable
-sync state at the beginning of a cycle, so an environment change cannot alter
-an in-progress traversal; the next cycle uses the new value.
+recipe accepts a conservative 1–180 day rolling lookback. Configured IDs are
+case-sensitive opaque values rather than values matched to an assumed provider
+format. Each is limited to 255 characters; control characters and the `.` and
+`..` service-ID values are rejected because they cannot be preserved as URL path
+segments, while duplicate IDs and surrounding whitespace are removed.
+Configuration is copied into serializable sync state at the beginning of a
+cycle, so an environment change cannot alter an in-progress traversal; the next
+cycle uses the new value.
 
 To retain 30 days and limit both databases to two services, edit `.env`:
 

--- a/workers/pagerduty-sync/README.md
+++ b/workers/pagerduty-sync/README.md
@@ -130,9 +130,9 @@ page can show or count its synced incidents.
 
 PagerDuty returns assignments only while an incident is open and returns
 acknowledgements only for an acknowledged incident. The transform therefore
-omits those properties when PagerDuty does not return them; it does not turn
-missing history into a misleading zero. Priority and Incident Type are also
-omitted for accounts or incidents where the features are unavailable.
+clears those Notion values when PagerDuty no longer returns them; it does not
+turn missing history into a misleading zero. Priority and Incident Type are
+also left empty for accounts or incidents where the features are unavailable.
 
 **Next Automatic Action** is the chronologically earliest valid pending action
 PagerDuty returns, with action type and destination used as deterministic tie
@@ -140,7 +140,7 @@ breakers. It describes provider automation such as escalation, unacknowledgment,
 auto-resolution, or an urgency change; it is not a task assigned in Notion.
 **Resolution Duration (min)** is rounded to one decimal and appears only when
 both timestamps form a valid nonnegative interval. Last Changed By may identify
-a user, service, or integration. Conference fields are omitted independently
+a user, service, or integration. Conference fields are cleared independently
 when PagerDuty does not return a safe web URL or a dial-in number.
 
 The incident page body is a bounded initial-trigger snapshot: the first-trigger
@@ -174,9 +174,18 @@ trigger details, notes, status updates, or the PagerDuty timeline. Follow
 
 The complete service description is also used as page content. A disabled or
 unavailable timeout is left empty instead of being presented as a duration.
-Integration Count preserves zero; Integrations is omitted when there are no
-names to display. Support Hours is omitted when the service has no configured
+Integration Count preserves zero; Integrations is empty when there are no
+names to display. Support Hours is empty when the service has no configured
 window.
+
+Every upsert includes every schema property, using an explicit empty value when
+PagerDuty removes data. This lets a populated incident or service converge to
+its new empty state instead of retaining stale Notion values. Provider-authored
+select and multi-select labels normalize ASCII commas, de-duplicate
+case-insensitively, sort deterministically, and bound long names with a stable
+digest suffix. A row with more than Notion's 100-value multi-select limit fails
+visibly rather than silently dropping ownership, responder, or integration
+data.
 
 Response State maps PagerDuty's service status as follows: `active` becomes
 **No Open Incidents**, `warning` becomes **Response in Progress**, `critical`
@@ -200,7 +209,9 @@ entries. Coverage can still be **Covered** when an entry exists but its user
 reference has no displayable name. The Worker never converts a failed,
 unauthorized, malformed, changing, or incomplete `/oncalls` traversal into the
 **No Primary On Call** state; the service replacement cycle fails instead and
-leaves the last successful snapshot in place.
+does not perform replacement deletion. Upserts from successful earlier publish
+pages may already be visible, so a failed multi-page cycle is not described as
+transactional.
 
 PagerDuty's service response has no general `updated_at` timestamp. Each row's
 `upstreamUpdatedAt` is therefore the cycle's pinned observation time so response
@@ -384,20 +395,24 @@ follows:
    stable total, processed count, and strictly increasing incident numbers. An
    inconsistent traversal fails visibly instead of committing a knowingly
    partial replacement.
-6. Without `PAGERDUTY_SERVICE_IDS`, services are sorted by name and checked for
-   duplicate IDs and total-count drift. A visible directory above 10,000 fails
-   with guidance to configure explicit service IDs. With IDs configured, each
-   service is fetched directly, a missing/invisible ID fails visibly, and the
+6. Without `PAGERDUTY_SERVICE_IDS`, the Worker first discovers the complete
+   service identity set without emitting rows, then traverses the directory
+   again to publish it. The publish pass must reproduce the same set, so an
+   equal-count delete/create race or mutable-name page shift fails before
+   replacement deletion instead of silently removing a still-live service. A
+   visible directory above 10,000 fails with guidance to configure explicit
+   service IDs. With IDs configured, each service is fetched directly and
+   published without discovery; a missing/invisible ID fails visibly, and the
    offset ceiling does not apply.
-7. Each service callback collects the unique escalation policies referenced by
-   that service page and reads their current on-calls at the cycle-pinned
-   **Coverage Checked** instant. The request uses the same timestamp for `since`
-   and `until`, follows every offset page, requires a stable reported total and
-   processed count, validates each entry, and fails above 10,000 entries. If the
-   result spans multiple pages, the Worker repeats the complete traversal and
-   requires the same raw identity multiset before publishing coverage. The
-   Worker transforms the service page only after this traversal completes. A
-   page with no escalation policies makes no `/oncalls` request.
+7. Each service publish callback collects the unique escalation policies
+   referenced by that service page and reads their current on-calls at the
+   cycle-pinned **Coverage Checked** instant. The request uses the same timestamp
+   for `since` and `until`, follows every offset page, requires a stable reported
+   total and processed count, validates each entry, and fails above 10,000
+   entries. If the result spans multiple pages, the Worker repeats the complete
+   traversal and requires the same raw identity multiset before publishing
+   coverage. The Worker transforms the service page only after this traversal
+   completes. A page with no escalation policies makes no `/oncalls` request.
 
 All state is plain serializable data; the sync never relies on a module-global
 cache surviving between Worker executions.
@@ -413,16 +428,18 @@ Per cycle, the open confirmation costs twice the number of open-incident pages,
 and recent history costs one request per page and subwindow. The new incident
 properties come from those list responses and do not add per-incident requests.
 
-An unfiltered service callback reads up to 100 services, then queries `/oncalls`
-for the unique escalation policies on that page. Its request cost is one service
-request plus one on-call request when the result fits on one page. A multi-page
+An unfiltered service cycle reads every `/services` page twice: discovery emits
+no rows and makes no `/oncalls` requests, then publish reproduces the discovered
+identity set. Each publish callback reads up to 100 services and queries
+`/oncalls` for the unique escalation policies on that page. A one-page directory
+with one-page coverage therefore costs three requests. A multi-page on-call
 result costs twice its page count because the Worker confirms the complete raw
-identity set with a second traversal. An explicit service scope reads one
-configured service per callback and queries that service's policy; a policy
-shared by services on different pages can therefore be queried again. A page
-with no policies skips the on-call request. Integrations and support hours come
-from the service response and add no per-service lookup. The shared pacer applies
-to all incident, service, and on-call requests combined.
+identity set with a second traversal. An explicit service scope skips discovery,
+reads one configured service per callback, and queries that service's policy; a
+policy shared by services on different pages can therefore be queried again. A
+page with no policies skips the on-call request. Integrations and support hours
+come from the service response and add no per-service lookup. The shared pacer
+applies to all incident, service, and on-call requests combined.
 
 The Worker deliberately does not duplicate the bounded incident traversal to
 calculate service-level open-incident counts. It also makes no per-incident
@@ -470,9 +487,10 @@ Use this checklist when extending the recipe:
 7. Whitelist any page content, render provider text as plain text, accept only
    safe context-link protocols, bound its size, and update the privacy inventory.
    Do not copy arbitrary provider payloads or credentials.
-8. Add offline tests for populated and omitted values, request parameters,
-   pagination, split boundaries, duplicate detection, filter semantics, and rate
-   limits. Add a safe live preview for behavior that fixtures cannot prove.
+8. Add offline tests for populated and explicitly cleared values, request
+   parameters, pagination, split boundaries, duplicate detection, filter
+   semantics, and rate limits. Add a safe live preview for behavior that fixtures
+   cannot prove.
 9. Update the property/configuration tables, expected output, extension notes,
    and verification steps. If behavior, entrypoints, integrations, or commands
    change, update the recipe's `catalog.json` entry too.
@@ -504,9 +522,10 @@ ntn workers sync trigger servicesSync --preview
 ntn workers sync trigger incidentsSync --preview
 ```
 
-For live verification, confirm that names are resolved, optional properties are
-omitted, source and conference links open safely, the two-way Incident → Service
-relation resolves, and resolution duration agrees with the source timestamps.
+For live verification, confirm that names are resolved, removed upstream values
+clear their prior Notion properties, source and conference links open safely,
+the two-way Incident → Service relation resolves, and resolution duration agrees
+with the source timestamps.
 For services, confirm Response State matches PagerDuty, Primary On Call contains
 only current level-one responders, Primary Coverage reflects that level rather
 than every fallback, Coverage Checked matches the snapshot instant, and

--- a/workers/pagerduty-sync/README.md
+++ b/workers/pagerduty-sync/README.md
@@ -1,0 +1,531 @@
+# Worker sync: PagerDuty
+
+Use this Worker as a read-only operations awareness and reliability handoff hub
+in Notion. It brings active and recent PagerDuty incidents together with service
+ownership, response state, current primary on-call coverage, integrations, and
+support hours. The Worker creates two managed databases, links each incident to
+its PagerDuty service, and preserves direct links back to PagerDuty.
+
+PagerDuty remains the response console and authoritative incident timeline.
+Responders still use PagerDuty to acknowledge, reassign, escalate, resolve, and
+inspect the complete event history. Notion provides a shared operational view
+and a place to coordinate durable follow-up; it does not replace paging or
+incident command.
+
+## Quickstart
+
+You need Node.js 22+, npm 10.9.2+, the Notion Workers CLI, and a PagerDuty REST
+API key that can read the incidents, services, and current on-calls you want to
+copy. For an account-wide sync, an Admin or Account Owner can create a
+**read-only** key under
+**Integrations > Developer Tools > API Access Keys**. Then run from the
+repository root:
+
+```sh
+npm install --global ntn
+cd workers/pagerduty-sync
+npm install
+cp .env.example .env
+# Edit .env: add the token, select the EU region if needed, and set any scope.
+ntn login
+ntn workers deploy --name pagerduty-sync
+ntn workers env push
+```
+
+Using the gitignored `.env` file keeps the token out of the command itself and
+your shell history. EU service-region accounts set `PAGERDUTY_REGION=eu` in
+that file before pushing it.
+
+Preview both syncs without writing rows:
+
+```sh
+ntn workers sync trigger servicesSync --preview
+ntn workers sync trigger incidentsSync --preview
+```
+
+Then populate the service directory before its incident relations:
+
+```sh
+ntn workers sync trigger servicesSync
+ntn workers sync trigger incidentsSync
+```
+
+The worker targets a five-minute cadence for both databases. A complete cycle
+can take longer when PagerDuty returns many pages or asks the Worker to retry.
+No `NOTION_API_TOKEN` is needed: the Workers platform supplies the Notion client
+and owns authentication to the managed databases.
+
+## What you can answer
+
+| Managed database        | Questions it helps answer                                                                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PagerDuty Incidents** | Which incidents need attention? Who is assigned? What changes automatically next? Is there a conference bridge? What was the resolution duration?                           |
+| **PagerDuty Services**  | What response state is PagerDuty reporting? Who is primary on call? Which services lack primary coverage or ownership? What integrations, support hours, and routing apply? |
+
+The sync is deliberately read-only. Responders follow **Incident Link** or
+**Service Link** back to PagerDuty for action and live detail. It does not copy
+stakeholder status updates, business-impact records, notes, or the full
+timeline. **Response State** is a readable form of PagerDuty's service status;
+it is not an independently calculated health score, uptime measurement, or open
+incident count.
+
+## Reference
+
+### Databases and schedules
+
+| Database                | Sync            | Mode    | Schedule    | Default scope                                       |
+| ----------------------- | --------------- | ------- | ----------- | --------------------------------------------------- |
+| **PagerDuty Incidents** | `incidentsSync` | replace | Every 5 min | All open incidents plus the last 90 days of history |
+| **PagerDuty Services**  | `servicesSync`  | replace | Every 5 min | All services visible to the key                     |
+
+The incident sweep first reads every Triggered or Acknowledged incident, without
+a creation-time cutoff. It then reads all statuses whose incident creation time
+falls in the rolling lookback, so recent Resolved incidents remain available for
+review. An old incident stays in Notion while it is open and ages out only after
+it is resolved and outside the lookback.
+
+Both syncs use replacement sweeps. At the end of a successful cycle, a row is
+removed when its upstream record was deleted, became invisible to the key, or
+fell outside the relevant service/team/history scope. A failed or incomplete
+sweep does not intentionally present itself as a complete snapshot.
+
+#### PagerDuty Incidents
+
+| Notion property           | PagerDuty field                                 | Type        |
+| ------------------------- | ----------------------------------------------- | ----------- |
+| Title                     | `title`                                         | title       |
+| Status                    | `status`                                        | select      |
+| Urgency                   | `urgency`                                       | select      |
+| Assigned To               | all `assignments[].assignee` names              | multiSelect |
+| Incident Link             | `html_url`                                      | url         |
+| Service                   | relation keyed by `service.id`                  | relation    |
+| Incident Type             | readable `incident_type.name`                   | select      |
+| Last Changed By           | `last_status_change_by` name                    | select      |
+| Next Automatic Action     | earliest valid `pending_actions[]` entry        | select      |
+| Next Action At            | timestamp paired with Next Automatic Action     | date        |
+| Conference Link           | safe HTTP(S) `conference_bridge.conference_url` | url         |
+| Conference Dial-in        | `conference_bridge.conference_number`           | richText    |
+| Resolution Duration (min) | elapsed time from `created_at` to `resolved_at` | number      |
+| Priority                  | `priority.summary` or `priority.name`           | select      |
+| Teams                     | all `teams[]` names                             | multiSelect |
+| Escalation Policy         | `escalation_policy` name                        | select      |
+| Last Status Change        | `last_status_change_at`                         | date        |
+| Updated                   | `updated_at`                                    | date        |
+| Total Alert Count         | `alert_counts.all`                              | number      |
+| Active Alert Count        | `alert_counts.triggered`                        | number      |
+| Acknowledged By           | current `acknowledgements[].acknowledger` names | multiSelect |
+| Last Acknowledged         | latest current `acknowledgements[].at`          | date        |
+| Assigned Via              | `assigned_via`                                  | select      |
+| Created                   | `created_at`                                    | date        |
+| Resolved                  | `resolved_at`                                   | date        |
+| Incident Number           | `incident_number`                               | number      |
+| PagerDuty Incident ID     | immutable `id`                                  | richText    |
+
+**PagerDuty Incident ID** is the primary key. The familiar incident number is
+retained for searching and sorting but is not used as sync identity.
+
+**Service** is a two-way relation keyed by the immutable service ID. Notion
+adds the reciprocal **Incidents** property to each related service so a service
+page can show or count its synced incidents.
+
+PagerDuty returns assignments only while an incident is open and returns
+acknowledgements only for an acknowledged incident. The transform therefore
+omits those properties when PagerDuty does not return them; it does not turn
+missing history into a misleading zero. Priority and Incident Type are also
+omitted for accounts or incidents where the features are unavailable.
+
+**Next Automatic Action** is the chronologically earliest valid pending action
+PagerDuty returns, with action type and destination used as deterministic tie
+breakers. It describes provider automation such as escalation, unacknowledgment,
+auto-resolution, or an urgency change; it is not a task assigned in Notion.
+**Resolution Duration (min)** is rounded to one decimal and appears only when
+both timestamps form a valid nonnegative interval. Last Changed By may identify
+a user, service, or integration. Conference fields are omitted independently
+when PagerDuty does not return a safe web URL or a dial-in number.
+
+The incident page body is a bounded initial-trigger snapshot: the first-trigger
+description, an included email trigger message rendered as plain text, and safe
+HTTP(S) context links. It does not copy the incident body, arbitrary structured
+trigger details, notes, status updates, or the PagerDuty timeline. Follow
+**Incident Link** for the full record and response history.
+
+#### PagerDuty Services
+
+| Notion property            | PagerDuty field or derivation                                  | Type        |
+| -------------------------- | -------------------------------------------------------------- | ----------- |
+| Name                       | `name`                                                         | title       |
+| Response State             | readable `status`                                              | select      |
+| Primary On Call            | level-one current on-call user names for the escalation policy | multiSelect |
+| Primary Coverage           | service status, policy presence, and current level-one entries | select      |
+| Teams                      | all `teams[]` names                                            | multiSelect |
+| Service Link               | `html_url`                                                     | url         |
+| Coverage Checked           | cycle-pinned on-call observation time                          | date        |
+| Integrations               | all `integrations[]` names                                     | multiSelect |
+| Integration Count          | number of unique returned integration IDs                      | number      |
+| Support Hours              | readable `support_hours` window and time zone                  | richText    |
+| Last Incident              | `last_incident_timestamp`                                      | date        |
+| Escalation Policy          | `escalation_policy` name                                       | select      |
+| Description                | `description`                                                  | richText    |
+| Urgency Rule               | readable `incident_urgency_rule` summary                       | richText    |
+| Auto Resolve (min)         | `auto_resolve_timeout` converted from seconds                  | number      |
+| Re-trigger After Ack (min) | `acknowledgement_timeout` converted from seconds               | number      |
+| Created                    | `created_at`                                                   | date        |
+| PagerDuty Service ID       | immutable `id`                                                 | richText    |
+
+The complete service description is also used as page content. A disabled or
+unavailable timeout is left empty instead of being presented as a duration.
+Integration Count preserves zero; Integrations is omitted when there are no
+names to display. Support Hours is omitted when the service has no configured
+window.
+
+Response State maps PagerDuty's service status as follows: `active` becomes
+**No Open Incidents**, `warning` becomes **Response in Progress**, `critical`
+becomes **Awaiting Response**, and maintenance and disabled services become
+**Maintenance** and **Disabled**. This is the service-level status PagerDuty
+returned at observation time, not a separately traversed incident aggregate.
+
+Primary Coverage describes only the first escalation level and uses exactly
+four states:
+
+- **Covered:** PagerDuty returned at least one current level-one on-call entry
+  for the service's escalation policy.
+- **No Primary On Call:** the service has an escalation policy, but the complete
+  current snapshot returned no level-one entry. A fallback escalation level may
+  still be staffed; this label does not claim that every policy level is empty.
+- **No Escalation Policy:** an enabled service has no policy to query.
+- **Not Applicable:** the service is disabled.
+
+Primary On Call contains the deduplicated, sorted names from those level-one
+entries. Coverage can still be **Covered** when an entry exists but its user
+reference has no displayable name. The Worker never converts a failed,
+unauthorized, malformed, changing, or incomplete `/oncalls` traversal into the
+**No Primary On Call** state; the service replacement cycle fails instead and
+leaves the last successful snapshot in place.
+
+PagerDuty's service response has no general `updated_at` timestamp. Each row's
+`upstreamUpdatedAt` is therefore the cycle's pinned observation time so response
+state, coverage, ownership, integrations, support hours, description, and
+timeout changes are reapplied rather than skipped against the service's creation
+time. **Coverage Checked** exposes that same instant. It is evidence of when
+the snapshot was taken, not a promise that the person remains on call after the
+row was written.
+
+### Recommended Notion views
+
+Deployment creates the databases and properties, but not saved views. Add these
+after the first successful sync.
+
+#### Operations awareness
+
+Create this view in **PagerDuty Incidents**:
+
+- Advanced filter: `(Status is Triggered) OR (Status is Acknowledged)`.
+- Group by **Status**.
+- Sort by **Priority** ascending, **Urgency** ascending, **Next Action At**
+  ascending, then **Last Status Change** descending.
+- Show **Title**, **Status**, **Urgency**, **Priority**, **Service**,
+  **Incident Type**, **Assigned To**, **Active Alert Count**,
+  **Next Automatic Action**, **Next Action At**, **Last Changed By**,
+  **Conference Link**, **Conference Dial-in**, and **Incident Link**.
+
+This is the shared awareness view. Use Incident Link for live response, because
+the five-minute sync cadence and a cycle's API work make it intentionally less
+current than PagerDuty.
+
+#### Service readiness and primary coverage gaps
+
+Create **Service readiness** in **PagerDuty Services**:
+
+- Filter **Response State** to anything except **Disabled**.
+- Group by **Response State**.
+- Sort by **Primary Coverage** ascending, then **Name** ascending.
+- Show **Name**, **Response State**, **Primary On Call**,
+  **Primary Coverage**, **Coverage Checked**, **Teams**,
+  **Escalation Policy**, **Support Hours**, **Integrations**,
+  **Integration Count**, and **Service Link**.
+
+Duplicate that view as **Primary coverage gaps**, then add the advanced filter
+`(Primary Coverage is No Primary On Call) OR (Primary Coverage is No Escalation Policy)`
+while retaining `Response State is not Disabled`. Group by **Primary Coverage**
+and sort by **Response State** ascending, then **Name** ascending.
+
+#### Review intake
+
+Create this view in **PagerDuty Incidents**:
+
+- Filter **Status** to **Resolved** and **Resolved** to within the past 30 days.
+- Sort by **Priority** ascending, **Resolution Duration (min)** descending, then
+  **Resolved** descending.
+- Show **Title**, **Priority**, **Service**, **Incident Type**, **Resolved**,
+  **Resolution Duration (min)**, **Last Changed By**, and **Incident Link**.
+
+Use this as intake for a native Notion review workflow, not as a claim that
+PagerDuty already classified an incident as requiring review.
+
+### User-owned Incident Reviews
+
+Do not add mutable review ownership or status to either managed sync database.
+Instead, create a normal Notion database named **Incident Reviews** with these
+properties:
+
+| Property            | Type             | Purpose                                                          |
+| ------------------- | ---------------- | ---------------------------------------------------------------- |
+| Review              | title            | Durable review or post-incident record                           |
+| PagerDuty Incident  | one-way relation | Links to PagerDuty Incidents without changing its managed schema |
+| Review Status       | status           | Needed, In progress, Complete, or Not required                   |
+| Review Owner        | people           | Notion-native follow-up owner                                    |
+| Review Due          | date             | Review deadline                                                  |
+| Review Document     | url              | Optional external postmortem                                     |
+| Service             | rollup           | Service from the related incident                                |
+| Priority            | rollup           | Priority from the related incident                               |
+| Resolved            | rollup           | Resolution time from the related incident                        |
+| Resolution Duration | rollup           | Resolution Duration (min) from the related incident              |
+
+From **Review intake**, decide whether a review is needed, create and relate an
+Incident Reviews page, assign its owner and due date, and keep notes, decisions,
+and action items in that native page. Use **Incident Link** for PagerDuty's
+authoritative history. A review page and all user-entered mutable fields remain
+owned by the workspace and are never written or replaced by this Worker. The
+related managed incident can age out after the configured lookback, so copy any
+facts that must remain durable instead of relying indefinitely on rollups.
+
+In Incident Reviews, a useful **Review queue** filters Review Status to Needed
+or In progress, groups by Review Status, and sorts Review Due ascending, then
+Priority ascending.
+
+### Configuration
+
+| Variable                           | Required | Default | Description                                                                                                 |
+| ---------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `PAGERDUTY_API_TOKEN`              | yes      | —       | REST API key sent only in the `Authorization` header                                                        |
+| `PAGERDUTY_REGION`                 | no       | `us`    | `us` uses `api.pagerduty.com`; `eu` uses `api.eu.pagerduty.com`                                             |
+| `PAGERDUTY_INCIDENT_LOOKBACK_DAYS` | no       | `90`    | Resolved/recent history in days, from 1 through 180; open incidents are retained regardless of age          |
+| `PAGERDUTY_SERVICE_IDS`            | no       | all     | Comma-separated service IDs; scopes incidents and directly selects the service rows to fetch                |
+| `PAGERDUTY_TEAM_IDS`               | no       | all     | Comma-separated team IDs applied only to incident queries; requires the PagerDuty account's `teams` ability |
+
+`PAGERDUTY_SERVICE_IDS` scopes both databases. When it is set, the service sync
+fetches those services directly by ID instead of scanning the service directory.
+A configured ID that is missing or invisible fails the cycle visibly instead of
+silently producing an incomplete service table. `PAGERDUTY_TEAM_IDS` scopes
+incidents only: the service directory remains unfiltered so Incident → Service
+relations can resolve. When both filters are set, they intersect for incidents,
+while the service database still follows only the service-ID scope. Omit the team
+filter when the PagerDuty account does not have the `teams` ability.
+
+PagerDuty describes the maximum incident search range as six months. This
+recipe accepts a conservative 1–180 day rolling lookback. Duplicate IDs and
+surrounding whitespace are removed. Configuration is copied into serializable
+sync state at the beginning of a cycle, so an environment change cannot alter
+an in-progress traversal; the next cycle uses the new value.
+
+To retain 30 days and limit both databases to two services, edit `.env`:
+
+```dotenv
+PAGERDUTY_INCIDENT_LOOKBACK_DAYS=30
+PAGERDUTY_SERVICE_IDS=PABC123,PDEF456
+```
+
+Then run `ntn workers env push` and repeat both preview commands before writing.
+PagerDuty service and team IDs appear in their web-app URLs and API responses.
+The `.env` file is gitignored; never put a real token in `.env.example`,
+`workers.json`, tests, or source control.
+
+### Authentication, visibility, and privacy
+
+The client uses PagerDuty REST API v2's `Token token=...` authorization scheme
+and accepts REST API access keys, not OAuth bearer tokens. A read-only account
+key is the simplest choice because this Worker makes only `GET` requests. A user
+API key also works, but its PagerDuty role and team access limit which incidents,
+services, and on-call entries appear. A `403` from `/oncalls` fails the service
+cycle; it is not represented as missing primary coverage.
+
+Incident titles, responder and current on-call names, team ownership,
+initial-trigger descriptions and messages, context links, conference URLs and
+dial-in numbers, integration names, support hours, and service descriptions may
+be sensitive. A conference URL or number may grant access to a live response
+call, and integration names can reveal internal architecture. The key's
+visibility defines what can be copied, but Notion sharing controls who can read
+the copy afterward. Hiding a property in one view is not an access boundary.
+
+Review the PagerDuty scope and destination sharing before the first write and
+before sharing either managed database broadly. Give a user-owned Incident
+Reviews database its own appropriate sharing policy. Preview output can contain
+the same source data, so treat it as sensitive too.
+
+### Pagination and consistency
+
+PagerDuty's list endpoints use offset pagination and expose at most 10,000
+records through an offset traversal. The worker protects completeness as
+follows:
+
+1. An incident cycle pins the recent-history upper boundary and the service/team
+   scope before its first request. Recent-history incidents created later wait
+   for the next cycle.
+2. The all-open phase is intentionally a live set with no creation-time cutoff,
+   so it can include an incident created during the cycle. The Worker scans this
+   set twice, and the confirmation pass must reproduce every first-pass ID in
+   order. Every continuing page also re-reads the preceding boundary incident
+   and verifies its immutable ID and incident number. A substitution, boundary
+   shift, total drift, or order drift therefore fails the replacement cycle
+   instead of silently skipping an older open incident. Because this set cannot
+   be divided by creation time, a total above 10,000 also fails with guidance to
+   narrow the service or team scope.
+3. The rolling-history phase requests all statuses in initial seven-day windows.
+   Any window above 10,000 records is divided into smaller time windows until
+   each part can be traversed completely. If an oversized remaining window is
+   one minute or less, the cycle fails with guidance to narrow the service or
+   team scope.
+4. History windows share their exact boundary, and the open and history phases
+   can return the same incident. Both cases intentionally replay the immutable
+   incident ID, so the upserts converge on one row instead of missing a boundary
+   record.
+5. Every list page requests `total=true`. The client checks the echoed offset,
+   full continuing pages, overlapping record boundary, continuation progress,
+   stable total, processed count, and strictly increasing incident numbers. An
+   inconsistent traversal fails visibly instead of committing a knowingly
+   partial replacement.
+6. Without `PAGERDUTY_SERVICE_IDS`, services are sorted by name and checked for
+   duplicate IDs and total-count drift. A visible directory above 10,000 fails
+   with guidance to configure explicit service IDs. With IDs configured, each
+   service is fetched directly, a missing/invisible ID fails visibly, and the
+   offset ceiling does not apply.
+7. Each service callback collects the unique escalation policies referenced by
+   that service page and reads their current on-calls at the cycle-pinned
+   **Coverage Checked** instant. The request uses the same timestamp for `since`
+   and `until`, follows every offset page, requires a stable reported total and
+   processed count, validates each entry, and fails above 10,000 entries. If the
+   result spans multiple pages, the Worker repeats the complete traversal and
+   requires the same raw identity multiset before publishing coverage. The
+   Worker transforms the service page only after this traversal completes. A
+   page with no escalation policies makes no `/oncalls` request.
+
+All state is plain serializable data; the sync never relies on a module-global
+cache surviving between Worker executions.
+
+### Rate limits
+
+Every request from both syncs shares one pacer capped at 120 requests per
+minute. This leaves substantial headroom beneath PagerDuty's general REST API
+allowance and for other applications sharing the same user or key. Actual
+limits can also vary by operation and credential.
+
+Per cycle, the open confirmation costs twice the number of open-incident pages,
+and recent history costs one request per page and subwindow. The new incident
+properties come from those list responses and do not add per-incident requests.
+
+An unfiltered service callback reads up to 100 services, then queries `/oncalls`
+for the unique escalation policies on that page. Its request cost is one service
+request plus one on-call request when the result fits on one page. A multi-page
+result costs twice its page count because the Worker confirms the complete raw
+identity set with a second traversal. An explicit service scope reads one
+configured service per callback and queries that service's policy; a policy
+shared by services on different pages can therefore be queried again. A page
+with no policies skips the on-call request. Integrations and support hours come
+from the service response and add no per-service lookup. The shared pacer applies
+to all incident, service, and on-call requests combined.
+
+The Worker deliberately does not duplicate the bounded incident traversal to
+calculate service-level open-incident counts. It also makes no per-incident
+stakeholder-status or business-impact calls. Those additions would materially
+increase request volume and could turn an awareness sync into an unbounded
+fan-out.
+
+When PagerDuty returns HTTP 429, the client raises the Workers runtime's
+`RateLimitError`. It honors `Retry-After` and PagerDuty's `ratelimit-reset`
+header, with a conservative fallback when neither is usable. Invalid JSON,
+non-success responses, malformed pages, and non-advancing pagination all fail
+closed.
+
+### Project structure
+
+```text
+src/
+├── index.ts       — registers both databases, schedules, snapshots, and pacer
+├── pagerduty.ts   — list/direct API reads, configuration, and validation
+├── sync-state.ts  — open/history phases, safe window splits, and offsets
+├── incidents.ts   — incident schema and transform
+├── services.ts    — service schema, coverage context, and transform
+└── helpers.ts     — labels, durations, support hours, and safe page formatting
+```
+
+### Extending the example
+
+Use this checklist when extending the recipe:
+
+1. Add the provider field to the relevant validated API type in
+   `src/pagerduty.ts`; do not trust an unvalidated response shape.
+2. Add its `Schema.*` property and matching `Builder.*` value in the same order.
+   Keep the first six columns focused on triage, ownership, relation, and source
+   actions.
+3. Define the behavior for populated, missing, empty, zero, and plan-dependent
+   values. Prefer human-readable `summary` or `name` fields over opaque IDs.
+4. Preserve deterministic primary keys and the two-way Incident → Service
+   relation. Do not let a team filter remove service rows needed by relations.
+5. If another endpoint is required, use a bounded batch or one lookup per cycle.
+   Do not introduce an unbounded per-incident request, and keep all calls on the
+   shared pacer.
+6. Revisit the 10,000-record boundary. List traversals need a deterministic split
+   strategy or a clear fail-closed scope requirement; explicit service IDs should
+   continue to use direct lookups.
+7. Whitelist any page content, render provider text as plain text, accept only
+   safe context-link protocols, bound its size, and update the privacy inventory.
+   Do not copy arbitrary provider payloads or credentials.
+8. Add offline tests for populated and omitted values, request parameters,
+   pagination, split boundaries, duplicate detection, filter semantics, and rate
+   limits. Add a safe live preview for behavior that fixtures cannot prove.
+9. Update the property/configuration tables, expected output, extension notes,
+   and verification steps. If behavior, entrypoints, integrations, or commands
+   change, update the recipe's `catalog.json` entry too.
+
+The default intentionally stops at current level-one coverage on each service.
+It does not create a third Worker-managed on-call or review database, browse
+future shifts, or copy incident timelines. The native Incident Reviews workflow
+above owns mutable follow-up in Notion. Any extension for upcoming schedules,
+stakeholder updates, or business impact should first define a bounded batch or
+hard scope; do not add an unbounded per-record request path.
+
+### Verification
+
+Run all deterministic checks without contacting PagerDuty or Notion:
+
+```sh
+npm run check
+npm test
+npm run build
+```
+
+With a safe test account and `.env` configured, inspect each live result before
+writing:
+
+```sh
+ntn workers exec servicesSync --local
+ntn workers exec incidentsSync --local
+ntn workers sync trigger servicesSync --preview
+ntn workers sync trigger incidentsSync --preview
+```
+
+For live verification, confirm that names are resolved, optional properties are
+omitted, source and conference links open safely, the two-way Incident → Service
+relation resolves, and resolution duration agrees with the source timestamps.
+For services, confirm Response State matches PagerDuty, Primary On Call contains
+only current level-one responders, Primary Coverage reflects that level rather
+than every fallback, Coverage Checked matches the snapshot instant, and
+integrations and support hours match the service. Also confirm EU accounts use
+the EU host, all open incidents are present regardless of age, and Resolved
+history stops at the configured lookback.
+
+The offline suite cannot prove workspace permissions, API-key visibility, the
+current person on call, live conference access, or plan-specific fields such as
+priorities. A permission or completeness failure must stop the preview or sync;
+do not reinterpret it as an empty or healthy result.
+
+## Learn more
+
+- [Notion sync guide](https://developers.notion.com/workers/guides/syncs)
+- [Notion secrets guide](https://developers.notion.com/workers/guides/secrets)
+- [PagerDuty REST API reference](https://developer.pagerduty.com/api-reference/)
+- [PagerDuty OpenAPI schema](https://github.com/PagerDuty/api-schema)
+- [PagerDuty API access keys](https://support.pagerduty.com/main/docs/api-access-keys)
+- [PagerDuty service regions](https://support.pagerduty.com/main/docs/service-regions)
+- [PagerDuty REST API rate limits](https://support.pagerduty.com/main/docs/rest-api-rate-limits)
+- [Contributing guide](../../CONTRIBUTING.md)

--- a/workers/pagerduty-sync/package.json
+++ b/workers/pagerduty-sync/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@notion-cookbook/pagerduty-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --project tsconfig.test.json",
+    "test": "node --import tsx --test test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": "^0.4.0"
+  }
+}

--- a/workers/pagerduty-sync/src/helpers.ts
+++ b/workers/pagerduty-sync/src/helpers.ts
@@ -1,0 +1,574 @@
+// Shared display and page-content helpers for PagerDuty resource transforms.
+// Keep API identifiers out of visible labels: references are useful to a
+// Notion user only when PagerDuty supplied a human-readable summary or name.
+
+import type {
+  PagerDutyIncident,
+  PagerDutyReference,
+  PagerDutyService,
+  PagerDutySupportHours,
+} from "./pagerduty.js"
+
+export const MAX_DETAIL_CHARACTERS = 12_000
+export const MAX_PAGE_CONTENT_CHARACTERS = 40_000
+export const MAX_RICH_TEXT_CHARACTERS = 2_000
+
+const MAX_TEXT_CHARACTERS = 8_000
+const MAX_DETAIL_DEPTH = 8
+const MAX_DETAIL_ITEMS = 100
+const MAX_CONTEXTS = 25
+const MAX_CONTEXT_LABEL_CHARACTERS = 300
+const REDACTED_VALUE = "[REDACTED]"
+const ACRONYM_LABELS: Record<string, string> = {
+  api: "API",
+  sms: "SMS",
+}
+
+/** Turn PagerDuty enum values such as `direct_assignment` into title case. */
+export function humanizeEnum(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  const acronym = ACRONYM_LABELS[trimmed.toLowerCase()]
+  if (acronym) return acronym
+
+  const normalized = trimmed
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+
+  return normalized.replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+/** Resolve a visible reference label without falling back to an opaque ID. */
+export function referenceName(
+  reference: PagerDutyReference | null | undefined
+): string | null {
+  return reference?.summary?.trim() || reference?.name?.trim() || null
+}
+
+/** Trim, omit, and de-duplicate human-readable labels while preserving order. */
+export function uniqueNames(
+  values: ReadonlyArray<string | null | undefined> | null | undefined
+): string[] {
+  const names: string[] = []
+  const seen = new Set<string>()
+
+  for (const value of values ?? []) {
+    const name = value?.trim()
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    names.push(name)
+  }
+
+  return names
+}
+
+export function referenceNames(
+  references:
+    | ReadonlyArray<PagerDutyReference | null | undefined>
+    | null
+    | undefined
+): string[] {
+  return uniqueNames((references ?? []).map(referenceName))
+}
+
+export function dateTime(value: string | null | undefined): string | null {
+  return value?.trim() || null
+}
+
+export type PendingAutomaticAction = {
+  type?: string | null
+  at?: string | null
+  to?: string | null
+}
+
+export type NextAutomaticAction = {
+  label: string
+  at: string
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+/**
+ * Select the chronologically next pending action. PagerDuty does not promise
+ * the array is ordered, so action type and destination break timestamp ties.
+ */
+export function nextAutomaticAction(
+  actions: ReadonlyArray<PendingAutomaticAction> | null | undefined
+): NextAutomaticAction | null {
+  const candidates = (actions ?? []).flatMap((action) => {
+    const type = action.type?.trim()
+    const at = dateTime(action.at)
+    const atMilliseconds = at ? Date.parse(at) : Number.NaN
+    if (!type || !at || !Number.isFinite(atMilliseconds)) return []
+
+    return [
+      {
+        type,
+        at,
+        atMilliseconds,
+        to: action.to?.trim() ?? "",
+      },
+    ]
+  })
+
+  candidates.sort(
+    (left, right) =>
+      left.atMilliseconds - right.atMilliseconds ||
+      compareText(left.type, right.type) ||
+      compareText(left.to, right.to) ||
+      compareText(left.at, right.at)
+  )
+
+  const next = candidates[0]
+  if (!next) return null
+
+  const action = humanizeEnum(next.type)
+  if (!action) return null
+  const destination = humanizeEnum(next.to)
+
+  return {
+    label:
+      next.type === "urgency_change" && destination
+        ? `${action} to ${destination}`
+        : action,
+    at: next.at,
+  }
+}
+
+/** Return an elapsed duration rounded to one decimal minute. */
+export function durationMinutes(
+  startedAt: string | null | undefined,
+  endedAt: string | null | undefined
+): number | null {
+  const start = startedAt ? Date.parse(startedAt) : Number.NaN
+  const end = endedAt ? Date.parse(endedAt) : Number.NaN
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) {
+    return null
+  }
+
+  return Math.round(((end - start) / 60_000) * 10) / 10
+}
+
+/** Return the latest valid API timestamp, or null when none was supplied. */
+export function latestDateTime(
+  values: ReadonlyArray<string | null | undefined> | null | undefined
+): string | null {
+  let latest: string | null = null
+  let latestMilliseconds = Number.NEGATIVE_INFINITY
+
+  for (const value of values ?? []) {
+    const timestamp = dateTime(value)
+    if (!timestamp) continue
+
+    const milliseconds = Date.parse(timestamp)
+    if (!Number.isFinite(milliseconds) || milliseconds <= latestMilliseconds) {
+      continue
+    }
+
+    latest = timestamp
+    latestMilliseconds = milliseconds
+  }
+
+  return latest
+}
+
+/** PagerDuty stores service timeouts in seconds; Notion shows useful minutes. */
+export function positiveMinutes(
+  seconds: number | null | undefined
+): number | null {
+  return typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+    ? seconds / 60
+    : null
+}
+
+/** Describe both constant and support-hours urgency rules in one short label. */
+export function urgencyRuleLabel(
+  rule: PagerDutyService["incident_urgency_rule"]
+): string | null {
+  if (!rule) return null
+
+  if (rule.type === "constant") {
+    const urgency = humanizeEnum(rule.urgency)
+    return urgency ? `Always ${urgency}` : "Constant"
+  }
+
+  if (rule.type === "use_support_hours") {
+    const during = humanizeEnum(rule.during_support_hours?.urgency)
+    const outside = humanizeEnum(rule.outside_support_hours?.urgency)
+
+    if (during && outside) {
+      return `${during} During Support Hours / ${outside} Outside`
+    }
+    if (during) return `${during} During Support Hours`
+    if (outside) return `${outside} Outside Support Hours`
+    return "Support Hours"
+  }
+
+  return humanizeEnum(rule.type)
+}
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+function supportDaysLabel(
+  values: ReadonlyArray<number | null> | null | undefined
+): string | null {
+  const days = [
+    ...new Set(
+      (values ?? []).filter(
+        (value): value is number =>
+          typeof value === "number" &&
+          Number.isInteger(value) &&
+          value >= 1 &&
+          value <= 7
+      )
+    ),
+  ].sort((left, right) => left - right)
+  if (days.length === 0) return null
+
+  const ranges: Array<{ start: number; end: number }> = []
+  for (const day of days) {
+    const current = ranges.at(-1)
+    if (current && day === current.end + 1) {
+      current.end = day
+    } else {
+      ranges.push({ start: day, end: day })
+    }
+  }
+
+  return ranges
+    .map(({ start, end }) => {
+      const startLabel = WEEKDAY_LABELS[start - 1]
+      const endLabel = WEEKDAY_LABELS[end - 1]
+      return start === end ? startLabel : `${startLabel}–${endLabel}`
+    })
+    .join(", ")
+}
+
+function supportTime(value: string | null | undefined): string | null {
+  const time = value?.trim()
+  if (!time) return null
+  const match = /^(\d{2}:\d{2})(?::\d{2}(?:\.\d+)?)?$/.exec(time)
+  return match?.[1] ?? time
+}
+
+/** Render PagerDuty's fixed daily support window as one compact label. */
+export function supportHoursLabel(
+  supportHours: PagerDutySupportHours | null | undefined
+): string | null {
+  if (!supportHours) return null
+
+  const days = supportDaysLabel(supportHours.days_of_week)
+  const start = supportTime(supportHours.start_time)
+  const end = supportTime(supportHours.end_time)
+  const time = start && end ? `${start}–${end}` : (start ?? end)
+  const timeZone = supportHours.time_zone?.trim() || null
+  const details = [days, time].filter((value): value is string =>
+    Boolean(value)
+  )
+
+  if (details.length > 0) {
+    const window = details.join(" ")
+    return timeZone ? `${window} (${timeZone})` : window
+  }
+
+  const type = humanizeEnum(supportHours.type)
+  return timeZone ? `${type ?? "Support Hours"} (${timeZone})` : type
+}
+
+function isSensitiveDetailKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "")
+  return (
+    normalized.endsWith("servicekey") ||
+    normalized.endsWith("routingkey") ||
+    normalized.endsWith("integrationkey") ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("privatekey") ||
+    normalized.endsWith("authorization") ||
+    normalized.endsWith("credential") ||
+    normalized.endsWith("credentials") ||
+    normalized.endsWith("headers") ||
+    normalized.endsWith("cookie") ||
+    normalized.endsWith("cookies") ||
+    normalized.endsWith("auth") ||
+    normalized.endsWith("password") ||
+    normalized.endsWith("passwd") ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("signature") ||
+    normalized === "sig" ||
+    normalized.endsWith("token")
+  )
+}
+
+function boundedString(value: string, limit: number): string {
+  const characters = Array.from(value.trim())
+  if (characters.length <= limit) return characters.join("")
+
+  const marker = Array.from("\n… [truncated]")
+  const contentLength = Math.max(0, limit - marker.length)
+  return [...characters.slice(0, contentLength), ...marker]
+    .slice(0, limit)
+    .join("")
+}
+
+/** Trim and cap plain API text before passing it to a Notion builder. */
+export function boundedText(
+  value: string | null | undefined,
+  limit = MAX_TEXT_CHARACTERS
+): string | null {
+  const text = value?.trim()
+  return text ? boundedString(text, limit) : null
+}
+
+/**
+ * Clone JSON-like details while redacting common credential fields and
+ * bounding pathological depth/width. API data is expected to be JSON, but the
+ * defensive cases keep this helper safe and reusable in unit tests.
+ */
+function safeDetailValue(
+  value: unknown,
+  depth: number,
+  ancestors: Set<object>
+): unknown {
+  if (
+    value == null ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return value
+  }
+  if (typeof value === "string") {
+    return boundedString(value, MAX_TEXT_CHARACTERS)
+  }
+  if (typeof value === "bigint") return value.toString()
+  if (typeof value !== "object") return String(value)
+  if (ancestors.has(value)) return "[Circular value omitted]"
+  if (depth >= MAX_DETAIL_DEPTH) return "[Maximum depth reached]"
+
+  ancestors.add(value)
+  try {
+    if (Array.isArray(value)) {
+      const items = value
+        .slice(0, MAX_DETAIL_ITEMS)
+        .map((item) => safeDetailValue(item, depth + 1, ancestors))
+      if (value.length > MAX_DETAIL_ITEMS) {
+        items.push(`[${value.length - MAX_DETAIL_ITEMS} more items omitted]`)
+      }
+      return items
+    }
+
+    const result: Record<string, unknown> = {}
+    const entries = Object.entries(value)
+    for (const [key, item] of entries.slice(0, MAX_DETAIL_ITEMS)) {
+      result[key] = isSensitiveDetailKey(key)
+        ? REDACTED_VALUE
+        : safeDetailValue(item, depth + 1, ancestors)
+    }
+    if (entries.length > MAX_DETAIL_ITEMS) {
+      result._omitted_fields = entries.length - MAX_DETAIL_ITEMS
+    }
+    return result
+  } finally {
+    ancestors.delete(value)
+  }
+}
+
+/**
+ * Serialize arbitrary details as valid, bounded JSON. Triple backticks are
+ * escaped so a value cannot terminate the surrounding Markdown code fence.
+ */
+export function boundedSafeJson(value: unknown): string | null {
+  if (value == null) return null
+  if (Array.isArray(value) && value.length === 0) return null
+  if (
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  ) {
+    return null
+  }
+
+  const safeValue = safeDetailValue(value, 0, new Set<object>())
+  const serialized = JSON.stringify(safeValue, null, 2)?.replace(
+    /```/g,
+    "\\u0060\\u0060\\u0060"
+  )
+  if (!serialized) return null
+  if (serialized.length <= MAX_DETAIL_CHARACTERS) return serialized
+
+  // The preview is itself JSON-encoded, keeping the shortened block valid.
+  let previewLength = Math.floor(MAX_DETAIL_CHARACTERS / 2)
+  while (previewLength > 0) {
+    const shortened = JSON.stringify(
+      {
+        _truncated: true,
+        _message: "Details exceeded the Notion page preview limit.",
+        preview: serialized.slice(0, previewLength),
+      },
+      null,
+      2
+    ).replace(/```/g, "\\u0060\\u0060\\u0060")
+
+    if (shortened.length <= MAX_DETAIL_CHARACTERS) return shortened
+    previewLength = Math.floor(previewLength * 0.75)
+  }
+
+  return '{"_truncated":true}'
+}
+
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_[\]{}()#+\-.!|<>])/g, "\\$1")
+}
+
+function prose(
+  value: string | null | undefined,
+  limit = MAX_TEXT_CHARACTERS
+): string | null {
+  const text = boundedText(value, limit)
+  return text ? escapeMarkdownText(text) : null
+}
+
+/** Render provider-authored plain text without letting it create Markdown. */
+export function plainTextPageContent(
+  value: string | null | undefined
+): string | null {
+  return prose(value, MAX_PAGE_CONTENT_CHARACTERS - 100)
+}
+
+export function safeWebUrl(value: string | null | undefined): string | null {
+  const candidate = value?.trim()
+  if (!candidate) return null
+
+  try {
+    const url = new URL(candidate)
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null
+    if (url.username || url.password) return null
+    if ([...url.searchParams.keys()].some(isSensitiveDetailKey)) return null
+    if (url.hash) {
+      let fragment = url.hash.slice(1)
+      try {
+        for (let pass = 0; pass < 3; pass++) {
+          const decoded = decodeURIComponent(fragment)
+          if (decoded === fragment) break
+          fragment = decoded
+        }
+      } catch {
+        return null
+      }
+      const queryStart = fragment.indexOf("?")
+      const fragmentParams = new URLSearchParams(
+        queryStart >= 0 ? fragment.slice(queryStart + 1) : fragment
+      )
+      if ([...fragmentParams.keys()].some(isSensitiveDetailKey)) return null
+    }
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function plainTextFromHtml(value: string): string {
+  return value
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<\/p\s*>/gi, "\n\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+}
+
+function boundedPageSections(sections: string[]): string {
+  const rendered: string[] = []
+  const marker =
+    "> Additional source detail was omitted to keep this incident page bounded."
+
+  for (const section of sections) {
+    const candidate = [...rendered, section].join("\n\n")
+    if (candidate.length <= MAX_PAGE_CONTENT_CHARACTERS) {
+      rendered.push(section)
+      continue
+    }
+
+    if (
+      [...rendered, marker].join("\n\n").length <= MAX_PAGE_CONTENT_CHARACTERS
+    ) {
+      rendered.push(marker)
+    }
+    break
+  }
+
+  return rendered.join("\n\n")
+}
+
+/**
+ * Render only explicitly descriptive incident detail PagerDuty embeds in the
+ * list response. Arbitrary channel and incident detail objects are intentionally
+ * excluded from default page content because they can contain integration keys,
+ * credentials, or provider-specific sensitive data.
+ */
+export function incidentPageContent(
+  incident: Pick<PagerDutyIncident, "first_trigger_log_entry">
+): string {
+  const trigger = incident.first_trigger_log_entry
+  const channel = trigger?.channel
+  const channelTypeValue = channel?.type?.trim().toLowerCase()
+  const sections: string[] = []
+
+  const eventDescription = prose(trigger?.event_details?.description)
+  const channelDescription = prose(channel?.description)
+  const descriptions = uniqueNames([
+    eventDescription,
+    channelDescription === eventDescription ? null : channelDescription,
+  ])
+
+  if (descriptions.length > 0) {
+    sections.push(["## Trigger", ...descriptions].join("\n\n"))
+  }
+
+  // Email body is the only channel-specific message field copied by default.
+  // `details` remains excluded for every channel, including web triggers.
+  const contentTypeValue = channel?.body_content_type?.trim()
+  const channelMessageValue =
+    channelTypeValue === "email" ? channel?.body : null
+  const channelMessageValueAsText =
+    channelMessageValue && contentTypeValue?.toLowerCase().includes("html")
+      ? plainTextFromHtml(
+          boundedString(channelMessageValue, MAX_TEXT_CHARACTERS)
+        )
+      : channelMessageValue
+  const channelMessage = prose(channelMessageValueAsText)
+  if (channelMessage) {
+    sections.push(["## Trigger message", channelMessage].join("\n\n"))
+  }
+
+  const contexts = trigger?.contexts ?? []
+  const contextLines = uniqueNames(
+    contexts.slice(0, MAX_CONTEXTS).map((context) => {
+      const label =
+        prose(context.text, MAX_CONTEXT_LABEL_CHARACTERS) ??
+        (context.type === "image" ? "Related image" : "Related link")
+      const url = safeWebUrl(context.href) ?? safeWebUrl(context.src)
+      return url ? `- [${label}](<${url}>)` : label ? `- ${label}` : null
+    })
+  )
+  if (contexts.length > MAX_CONTEXTS) {
+    contextLines.push(
+      `- _… ${contexts.length - MAX_CONTEXTS} additional contexts omitted._`
+    )
+  }
+  if (contextLines.length > 0) {
+    sections.push(`## Context\n\n${contextLines.join("\n")}`)
+  }
+
+  return boundedPageSections(sections)
+}

--- a/workers/pagerduty-sync/src/helpers.ts
+++ b/workers/pagerduty-sync/src/helpers.ts
@@ -11,18 +11,14 @@ import type {
   PagerDutySupportHours,
 } from "./pagerduty.js"
 
-export const MAX_DETAIL_CHARACTERS = 12_000
 export const MAX_PAGE_CONTENT_CHARACTERS = 40_000
 export const MAX_RICH_TEXT_CHARACTERS = 2_000
 export const MAX_MULTI_SELECT_OPTIONS = 100
 export const MAX_OPTION_NAME_CHARACTERS = 100
 
 const MAX_TEXT_CHARACTERS = 8_000
-const MAX_DETAIL_DEPTH = 8
-const MAX_DETAIL_ITEMS = 100
 const MAX_CONTEXTS = 25
 const MAX_CONTEXT_LABEL_CHARACTERS = 300
-const REDACTED_VALUE = "[REDACTED]"
 const ACRONYM_LABELS: Record<string, string> = {
   api: "API",
   sms: "SMS",
@@ -65,15 +61,6 @@ export function uniqueNames(
   }
 
   return names
-}
-
-export function referenceNames(
-  references:
-    | ReadonlyArray<PagerDutyReference | null | undefined>
-    | null
-    | undefined
-): string[] {
-  return uniqueNames((references ?? []).map(referenceName))
 }
 
 /**
@@ -361,7 +348,7 @@ export function supportHoursLabel(
   return timeZone ? `${type ?? "Support Hours"} (${timeZone})` : type
 }
 
-function isSensitiveDetailKey(key: string): boolean {
+function isSensitiveUrlParameter(key: string): boolean {
   const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "")
   return (
     normalized.endsWith("servicekey") ||
@@ -405,102 +392,6 @@ export function boundedText(
   return text ? boundedString(text, limit) : null
 }
 
-/**
- * Clone JSON-like details while redacting common credential fields and
- * bounding pathological depth/width. API data is expected to be JSON, but the
- * defensive cases keep this helper safe and reusable in unit tests.
- */
-function safeDetailValue(
-  value: unknown,
-  depth: number,
-  ancestors: Set<object>
-): unknown {
-  if (
-    value == null ||
-    typeof value === "boolean" ||
-    typeof value === "number"
-  ) {
-    return value
-  }
-  if (typeof value === "string") {
-    return boundedString(value, MAX_TEXT_CHARACTERS)
-  }
-  if (typeof value === "bigint") return value.toString()
-  if (typeof value !== "object") return String(value)
-  if (ancestors.has(value)) return "[Circular value omitted]"
-  if (depth >= MAX_DETAIL_DEPTH) return "[Maximum depth reached]"
-
-  ancestors.add(value)
-  try {
-    if (Array.isArray(value)) {
-      const items = value
-        .slice(0, MAX_DETAIL_ITEMS)
-        .map((item) => safeDetailValue(item, depth + 1, ancestors))
-      if (value.length > MAX_DETAIL_ITEMS) {
-        items.push(`[${value.length - MAX_DETAIL_ITEMS} more items omitted]`)
-      }
-      return items
-    }
-
-    const result: Record<string, unknown> = {}
-    const entries = Object.entries(value)
-    for (const [key, item] of entries.slice(0, MAX_DETAIL_ITEMS)) {
-      result[key] = isSensitiveDetailKey(key)
-        ? REDACTED_VALUE
-        : safeDetailValue(item, depth + 1, ancestors)
-    }
-    if (entries.length > MAX_DETAIL_ITEMS) {
-      result._omitted_fields = entries.length - MAX_DETAIL_ITEMS
-    }
-    return result
-  } finally {
-    ancestors.delete(value)
-  }
-}
-
-/**
- * Serialize arbitrary details as valid, bounded JSON. Triple backticks are
- * escaped so a value cannot terminate the surrounding Markdown code fence.
- */
-export function boundedSafeJson(value: unknown): string | null {
-  if (value == null) return null
-  if (Array.isArray(value) && value.length === 0) return null
-  if (
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    Object.keys(value).length === 0
-  ) {
-    return null
-  }
-
-  const safeValue = safeDetailValue(value, 0, new Set<object>())
-  const serialized = JSON.stringify(safeValue, null, 2)?.replace(
-    /```/g,
-    "\\u0060\\u0060\\u0060"
-  )
-  if (!serialized) return null
-  if (serialized.length <= MAX_DETAIL_CHARACTERS) return serialized
-
-  // The preview is itself JSON-encoded, keeping the shortened block valid.
-  let previewLength = Math.floor(MAX_DETAIL_CHARACTERS / 2)
-  while (previewLength > 0) {
-    const shortened = JSON.stringify(
-      {
-        _truncated: true,
-        _message: "Details exceeded the Notion page preview limit.",
-        preview: serialized.slice(0, previewLength),
-      },
-      null,
-      2
-    ).replace(/```/g, "\\u0060\\u0060\\u0060")
-
-    if (shortened.length <= MAX_DETAIL_CHARACTERS) return shortened
-    previewLength = Math.floor(previewLength * 0.75)
-  }
-
-  return '{"_truncated":true}'
-}
-
 function escapeMarkdownText(value: string): string {
   return value.replace(/([\\`*_[\]{}()#+\-.!|<>])/g, "\\$1")
 }
@@ -528,7 +419,7 @@ export function safeWebUrl(value: string | null | undefined): string | null {
     const url = new URL(candidate)
     if (url.protocol !== "https:" && url.protocol !== "http:") return null
     if (url.username || url.password) return null
-    if ([...url.searchParams.keys()].some(isSensitiveDetailKey)) return null
+    if ([...url.searchParams.keys()].some(isSensitiveUrlParameter)) return null
     if (url.hash) {
       let fragment = url.hash.slice(1)
       try {
@@ -544,7 +435,7 @@ export function safeWebUrl(value: string | null | undefined): string | null {
       const fragmentParams = new URLSearchParams(
         queryStart >= 0 ? fragment.slice(queryStart + 1) : fragment
       )
-      if ([...fragmentParams.keys()].some(isSensitiveDetailKey)) return null
+      if ([...fragmentParams.keys()].some(isSensitiveUrlParameter)) return null
     }
     return url.toString()
   } catch {

--- a/workers/pagerduty-sync/src/helpers.ts
+++ b/workers/pagerduty-sync/src/helpers.ts
@@ -2,6 +2,8 @@
 // Keep API identifiers out of visible labels: references are useful to a
 // Notion user only when PagerDuty supplied a human-readable summary or name.
 
+import { createHash } from "node:crypto"
+
 import type {
   PagerDutyIncident,
   PagerDutyReference,
@@ -12,6 +14,8 @@ import type {
 export const MAX_DETAIL_CHARACTERS = 12_000
 export const MAX_PAGE_CONTENT_CHARACTERS = 40_000
 export const MAX_RICH_TEXT_CHARACTERS = 2_000
+export const MAX_MULTI_SELECT_OPTIONS = 100
+export const MAX_OPTION_NAME_CHARACTERS = 100
 
 const MAX_TEXT_CHARACTERS = 8_000
 const MAX_DETAIL_DEPTH = 8
@@ -70,6 +74,83 @@ export function referenceNames(
     | undefined
 ): string[] {
   return uniqueNames((references ?? []).map(referenceName))
+}
+
+/**
+ * Normalize provider-authored option labels before they reach a Notion
+ * select. ASCII commas are not valid option-name characters in Notion.
+ */
+export function providerOptionLabel(
+  value: string | null | undefined
+): string | null {
+  const normalized = value?.normalize("NFKC").trim().replace(/\s+/gu, " ")
+  if (!normalized) return null
+
+  // A full-width comma remains readable without colliding with a provider
+  // label that already uses a middle dot.
+  const safe = normalized.replace(/,/gu, "，")
+  const characters = Array.from(safe)
+  if (characters.length <= MAX_OPTION_NAME_CHARACTERS) return safe
+
+  const digest = createHash("sha256")
+    .update(normalized)
+    .digest("hex")
+    .slice(0, 8)
+  const suffix = `… ${digest}`
+  const prefixLength = MAX_OPTION_NAME_CHARACTERS - Array.from(suffix).length
+
+  return `${characters.slice(0, prefixLength).join("")}${suffix}`
+}
+
+/**
+ * Produce one deterministic, Notion-safe option list. De-duplicate using
+ * Notion's case-insensitive option identity and fail rather than silently
+ * discard operational data above the per-value multi-select limit.
+ */
+export function providerOptionLabels(
+  property: string,
+  values: ReadonlyArray<string | null | undefined> | null | undefined
+): string[] {
+  const candidates = (values ?? [])
+    .map(providerOptionLabel)
+    .filter((label): label is string => label !== null)
+    .sort(
+      (left, right) =>
+        left.localeCompare(right, "en-US", { sensitivity: "base" }) ||
+        (left < right ? -1 : left > right ? 1 : 0)
+    )
+  const unique = new Map<string, string>()
+
+  for (const label of candidates) {
+    const identity = label.toLocaleLowerCase("en-US")
+    if (!unique.has(identity)) unique.set(identity, label)
+  }
+
+  const labels = [...unique.values()]
+
+  if (labels.length > MAX_MULTI_SELECT_OPTIONS) {
+    throw new Error(
+      `PagerDuty ${property} produced ${labels.length} unique values; Notion supports at most ${MAX_MULTI_SELECT_OPTIONS} options in one multi-select value.`
+    )
+  }
+
+  return labels
+}
+
+export function referenceOptionName(
+  reference: PagerDutyReference | null | undefined
+): string | null {
+  return providerOptionLabel(referenceName(reference))
+}
+
+export function referenceOptionNames(
+  property: string,
+  references:
+    | ReadonlyArray<PagerDutyReference | null | undefined>
+    | null
+    | undefined
+): string[] {
+  return providerOptionLabels(property, (references ?? []).map(referenceName))
 }
 
 export function dateTime(value: string | null | undefined): string | null {

--- a/workers/pagerduty-sync/src/helpers.ts
+++ b/workers/pagerduty-sync/src/helpers.ts
@@ -15,6 +15,7 @@ export const MAX_PAGE_CONTENT_CHARACTERS = 40_000
 export const MAX_RICH_TEXT_CHARACTERS = 2_000
 export const MAX_MULTI_SELECT_OPTIONS = 100
 export const MAX_OPTION_NAME_CHARACTERS = 100
+export const MAX_URL_CHARACTERS = 2_000
 
 const MAX_TEXT_CHARACTERS = 8_000
 const MAX_CONTEXTS = 25
@@ -437,7 +438,8 @@ export function safeWebUrl(value: string | null | undefined): string | null {
       )
       if ([...fragmentParams.keys()].some(isSensitiveUrlParameter)) return null
     }
-    return url.toString()
+    const normalized = url.toString()
+    return normalized.length <= MAX_URL_CHARACTERS ? normalized : null
   } catch {
     return null
   }

--- a/workers/pagerduty-sync/src/incidents.ts
+++ b/workers/pagerduty-sync/src/incidents.ts
@@ -1,0 +1,223 @@
+// PagerDuty incidents — the active operational view for responders and
+// stakeholders. Keep schema and transform property order exactly aligned.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+
+import type { PagerDutyIncident } from "./pagerduty.js"
+import {
+  boundedText,
+  dateTime,
+  durationMinutes,
+  humanizeEnum,
+  incidentPageContent,
+  latestDateTime,
+  nextAutomaticAction,
+  referenceName,
+  referenceNames,
+  safeWebUrl,
+  MAX_RICH_TEXT_CHARACTERS,
+} from "./helpers.js"
+
+export const INITIAL_TITLE = "PagerDuty Incidents"
+export const PRIMARY_KEY = "PagerDuty Incident ID"
+
+export const incidentSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("alarm", "red"),
+  properties: {
+    Title: Schema.title(),
+
+    Status: Schema.select([
+      { name: "Triggered" },
+      { name: "Acknowledged" },
+      { name: "Resolved" },
+    ]),
+
+    Urgency: Schema.select([{ name: "High" }, { name: "Low" }]),
+
+    "Assigned To": Schema.multiSelect([]),
+
+    "Incident Link": Schema.url(),
+
+    // Relation values use the immutable service key; users see service pages.
+    Service: Schema.relation("services", {
+      twoWay: true,
+      relatedPropertyName: "Incidents",
+    }),
+
+    // Incident types are configured by each PagerDuty account.
+    "Incident Type": Schema.select([]),
+
+    // The actor may be a user, service, or integration.
+    "Last Changed By": Schema.select([]),
+
+    "Next Automatic Action": Schema.select([]),
+
+    "Next Action At": Schema.date(),
+
+    "Conference Link": Schema.url(),
+
+    "Conference Dial-in": Schema.richText(),
+
+    "Resolution Duration (min)": Schema.number(),
+
+    // Priorities are account-configured, so their options are dynamic.
+    Priority: Schema.select([]),
+
+    Teams: Schema.multiSelect([]),
+
+    "Escalation Policy": Schema.select([]),
+
+    "Last Status Change": Schema.date(),
+
+    Updated: Schema.date(),
+
+    "Total Alert Count": Schema.number(),
+
+    "Active Alert Count": Schema.number(),
+
+    "Acknowledged By": Schema.multiSelect([]),
+
+    "Last Acknowledged": Schema.date(),
+
+    "Assigned Via": Schema.select([
+      { name: "Escalation Policy" },
+      { name: "Direct Assignment" },
+    ]),
+
+    Created: Schema.date(),
+
+    Resolved: Schema.date(),
+
+    "Incident Number": Schema.number(),
+
+    "PagerDuty Incident ID": Schema.richText(),
+  },
+}
+
+const ASSIGNED_VIA_LABELS: Record<string, string> = {
+  escalation_policy: "Escalation Policy",
+  direct_assignment: "Direct Assignment",
+}
+
+export function incidentToChange(incident: PagerDutyIncident) {
+  const title =
+    boundedText(incident.title, MAX_RICH_TEXT_CHARACTERS) ?? incident.id
+  const status = humanizeEnum(incident.status)
+  const urgency = humanizeEnum(incident.urgency)
+  const assignedTo = referenceNames(
+    incident.assignments?.map((assignment) => assignment.assignee)
+  )
+  const incidentLink = safeWebUrl(incident.html_url)
+  const serviceId = incident.service?.id.trim()
+  const incidentType = boundedText(
+    humanizeEnum(incident.incident_type?.name),
+    MAX_RICH_TEXT_CHARACTERS
+  )
+  const lastChangedBy = referenceName(incident.last_status_change_by)
+  const nextAction = nextAutomaticAction(incident.pending_actions)
+  const conferenceLink = safeWebUrl(incident.conference_bridge?.conference_url)
+  const conferenceDialIn = boundedText(
+    incident.conference_bridge?.conference_number,
+    MAX_RICH_TEXT_CHARACTERS
+  )
+  const priority = referenceName(incident.priority)
+  const teams = referenceNames(incident.teams)
+  const escalationPolicy = referenceName(incident.escalation_policy)
+  const lastStatusChange = dateTime(incident.last_status_change_at)
+  const updated = dateTime(incident.updated_at)
+  const totalAlertCount = incident.alert_counts?.all
+  const activeAlertCount = incident.alert_counts?.triggered
+
+  // PagerDuty exposes only current acknowledgements here (the list is empty
+  // after retrigger or resolution), so do not present this as lifetime data.
+  const acknowledgedBy = referenceNames(
+    incident.acknowledgements?.map(
+      (acknowledgement) => acknowledgement.acknowledger
+    )
+  )
+  const lastAcknowledged = latestDateTime(
+    incident.acknowledgements?.map((acknowledgement) => acknowledgement.at)
+  )
+  const assignedViaValue = incident.assigned_via?.trim()
+  const assignedVia = assignedViaValue
+    ? (ASSIGNED_VIA_LABELS[assignedViaValue] ?? humanizeEnum(assignedViaValue))
+    : null
+  const created = dateTime(incident.created_at)
+  const resolved = dateTime(incident.resolved_at)
+  const resolutionDuration = durationMinutes(created, resolved)
+  const pageContent = incidentPageContent(incident)
+
+  return {
+    type: "upsert" as const,
+    // PagerDuty's immutable incident ID is the sync identity.
+    key: incident.id,
+    upstreamUpdatedAt: incident.updated_at,
+    ...(pageContent ? { pageContentMarkdown: pageContent } : {}),
+    properties: {
+      Title: Builder.title(title),
+      ...(status ? { Status: Builder.select(status) } : {}),
+      ...(urgency ? { Urgency: Builder.select(urgency) } : {}),
+      ...(assignedTo.length > 0
+        ? { "Assigned To": Builder.multiSelect(...assignedTo) }
+        : {}),
+      ...(incidentLink ? { "Incident Link": Builder.url(incidentLink) } : {}),
+      ...(serviceId ? { Service: [Builder.relation(serviceId)] } : {}),
+      ...(incidentType
+        ? { "Incident Type": Builder.select(incidentType) }
+        : {}),
+      ...(lastChangedBy
+        ? { "Last Changed By": Builder.select(lastChangedBy) }
+        : {}),
+      ...(nextAction
+        ? {
+            "Next Automatic Action": Builder.select(nextAction.label),
+            "Next Action At": Builder.dateTime(nextAction.at),
+          }
+        : {}),
+      ...(conferenceLink
+        ? { "Conference Link": Builder.url(conferenceLink) }
+        : {}),
+      ...(conferenceDialIn
+        ? { "Conference Dial-in": Builder.richText(conferenceDialIn) }
+        : {}),
+      ...(resolutionDuration != null
+        ? {
+            "Resolution Duration (min)": Builder.number(resolutionDuration),
+          }
+        : {}),
+      ...(priority ? { Priority: Builder.select(priority) } : {}),
+      ...(teams.length > 0 ? { Teams: Builder.multiSelect(...teams) } : {}),
+      ...(escalationPolicy
+        ? { "Escalation Policy": Builder.select(escalationPolicy) }
+        : {}),
+      ...(lastStatusChange
+        ? { "Last Status Change": Builder.dateTime(lastStatusChange) }
+        : {}),
+      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
+      ...(typeof totalAlertCount === "number" &&
+      Number.isFinite(totalAlertCount)
+        ? { "Total Alert Count": Builder.number(totalAlertCount) }
+        : {}),
+      ...(typeof activeAlertCount === "number" &&
+      Number.isFinite(activeAlertCount)
+        ? { "Active Alert Count": Builder.number(activeAlertCount) }
+        : {}),
+      ...(acknowledgedBy.length > 0
+        ? { "Acknowledged By": Builder.multiSelect(...acknowledgedBy) }
+        : {}),
+      ...(lastAcknowledged
+        ? { "Last Acknowledged": Builder.dateTime(lastAcknowledged) }
+        : {}),
+      ...(assignedVia ? { "Assigned Via": Builder.select(assignedVia) } : {}),
+      ...(created ? { Created: Builder.dateTime(created) } : {}),
+      ...(resolved ? { Resolved: Builder.dateTime(resolved) } : {}),
+      ...(typeof incident.incident_number === "number" &&
+      Number.isFinite(incident.incident_number)
+        ? { "Incident Number": Builder.number(incident.incident_number) }
+        : {}),
+      "PagerDuty Incident ID": Builder.richText(incident.id),
+    },
+  }
+}

--- a/workers/pagerduty-sync/src/incidents.ts
+++ b/workers/pagerduty-sync/src/incidents.ts
@@ -3,7 +3,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 
 import type { PagerDutyIncident } from "./pagerduty.js"
 import {
@@ -14,8 +14,9 @@ import {
   incidentPageContent,
   latestDateTime,
   nextAutomaticAction,
-  referenceName,
-  referenceNames,
+  providerOptionLabel,
+  referenceOptionName,
+  referenceOptionNames,
   safeWebUrl,
   MAX_RICH_TEXT_CHARACTERS,
 } from "./helpers.js"
@@ -23,7 +24,7 @@ import {
 export const INITIAL_TITLE = "PagerDuty Incidents"
 export const PRIMARY_KEY = "PagerDuty Incident ID"
 
-export const incidentSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const incidentSchema = {
   databaseIcon: notionIcon("alarm", "red"),
   properties: {
     Title: Schema.title(),
@@ -94,37 +95,43 @@ export const incidentSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "PagerDuty Incident ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 const ASSIGNED_VIA_LABELS: Record<string, string> = {
   escalation_policy: "Escalation Policy",
   direct_assignment: "Direct Assignment",
 }
 
-export function incidentToChange(incident: PagerDutyIncident) {
+export function incidentToChange(
+  incident: PagerDutyIncident
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof incidentSchema.properties> {
   const title =
     boundedText(incident.title, MAX_RICH_TEXT_CHARACTERS) ?? incident.id
-  const status = humanizeEnum(incident.status)
-  const urgency = humanizeEnum(incident.urgency)
-  const assignedTo = referenceNames(
+  const status = providerOptionLabel(humanizeEnum(incident.status))
+  const urgency = providerOptionLabel(humanizeEnum(incident.urgency))
+  const assignedTo = referenceOptionNames(
+    "Assigned To",
     incident.assignments?.map((assignment) => assignment.assignee)
   )
   const incidentLink = safeWebUrl(incident.html_url)
   const serviceId = incident.service?.id.trim()
-  const incidentType = boundedText(
-    humanizeEnum(incident.incident_type?.name),
-    MAX_RICH_TEXT_CHARACTERS
+  const incidentType = providerOptionLabel(
+    boundedText(
+      humanizeEnum(incident.incident_type?.name),
+      MAX_RICH_TEXT_CHARACTERS
+    )
   )
-  const lastChangedBy = referenceName(incident.last_status_change_by)
+  const lastChangedBy = referenceOptionName(incident.last_status_change_by)
   const nextAction = nextAutomaticAction(incident.pending_actions)
+  const nextActionLabel = providerOptionLabel(nextAction?.label)
   const conferenceLink = safeWebUrl(incident.conference_bridge?.conference_url)
   const conferenceDialIn = boundedText(
     incident.conference_bridge?.conference_number,
     MAX_RICH_TEXT_CHARACTERS
   )
-  const priority = referenceName(incident.priority)
-  const teams = referenceNames(incident.teams)
-  const escalationPolicy = referenceName(incident.escalation_policy)
+  const priority = referenceOptionName(incident.priority)
+  const teams = referenceOptionNames("Teams", incident.teams)
+  const escalationPolicy = referenceOptionName(incident.escalation_policy)
   const lastStatusChange = dateTime(incident.last_status_change_at)
   const updated = dateTime(incident.updated_at)
   const totalAlertCount = incident.alert_counts?.all
@@ -132,7 +139,8 @@ export function incidentToChange(incident: PagerDutyIncident) {
 
   // PagerDuty exposes only current acknowledgements here (the list is empty
   // after retrigger or resolution), so do not present this as lifetime data.
-  const acknowledgedBy = referenceNames(
+  const acknowledgedBy = referenceOptionNames(
+    "Acknowledged By",
     incident.acknowledgements?.map(
       (acknowledgement) => acknowledgement.acknowledger
     )
@@ -141,9 +149,12 @@ export function incidentToChange(incident: PagerDutyIncident) {
     incident.acknowledgements?.map((acknowledgement) => acknowledgement.at)
   )
   const assignedViaValue = incident.assigned_via?.trim()
-  const assignedVia = assignedViaValue
-    ? (ASSIGNED_VIA_LABELS[assignedViaValue] ?? humanizeEnum(assignedViaValue))
-    : null
+  const assignedVia = providerOptionLabel(
+    assignedViaValue
+      ? (ASSIGNED_VIA_LABELS[assignedViaValue] ??
+          humanizeEnum(assignedViaValue))
+      : null
+  )
   const created = dateTime(incident.created_at)
   const resolved = dateTime(incident.resolved_at)
   const resolutionDuration = durationMinutes(created, resolved)
@@ -154,69 +165,58 @@ export function incidentToChange(incident: PagerDutyIncident) {
     // PagerDuty's immutable incident ID is the sync identity.
     key: incident.id,
     upstreamUpdatedAt: incident.updated_at,
-    ...(pageContent ? { pageContentMarkdown: pageContent } : {}),
+    pageContentMarkdown: pageContent,
     properties: {
       Title: Builder.title(title),
-      ...(status ? { Status: Builder.select(status) } : {}),
-      ...(urgency ? { Urgency: Builder.select(urgency) } : {}),
-      ...(assignedTo.length > 0
-        ? { "Assigned To": Builder.multiSelect(...assignedTo) }
-        : {}),
-      ...(incidentLink ? { "Incident Link": Builder.url(incidentLink) } : {}),
-      ...(serviceId ? { Service: [Builder.relation(serviceId)] } : {}),
-      ...(incidentType
-        ? { "Incident Type": Builder.select(incidentType) }
-        : {}),
-      ...(lastChangedBy
-        ? { "Last Changed By": Builder.select(lastChangedBy) }
-        : {}),
-      ...(nextAction
-        ? {
-            "Next Automatic Action": Builder.select(nextAction.label),
-            "Next Action At": Builder.dateTime(nextAction.at),
-          }
-        : {}),
-      ...(conferenceLink
-        ? { "Conference Link": Builder.url(conferenceLink) }
-        : {}),
-      ...(conferenceDialIn
-        ? { "Conference Dial-in": Builder.richText(conferenceDialIn) }
-        : {}),
-      ...(resolutionDuration != null
-        ? {
-            "Resolution Duration (min)": Builder.number(resolutionDuration),
-          }
-        : {}),
-      ...(priority ? { Priority: Builder.select(priority) } : {}),
-      ...(teams.length > 0 ? { Teams: Builder.multiSelect(...teams) } : {}),
-      ...(escalationPolicy
-        ? { "Escalation Policy": Builder.select(escalationPolicy) }
-        : {}),
-      ...(lastStatusChange
-        ? { "Last Status Change": Builder.dateTime(lastStatusChange) }
-        : {}),
-      ...(updated ? { Updated: Builder.dateTime(updated) } : {}),
-      ...(typeof totalAlertCount === "number" &&
-      Number.isFinite(totalAlertCount)
-        ? { "Total Alert Count": Builder.number(totalAlertCount) }
-        : {}),
-      ...(typeof activeAlertCount === "number" &&
-      Number.isFinite(activeAlertCount)
-        ? { "Active Alert Count": Builder.number(activeAlertCount) }
-        : {}),
-      ...(acknowledgedBy.length > 0
-        ? { "Acknowledged By": Builder.multiSelect(...acknowledgedBy) }
-        : {}),
-      ...(lastAcknowledged
-        ? { "Last Acknowledged": Builder.dateTime(lastAcknowledged) }
-        : {}),
-      ...(assignedVia ? { "Assigned Via": Builder.select(assignedVia) } : {}),
-      ...(created ? { Created: Builder.dateTime(created) } : {}),
-      ...(resolved ? { Resolved: Builder.dateTime(resolved) } : {}),
-      ...(typeof incident.incident_number === "number" &&
-      Number.isFinite(incident.incident_number)
-        ? { "Incident Number": Builder.number(incident.incident_number) }
-        : {}),
+      Status: status ? Builder.select(status) : [],
+      Urgency: urgency ? Builder.select(urgency) : [],
+      "Assigned To":
+        assignedTo.length > 0 ? Builder.multiSelect(...assignedTo) : [],
+      "Incident Link": incidentLink ? Builder.url(incidentLink) : [],
+      Service: serviceId ? [Builder.relation(serviceId)] : [],
+      "Incident Type": incidentType ? Builder.select(incidentType) : [],
+      "Last Changed By": lastChangedBy ? Builder.select(lastChangedBy) : [],
+      "Next Automatic Action": nextActionLabel
+        ? Builder.select(nextActionLabel)
+        : [],
+      "Next Action At": nextAction ? Builder.dateTime(nextAction.at) : [],
+      "Conference Link": conferenceLink ? Builder.url(conferenceLink) : [],
+      "Conference Dial-in": conferenceDialIn
+        ? Builder.richText(conferenceDialIn)
+        : [],
+      "Resolution Duration (min)":
+        resolutionDuration != null ? Builder.number(resolutionDuration) : [],
+      Priority: priority ? Builder.select(priority) : [],
+      Teams: teams.length > 0 ? Builder.multiSelect(...teams) : [],
+      "Escalation Policy": escalationPolicy
+        ? Builder.select(escalationPolicy)
+        : [],
+      "Last Status Change": lastStatusChange
+        ? Builder.dateTime(lastStatusChange)
+        : [],
+      Updated: updated ? Builder.dateTime(updated) : [],
+      "Total Alert Count":
+        typeof totalAlertCount === "number" && Number.isFinite(totalAlertCount)
+          ? Builder.number(totalAlertCount)
+          : [],
+      "Active Alert Count":
+        typeof activeAlertCount === "number" &&
+        Number.isFinite(activeAlertCount)
+          ? Builder.number(activeAlertCount)
+          : [],
+      "Acknowledged By":
+        acknowledgedBy.length > 0 ? Builder.multiSelect(...acknowledgedBy) : [],
+      "Last Acknowledged": lastAcknowledged
+        ? Builder.dateTime(lastAcknowledged)
+        : [],
+      "Assigned Via": assignedVia ? Builder.select(assignedVia) : [],
+      Created: created ? Builder.dateTime(created) : [],
+      Resolved: resolved ? Builder.dateTime(resolved) : [],
+      "Incident Number":
+        typeof incident.incident_number === "number" &&
+        Number.isFinite(incident.incident_number)
+          ? Builder.number(incident.incident_number)
+          : [],
       "PagerDuty Incident ID": Builder.richText(incident.id),
     },
   }

--- a/workers/pagerduty-sync/src/index.ts
+++ b/workers/pagerduty-sync/src/index.ts
@@ -68,7 +68,11 @@ export async function executeIncidents(
     offset: state.offset,
   })
   const nextState = nextIncidentSyncState(state, page)
-  const changes = page.resources.map(incidentToChange)
+  // Confirmation validates the complete identity set only. The first open
+  // pass already emitted these keys, so replaying their full upserts would add
+  // write volume without strengthening replacement completeness.
+  const changes =
+    state.phase === "openConfirm" ? [] : page.resources.map(incidentToChange)
 
   return nextState
     ? { changes, hasMore: true as const, nextState }

--- a/workers/pagerduty-sync/src/index.ts
+++ b/workers/pagerduty-sync/src/index.ts
@@ -1,0 +1,151 @@
+// Entry point — syncs active and recent PagerDuty incidents and their services
+// into related managed Notion databases.
+//
+// Two databases are created:
+//   1. Incidents — operations awareness and handoff (every 5 min)
+//   2. Services  — readiness, coverage, ownership, and routing (every 5 min)
+//
+// Both replacement traversals keep their complete cycle state serializable.
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  INITIAL_TITLE as INCIDENTS_TITLE,
+  PRIMARY_KEY as INCIDENTS_PK,
+  incidentSchema,
+  incidentToChange,
+} from "./incidents.js"
+import {
+  createPagerDutyClient,
+  getPagerDutyConfig,
+  type PagerDutyClient,
+  type PagerDutyConfig,
+} from "./pagerduty.js"
+import {
+  INITIAL_TITLE as SERVICES_TITLE,
+  PRIMARY_KEY as SERVICES_PK,
+  buildServiceOperationalContext,
+  serviceSchema,
+  serviceToChange,
+} from "./services.js"
+import {
+  initialIncidentSyncState,
+  initialServiceSyncState,
+  nextIncidentSyncState,
+  nextServiceSyncState,
+  type IncidentSyncState,
+  type ServiceSyncState,
+} from "./sync-state.js"
+
+const worker = new Worker()
+
+// PagerDuty's limits depend on the credential and operation. Keep aggregate
+// cookbook traffic conservative and still honor server-provided 429 delays.
+const pacer = worker.pacer("pagerduty", {
+  allowedRequests: 120,
+  intervalMs: 60_000,
+})
+const beforePagerDutyRequest = () => pacer.wait()
+const pagerduty = createPagerDutyClient({
+  beforeRequest: beforePagerDutyRequest,
+})
+
+type ConfigProvider = () => PagerDutyConfig
+
+/**
+ * One incidents callback, exported with injectable boundaries so this file is
+ * both the production registration point and an end-to-end example to test.
+ */
+export async function executeIncidents(
+  previousState: IncidentSyncState | undefined,
+  client: PagerDutyClient = pagerduty,
+  readConfig: ConfigProvider = getPagerDutyConfig
+) {
+  const state = previousState ?? initialIncidentSyncState(readConfig())
+  const page = await client.fetchIncidentsPage(state.scope, {
+    since: state.windowSince,
+    until: state.windowUntil,
+    offset: state.offset,
+  })
+  const nextState = nextIncidentSyncState(state, page)
+  const changes = page.resources.map(incidentToChange)
+
+  return nextState
+    ? { changes, hasMore: true as const, nextState }
+    : { changes, hasMore: false as const }
+}
+
+/** Services have no updated_at, so the state-pinned observation time is used. */
+export async function executeServices(
+  previousState: ServiceSyncState | undefined,
+  client: PagerDutyClient = pagerduty,
+  readConfig: ConfigProvider = getPagerDutyConfig
+) {
+  const state = previousState ?? initialServiceSyncState(readConfig())
+  const page = await client.fetchServicesPage(state.scope, state.offset)
+  const nextState = nextServiceSyncState(state, page)
+  const escalationPolicyIds = [
+    ...new Set(
+      page.resources.flatMap((service) => {
+        const id = service.escalation_policy?.id.trim()
+        return id ? [id] : []
+      })
+    ),
+  ]
+  const currentOnCalls = await client.fetchCurrentOnCalls(
+    state.scope,
+    escalationPolicyIds,
+    state.observedAt
+  )
+  const operationalContext = buildServiceOperationalContext(
+    escalationPolicyIds,
+    currentOnCalls
+  )
+  const changes = page.resources.map((service) =>
+    serviceToChange(service, state.observedAt, operationalContext)
+  )
+
+  return nextState
+    ? { changes, hasMore: true as const, nextState }
+    : { changes, hasMore: false as const }
+}
+
+// ---------------------------------------------------------------------------
+// Incidents — active plus recent workflow, linked to managed service rows
+// ---------------------------------------------------------------------------
+
+const incidents = worker.database("incidents", {
+  type: "managed",
+  initialTitle: INCIDENTS_TITLE,
+  primaryKeyProperty: INCIDENTS_PK,
+  schema: incidentSchema,
+})
+
+worker.sync("incidentsSync", {
+  database: incidents,
+  mode: "replace",
+  schedule: "5m",
+  execute: (previousState: IncidentSyncState | undefined) =>
+    executeIncidents(previousState),
+})
+
+// ---------------------------------------------------------------------------
+// Services — readiness, current coverage, ownership, and routing context
+// ---------------------------------------------------------------------------
+
+const services = worker.database("services", {
+  type: "managed",
+  initialTitle: SERVICES_TITLE,
+  primaryKeyProperty: SERVICES_PK,
+  schema: serviceSchema,
+})
+
+worker.sync("servicesSync", {
+  database: services,
+  mode: "replace",
+  schedule: "5m",
+  execute: (previousState: ServiceSyncState | undefined) =>
+    executeServices(previousState),
+})
+
+export default worker

--- a/workers/pagerduty-sync/src/index.ts
+++ b/workers/pagerduty-sync/src/index.ts
@@ -84,6 +84,19 @@ export async function executeServices(
   const state = previousState ?? initialServiceSyncState(readConfig())
   const page = await client.fetchServicesPage(state.scope, state.offset)
   const nextState = nextServiceSyncState(state, page)
+
+  // The unscoped collection is live offset pagination ordered by mutable
+  // name. Discover the complete identity set before emitting replacement rows,
+  // then require the publish pass to reproduce that set exactly.
+  if (state.phase === "discover") {
+    if (!nextState) {
+      throw new Error(
+        "PagerDuty service discovery completed without a publish state."
+      )
+    }
+    return { changes: [], hasMore: true as const, nextState }
+  }
+
   const escalationPolicyIds = [
     ...new Set(
       page.resources.flatMap((service) => {

--- a/workers/pagerduty-sync/src/pagerduty.ts
+++ b/workers/pagerduty-sync/src/pagerduty.ts
@@ -1,0 +1,1160 @@
+// PagerDuty REST API v2 client. Authentication, regional routing, response
+// validation, pagination, and rate-limit behavior live here so resource
+// transforms remain small and easy to extend.
+
+import { RateLimitError } from "@notionhq/workers"
+
+const API_BASE_URLS = {
+  us: "https://api.pagerduty.com",
+  eu: "https://api.eu.pagerduty.com",
+} as const
+
+const PAGE_SIZE = 100
+export const MAX_PAGERDUTY_OFFSET_RECORDS = 10_000
+const DEFAULT_LOOKBACK_DAYS = 90
+const MAX_LOOKBACK_DAYS = 180
+const DEFAULT_RATE_LIMIT_DELAY_SECONDS = 60
+
+export type PagerDutyRegion = keyof typeof API_BASE_URLS
+export type IncidentSyncPhase = "open" | "openConfirm" | "recent"
+
+export type PagerDutyReference = {
+  id: string
+  type?: string | null
+  summary?: string | null
+  name?: string | null
+  self?: string | null
+  html_url?: string | null
+}
+
+export type PagerDutyAssignment = {
+  at: string
+  assignee: PagerDutyReference
+}
+
+export type PagerDutyAcknowledgement = {
+  at: string
+  acknowledger: PagerDutyReference
+}
+
+export type PagerDutyIncidentContext = {
+  type: string
+  href?: string | null
+  src?: string | null
+  text?: string | null
+}
+
+export type PagerDutyTriggerLogEntry = {
+  event_details?: { description?: string | null } | null
+  channel?: {
+    type?: string | null
+    description?: string | null
+    body?: string | null
+    body_content_type?: string | null
+    details?: unknown
+  } | null
+  contexts?: PagerDutyIncidentContext[] | null
+}
+
+export type PagerDutyIncidentType = {
+  name: string
+}
+
+export type PagerDutyIncidentAction = {
+  type: string
+  at: string
+  to?: string | null
+}
+
+export type PagerDutyConferenceBridge = {
+  conference_url?: string | null
+  conference_number?: string | null
+}
+
+export type PagerDutyIncident = {
+  id: string
+  incident_number: number
+  title: string
+  html_url?: string | null
+  status: string
+  urgency?: string | null
+  priority?: PagerDutyReference | null
+  service?: PagerDutyReference | null
+  assignments?: PagerDutyAssignment[] | null
+  assigned_via?: string | null
+  last_status_change_at?: string | null
+  last_status_change_by?: PagerDutyReference | null
+  resolved_at?: string | null
+  incident_type?: PagerDutyIncidentType | null
+  pending_actions?: PagerDutyIncidentAction[] | null
+  conference_bridge?: PagerDutyConferenceBridge | null
+  first_trigger_log_entry?: PagerDutyTriggerLogEntry | null
+  alert_counts?: {
+    all?: number | null
+    triggered?: number | null
+    resolved?: number | null
+  } | null
+  escalation_policy?: PagerDutyReference | null
+  teams?: PagerDutyReference[] | null
+  acknowledgements?: PagerDutyAcknowledgement[] | null
+  created_at: string
+  updated_at: string
+}
+
+export type PagerDutyUrgencyRule = {
+  type: string
+  urgency?: string | null
+  during_support_hours?: { urgency?: string | null } | null
+  outside_support_hours?: { urgency?: string | null } | null
+}
+
+export type PagerDutySupportHours = {
+  type: string
+  time_zone: string
+  days_of_week: number[]
+  start_time: string
+  end_time: string
+}
+
+export type PagerDutyService = {
+  id: string
+  name: string
+  description?: string | null
+  html_url?: string | null
+  status: string
+  created_at: string
+  last_incident_timestamp?: string | null
+  escalation_policy?: PagerDutyReference | null
+  teams?: PagerDutyReference[] | null
+  integrations?: PagerDutyReference[] | null
+  auto_resolve_timeout?: number | null
+  acknowledgement_timeout?: number | null
+  incident_urgency_rule?: PagerDutyUrgencyRule | null
+  support_hours?: PagerDutySupportHours | null
+}
+
+export type PagerDutyOnCall = {
+  escalation_policy: PagerDutyReference
+  user: PagerDutyReference
+  schedule?: PagerDutyReference | null
+  escalation_level: number
+  start: string | null
+  end: string | null
+}
+
+type PagerDutyOnCallTraversal = {
+  onCalls: PagerDutyOnCall[]
+  identities: string[]
+  total: number
+  pageCount: number
+}
+
+export type PagerDutyScope = {
+  region: PagerDutyRegion
+  serviceIds: string[]
+  teamIds: string[]
+  /** Pinned only for incident traversals; service scopes leave this unset. */
+  incidentPhase?: IncidentSyncPhase
+}
+
+export type PagerDutyConfig = PagerDutyScope & {
+  incidentLookbackDays: number
+}
+
+export type PagerDutyOffsetPage<T> = {
+  resources: T[]
+  offset: number
+  limit: number
+  total: number
+  more: boolean
+  nextOffset: number | undefined
+  /** The state machine must narrow the time window before emitting resources. */
+  requiresWindowSplit?: true
+}
+
+export type IncidentPageQuery = {
+  since: string
+  until: string
+  offset?: number
+}
+
+export type BeforeRequest = () => Promise<void>
+
+type FetchFunction = (
+  input: string | URL,
+  init?: RequestInit
+) => Promise<Response>
+
+export type PagerDutyClientOptions = {
+  beforeRequest: BeforeRequest
+  fetch?: FetchFunction
+  getApiToken?: () => string
+}
+
+export type PagerDutyClient = {
+  fetchIncidentsPage(
+    scope: PagerDutyScope,
+    query: IncidentPageQuery
+  ): Promise<PagerDutyOffsetPage<PagerDutyIncident>>
+  fetchServicesPage(
+    scope: PagerDutyScope,
+    offset?: number
+  ): Promise<PagerDutyOffsetPage<PagerDutyService>>
+  fetchCurrentOnCalls(
+    scope: PagerDutyScope,
+    escalationPolicyIds: string[],
+    observedAt: string
+  ): Promise<PagerDutyOnCall[]>
+}
+
+type Environment = Record<string, string | undefined>
+
+function parseIdList(name: string, raw: string | undefined): string[] {
+  if (!raw?.trim()) return []
+
+  const ids: string[] = []
+  const seen = new Set<string>()
+  for (const part of raw.split(",")) {
+    const id = part.trim()
+    if (!id) continue
+    if (!/^P[A-Z0-9]{6}$/.test(id)) {
+      throw new Error(`${name} contains an invalid PagerDuty ID: "${id}"`)
+    }
+    if (!seen.has(id)) {
+      ids.push(id)
+      seen.add(id)
+    }
+  }
+
+  if (ids.length === 0) {
+    throw new Error(`${name} must contain at least one PagerDuty ID when set.`)
+  }
+  return ids
+}
+
+function parseLookbackDays(raw: string | undefined): number {
+  if (!raw?.trim()) return DEFAULT_LOOKBACK_DAYS
+
+  const days = Number(raw)
+  if (!Number.isSafeInteger(days) || days < 1 || days > MAX_LOOKBACK_DAYS) {
+    throw new Error(
+      `PAGERDUTY_INCIDENT_LOOKBACK_DAYS must be an integer from 1 to ${MAX_LOOKBACK_DAYS}.`
+    )
+  }
+  return days
+}
+
+/** Parse non-secret configuration. The API token is read only at request time. */
+export function getPagerDutyConfig(
+  env: Environment = process.env
+): PagerDutyConfig {
+  const regionValue = env.PAGERDUTY_REGION?.trim().toLowerCase() || "us"
+  if (regionValue !== "us" && regionValue !== "eu") {
+    throw new Error('PAGERDUTY_REGION must be either "us" or "eu".')
+  }
+
+  return {
+    region: regionValue,
+    incidentLookbackDays: parseLookbackDays(
+      env.PAGERDUTY_INCIDENT_LOOKBACK_DAYS
+    ),
+    serviceIds: parseIdList("PAGERDUTY_SERVICE_IDS", env.PAGERDUTY_SERVICE_IDS),
+    teamIds: parseIdList("PAGERDUTY_TEAM_IDS", env.PAGERDUTY_TEAM_IDS),
+  }
+}
+
+function requireApiToken(env: Environment = process.env): string {
+  const token = env.PAGERDUTY_API_TOKEN?.trim()
+  if (!token) throw new Error("PAGERDUTY_API_TOKEN is not set.")
+  return token
+}
+
+export function parseRetryAfterSeconds(
+  value: string | null,
+  now = Date.now()
+): number | undefined {
+  if (!value?.trim()) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds)
+  }
+
+  const retryAt = Date.parse(value)
+  if (!Number.isFinite(retryAt)) return undefined
+  return Math.max(0, Math.ceil((retryAt - now) / 1_000))
+}
+
+/**
+ * PagerDuty documents `ratelimit-reset` as a delay in seconds. Accept epoch
+ * seconds/milliseconds too, since proxies and older clients have exposed both.
+ */
+function parseRateLimitResetSeconds(
+  value: string | null,
+  now: number
+): number | undefined {
+  if (!value?.trim()) return undefined
+  const reset = Number(value)
+  if (!Number.isFinite(reset) || reset < 0) return undefined
+
+  if (reset >= 1_000_000_000_000) {
+    return Math.max(0, Math.ceil((reset - now) / 1_000))
+  }
+  if (reset >= 1_000_000_000) {
+    return Math.max(0, Math.ceil(reset - now / 1_000))
+  }
+  return Math.ceil(reset)
+}
+
+export function rateLimitRetryAfterSeconds(
+  headers: Headers,
+  now = Date.now()
+): number | undefined {
+  const delays = [
+    parseRetryAfterSeconds(headers.get("retry-after"), now),
+    parseRateLimitResetSeconds(headers.get("ratelimit-reset"), now),
+  ].filter((delay): delay is number => delay !== undefined)
+
+  return delays.length > 0 ? Math.max(...delays) : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function requireString(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): string {
+  const value = record[key]
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`PagerDuty ${resource} is missing ${key}.`)
+  }
+  return value
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): void {
+  const value = record[key]
+  if (value !== undefined && value !== null && typeof value !== "string") {
+    throw new Error(`PagerDuty ${resource} has an invalid ${key}.`)
+  }
+}
+
+function requireTimestamp(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): string {
+  const value = requireString(record, key, resource)
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new Error(`PagerDuty ${resource} has an invalid ${key}.`)
+  }
+  return value
+}
+
+function optionalTimestamp(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): void {
+  optionalString(record, key, resource)
+  const value = record[key]
+  if (
+    typeof value === "string" &&
+    value.trim() &&
+    !Number.isFinite(Date.parse(value))
+  ) {
+    throw new Error(`PagerDuty ${resource} has an invalid ${key}.`)
+  }
+}
+
+function optionalFiniteNumber(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): void {
+  const value = record[key]
+  if (
+    value !== undefined &&
+    value !== null &&
+    (typeof value !== "number" || !Number.isFinite(value))
+  ) {
+    throw new Error(`PagerDuty ${resource} has an invalid ${key}.`)
+  }
+}
+
+function optionalRecord(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): Record<string, unknown> | undefined {
+  const value = record[key]
+  if (value === undefined || value === null) return undefined
+  if (!isRecord(value)) {
+    throw new Error(`PagerDuty ${resource} has an invalid ${key}.`)
+  }
+  return value
+}
+
+function validateReference(
+  value: unknown,
+  resource: string
+): PagerDutyReference {
+  if (!isRecord(value)) {
+    throw new Error(`PagerDuty ${resource} is not a reference object.`)
+  }
+  requireString(value, "id", resource)
+  optionalString(value, "type", resource)
+  optionalString(value, "summary", resource)
+  optionalString(value, "name", resource)
+  optionalString(value, "self", resource)
+  optionalString(value, "html_url", resource)
+  return value as PagerDutyReference
+}
+
+function validateOptionalReference(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): void {
+  const value = record[key]
+  if (value !== undefined && value !== null) {
+    validateReference(value, `${resource}.${key}`)
+  }
+}
+
+function validateReferenceArray(
+  record: Record<string, unknown>,
+  key: string,
+  resource: string
+): void {
+  const value = record[key]
+  if (value === undefined || value === null) return
+  if (!Array.isArray(value)) {
+    throw new Error(`PagerDuty ${resource} has an invalid ${key}.`)
+  }
+  value.forEach((item, index) =>
+    validateReference(item, `${resource}.${key}[${index}]`)
+  )
+}
+
+function validateAssignments(
+  record: Record<string, unknown>,
+  resource: string
+): void {
+  const value = record.assignments
+  if (value === undefined || value === null) return
+  if (!Array.isArray(value)) {
+    throw new Error(`PagerDuty ${resource} has invalid assignments.`)
+  }
+  value.forEach((item, index) => {
+    if (!isRecord(item)) {
+      throw new Error(
+        `PagerDuty ${resource}.assignments[${index}] is not an object.`
+      )
+    }
+    requireTimestamp(item, "at", `${resource}.assignments[${index}]`)
+    validateReference(
+      item.assignee,
+      `${resource}.assignments[${index}].assignee`
+    )
+  })
+}
+
+function validateAcknowledgements(
+  record: Record<string, unknown>,
+  resource: string
+): void {
+  const value = record.acknowledgements
+  if (value === undefined || value === null) return
+  if (!Array.isArray(value)) {
+    throw new Error(`PagerDuty ${resource} has invalid acknowledgements.`)
+  }
+  value.forEach((item, index) => {
+    if (!isRecord(item)) {
+      throw new Error(
+        `PagerDuty ${resource}.acknowledgements[${index}] is not an object.`
+      )
+    }
+    requireTimestamp(item, "at", `${resource}.acknowledgements[${index}]`)
+    validateReference(
+      item.acknowledger,
+      `${resource}.acknowledgements[${index}].acknowledger`
+    )
+  })
+}
+
+function validateIncidentDetails(
+  record: Record<string, unknown>,
+  resource: string
+): void {
+  const incidentType = optionalRecord(record, "incident_type", resource)
+  if (incidentType) {
+    requireString(incidentType, "name", `${resource}.incident_type`)
+  }
+
+  const pendingActions = record.pending_actions
+  if (pendingActions !== undefined && pendingActions !== null) {
+    if (!Array.isArray(pendingActions)) {
+      throw new Error(`PagerDuty ${resource} has invalid pending_actions.`)
+    }
+    pendingActions.forEach((action, index) => {
+      const actionResource = `${resource}.pending_actions[${index}]`
+      if (!isRecord(action)) {
+        throw new Error(`PagerDuty ${actionResource} is not an object.`)
+      }
+      requireString(action, "type", actionResource)
+      requireTimestamp(action, "at", actionResource)
+      optionalString(action, "to", actionResource)
+    })
+  }
+
+  const conferenceBridge = optionalRecord(record, "conference_bridge", resource)
+  if (conferenceBridge) {
+    optionalString(
+      conferenceBridge,
+      "conference_url",
+      `${resource}.conference_bridge`
+    )
+    optionalString(
+      conferenceBridge,
+      "conference_number",
+      `${resource}.conference_bridge`
+    )
+  }
+}
+
+function validateTriggerLogEntry(
+  record: Record<string, unknown>,
+  resource: string
+): void {
+  const trigger = optionalRecord(record, "first_trigger_log_entry", resource)
+  if (!trigger) return
+
+  const eventDetails = optionalRecord(
+    trigger,
+    "event_details",
+    `${resource}.first_trigger_log_entry`
+  )
+  if (eventDetails) {
+    optionalString(
+      eventDetails,
+      "description",
+      `${resource}.first_trigger_log_entry.event_details`
+    )
+  }
+
+  const channel = optionalRecord(
+    trigger,
+    "channel",
+    `${resource}.first_trigger_log_entry`
+  )
+  if (channel) {
+    for (const key of ["type", "description", "body", "body_content_type"]) {
+      optionalString(
+        channel,
+        key,
+        `${resource}.first_trigger_log_entry.channel`
+      )
+    }
+  }
+
+  const contexts = trigger.contexts
+  if (contexts === undefined || contexts === null) return
+  if (!Array.isArray(contexts)) {
+    throw new Error(
+      `PagerDuty ${resource}.first_trigger_log_entry has invalid contexts.`
+    )
+  }
+  contexts.forEach((context, index) => {
+    const contextResource = `${resource}.first_trigger_log_entry.contexts[${index}]`
+    if (!isRecord(context)) {
+      throw new Error(`PagerDuty ${contextResource} is not an object.`)
+    }
+    requireString(context, "type", contextResource)
+    optionalString(context, "href", contextResource)
+    optionalString(context, "src", contextResource)
+    optionalString(context, "text", contextResource)
+  })
+}
+
+function validateIncident(value: unknown, index: number): PagerDutyIncident {
+  if (!isRecord(value)) {
+    throw new Error(`PagerDuty incidents[${index}] is not an object.`)
+  }
+  requireString(value, "id", `incidents[${index}]`)
+  requireString(value, "title", `incidents[${index}]`)
+  requireString(value, "status", `incidents[${index}]`)
+  const resource = `incidents[${index}]`
+  requireTimestamp(value, "created_at", resource)
+  requireTimestamp(value, "updated_at", resource)
+  optionalString(value, "html_url", resource)
+  optionalString(value, "urgency", resource)
+  optionalString(value, "assigned_via", resource)
+  optionalTimestamp(value, "last_status_change_at", resource)
+  optionalTimestamp(value, "resolved_at", resource)
+  validateOptionalReference(value, "priority", resource)
+  validateOptionalReference(value, "service", resource)
+  validateOptionalReference(value, "escalation_policy", resource)
+  validateOptionalReference(value, "last_status_change_by", resource)
+  validateReferenceArray(value, "teams", resource)
+  validateAssignments(value, resource)
+  validateAcknowledgements(value, resource)
+  validateIncidentDetails(value, resource)
+  validateTriggerLogEntry(value, resource)
+
+  const alertCounts = optionalRecord(value, "alert_counts", resource)
+  if (alertCounts) {
+    optionalFiniteNumber(alertCounts, "all", `${resource}.alert_counts`)
+    optionalFiniteNumber(alertCounts, "triggered", `${resource}.alert_counts`)
+    optionalFiniteNumber(alertCounts, "resolved", `${resource}.alert_counts`)
+  }
+
+  if (
+    !Number.isSafeInteger(value.incident_number) ||
+    (value.incident_number as number) < 0
+  ) {
+    throw new Error(
+      `PagerDuty incidents[${index}] has an invalid incident_number.`
+    )
+  }
+  return value as PagerDutyIncident
+}
+
+function validateService(value: unknown, index: number): PagerDutyService {
+  if (!isRecord(value)) {
+    throw new Error(`PagerDuty services[${index}] is not an object.`)
+  }
+  requireString(value, "id", `services[${index}]`)
+  requireString(value, "name", `services[${index}]`)
+  requireString(value, "status", `services[${index}]`)
+  const resource = `services[${index}]`
+  requireTimestamp(value, "created_at", resource)
+  optionalString(value, "html_url", resource)
+  optionalString(value, "description", resource)
+  optionalTimestamp(value, "last_incident_timestamp", resource)
+  validateOptionalReference(value, "escalation_policy", resource)
+  validateReferenceArray(value, "teams", resource)
+  validateReferenceArray(value, "integrations", resource)
+  optionalFiniteNumber(value, "auto_resolve_timeout", resource)
+  optionalFiniteNumber(value, "acknowledgement_timeout", resource)
+  const urgencyRule = optionalRecord(value, "incident_urgency_rule", resource)
+  if (urgencyRule) {
+    requireString(urgencyRule, "type", `${resource}.incident_urgency_rule`)
+    optionalString(urgencyRule, "urgency", `${resource}.incident_urgency_rule`)
+    for (const key of ["during_support_hours", "outside_support_hours"]) {
+      const rulePart = optionalRecord(
+        urgencyRule,
+        key,
+        `${resource}.incident_urgency_rule`
+      )
+      if (rulePart) {
+        optionalString(
+          rulePart,
+          "urgency",
+          `${resource}.incident_urgency_rule.${key}`
+        )
+      }
+    }
+  }
+
+  const supportHours = optionalRecord(value, "support_hours", resource)
+  if (supportHours) {
+    const supportHoursResource = `${resource}.support_hours`
+    requireString(supportHours, "type", supportHoursResource)
+    requireString(supportHours, "time_zone", supportHoursResource)
+    requireString(supportHours, "start_time", supportHoursResource)
+    requireString(supportHours, "end_time", supportHoursResource)
+
+    const daysOfWeek = supportHours.days_of_week
+    if (!Array.isArray(daysOfWeek)) {
+      throw new Error(
+        `PagerDuty ${supportHoursResource} has invalid days_of_week.`
+      )
+    }
+    daysOfWeek.forEach((day, index) => {
+      if (!Number.isSafeInteger(day) || (day as number) < 1 || day > 7) {
+        throw new Error(
+          `PagerDuty ${supportHoursResource}.days_of_week[${index}] is invalid.`
+        )
+      }
+    })
+  }
+  return value as PagerDutyService
+}
+
+function validateOnCall(value: unknown, index: number): PagerDutyOnCall {
+  const resource = `oncalls[${index}]`
+  if (!isRecord(value)) {
+    throw new Error(`PagerDuty ${resource} is not an object.`)
+  }
+
+  validateReference(value.escalation_policy, `${resource}.escalation_policy`)
+  validateReference(value.user, `${resource}.user`)
+  validateOptionalReference(value, "schedule", resource)
+
+  if (
+    !Number.isSafeInteger(value.escalation_level) ||
+    (value.escalation_level as number) < 1
+  ) {
+    throw new Error(`PagerDuty ${resource} has an invalid escalation_level.`)
+  }
+
+  for (const key of ["start", "end"] as const) {
+    if (value[key] !== null) requireTimestamp(value, key, resource)
+  }
+
+  return value as unknown as PagerDutyOnCall
+}
+
+function onCallIdentity(onCall: PagerDutyOnCall): string {
+  return JSON.stringify([
+    onCall.escalation_policy.id,
+    onCall.escalation_level,
+    onCall.user.id,
+    onCall.schedule?.id ?? null,
+    onCall.start,
+    onCall.end,
+  ])
+}
+
+function deduplicateOnCalls(onCalls: PagerDutyOnCall[]): PagerDutyOnCall[] {
+  const unique: PagerDutyOnCall[] = []
+  const seen = new Set<string>()
+  for (const onCall of onCalls) {
+    const identity = onCallIdentity(onCall)
+    if (seen.has(identity)) continue
+    seen.add(identity)
+    unique.push(onCall)
+  }
+  return unique
+}
+
+function requirePageInteger(
+  body: Record<string, unknown>,
+  key: string,
+  minimum: number
+): number {
+  const value = body[key]
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    throw new Error(`PagerDuty pagination response has an invalid ${key}.`)
+  }
+  return value as number
+}
+
+function parseOffsetPage<T>(
+  value: unknown,
+  collection: string,
+  requestedOffset: number,
+  validate: (item: unknown, index: number) => T
+): PagerDutyOffsetPage<T> {
+  if (!isRecord(value)) {
+    throw new Error("PagerDuty API response is not an object.")
+  }
+
+  const rawResources = value[collection]
+  if (!Array.isArray(rawResources)) {
+    throw new Error(`PagerDuty response is missing ${collection}.`)
+  }
+
+  const offset = requirePageInteger(value, "offset", 0)
+  const limit = requirePageInteger(value, "limit", 1)
+  const total = requirePageInteger(value, "total", 0)
+  if (offset !== requestedOffset) {
+    throw new Error(
+      `PagerDuty pagination returned offset ${offset}; expected ${requestedOffset}.`
+    )
+  }
+  if (typeof value.more !== "boolean") {
+    throw new Error("PagerDuty pagination response is missing more.")
+  }
+
+  const resources = rawResources.map(validate)
+  if (resources.length > limit) {
+    throw new Error(
+      "PagerDuty pagination returned more records than its limit."
+    )
+  }
+
+  const more = value.more
+  const nextOffset = more ? offset + limit : undefined
+  if (more && resources.length === 0) {
+    throw new Error("PagerDuty pagination reported more after an empty page.")
+  }
+  if (more && resources.length !== limit) {
+    throw new Error(
+      "PagerDuty pagination returned a partial page while more records remained."
+    )
+  }
+  if (more && (nextOffset ?? offset) <= offset) {
+    throw new Error("PagerDuty pagination did not advance its offset.")
+  }
+  if (more && offset + resources.length >= total) {
+    throw new Error("PagerDuty pagination total conflicts with more=true.")
+  }
+  if (!more && offset + resources.length < total) {
+    throw new Error("PagerDuty pagination ended before reaching its total.")
+  }
+
+  return { resources, offset, limit, total, more, nextOffset }
+}
+
+function addRepeatedParams(url: URL, name: string, values: string[]): void {
+  for (const value of values) url.searchParams.append(name, value)
+}
+
+function assertDateRange(since: string, until: string): void {
+  const sinceMs = Date.parse(since)
+  const untilMs = Date.parse(until)
+  if (!Number.isFinite(sinceMs) || !Number.isFinite(untilMs)) {
+    throw new Error("PagerDuty incident range must use ISO 8601 timestamps.")
+  }
+  if (sinceMs > untilMs) {
+    throw new Error("PagerDuty incident range starts after it ends.")
+  }
+}
+
+function apiErrorDetail(text: string, token: string): string {
+  try {
+    const body = JSON.parse(text) as unknown
+    if (!isRecord(body) || !isRecord(body.error))
+      return "Unexpected error response"
+
+    const message = body.error.message
+    const code = body.error.code
+    const safeMessage =
+      typeof message === "string"
+        ? message.split(token).join("[REDACTED]").slice(0, 300)
+        : null
+    const safeCode = Number.isSafeInteger(code) ? `code ${code}` : null
+    return (
+      [safeCode, safeMessage].filter(Boolean).join(": ") || "Request failed"
+    )
+  } catch {
+    return "Unexpected non-JSON error response"
+  }
+}
+
+export function createPagerDutyClient(
+  options: PagerDutyClientOptions
+): PagerDutyClient {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const getApiToken = options.getApiToken ?? (() => requireApiToken())
+
+  async function fetchJson(url: URL): Promise<unknown> {
+    const token = getApiToken().trim()
+    if (!token) throw new Error("PAGERDUTY_API_TOKEN is not set.")
+
+    await options.beforeRequest()
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Token token=${token}`,
+        Accept: "application/vnd.pagerduty+json;version=2",
+        "Content-Type": "application/json",
+        "User-Agent": "notion-cookbook-pagerduty-sync",
+      },
+      redirect: "error",
+    })
+
+    const text = await response.text()
+    if (response.status === 429) {
+      throw new RateLimitError({
+        retryAfter:
+          rateLimitRetryAfterSeconds(response.headers) ??
+          DEFAULT_RATE_LIMIT_DELAY_SECONDS,
+      })
+    }
+    if (!response.ok) {
+      throw new Error(
+        `PagerDuty API error (${response.status}): ${apiErrorDetail(text, token)}`
+      )
+    }
+    if (!text) throw new Error("PagerDuty API returned an empty response.")
+
+    try {
+      return JSON.parse(text) as unknown
+    } catch {
+      throw new Error(
+        `PagerDuty API returned invalid JSON (${response.status}).`
+      )
+    }
+  }
+
+  async function fetchOnCallTraversal(
+    scope: PagerDutyScope,
+    policyIds: string[],
+    requestedPolicyIds: ReadonlySet<string>,
+    observedAt: string
+  ): Promise<PagerDutyOnCallTraversal> {
+    const onCalls: PagerDutyOnCall[] = []
+    const identities: string[] = []
+    let offset = 0
+    let processed = 0
+    let pageCount = 0
+    let expectedTotal: number | undefined
+
+    while (true) {
+      const url = new URL("/oncalls", API_BASE_URLS[scope.region])
+      url.searchParams.set("limit", String(PAGE_SIZE))
+      url.searchParams.set("offset", String(offset))
+      url.searchParams.set("total", "true")
+      url.searchParams.set("since", observedAt)
+      url.searchParams.set("until", observedAt)
+      addRepeatedParams(url, "escalation_policy_ids[]", policyIds)
+
+      const page = parseOffsetPage(
+        await fetchJson(url),
+        "oncalls",
+        offset,
+        validateOnCall
+      )
+      pageCount++
+      if (page.total > MAX_PAGERDUTY_OFFSET_RECORDS) {
+        throw new Error(
+          `PagerDuty returned more than ${MAX_PAGERDUTY_OFFSET_RECORDS.toLocaleString()} current on-call entries. ` +
+            "Narrow the configured service scope before retrying."
+        )
+      }
+      if (expectedTotal === undefined) {
+        expectedTotal = page.total
+      } else if (page.total !== expectedTotal) {
+        throw new Error(
+          `PagerDuty current on-call total changed during pagination (${expectedTotal} to ${page.total}).`
+        )
+      }
+
+      processed += page.resources.length
+      for (const onCall of page.resources) {
+        if (!requestedPolicyIds.has(onCall.escalation_policy.id)) {
+          throw new Error(
+            `PagerDuty returned an on-call entry for unrequested escalation policy ${onCall.escalation_policy.id}.`
+          )
+        }
+        onCalls.push(onCall)
+        identities.push(onCallIdentity(onCall))
+      }
+
+      if (!page.more) break
+      if (page.nextOffset === undefined) {
+        throw new Error("PagerDuty on-call pagination did not advance.")
+      }
+      offset = page.nextOffset
+    }
+
+    const total = expectedTotal ?? 0
+    if (processed !== total) {
+      throw new Error(
+        `PagerDuty current on-call pagination processed ${processed} of ${total} entries.`
+      )
+    }
+    identities.sort()
+    return { onCalls, identities, total, pageCount }
+  }
+
+  return {
+    async fetchIncidentsPage(
+      scope: PagerDutyScope,
+      query: IncidentPageQuery
+    ): Promise<PagerDutyOffsetPage<PagerDutyIncident>> {
+      const offset = query.offset ?? 0
+      if (!Number.isSafeInteger(offset) || offset < 0) {
+        throw new Error(
+          "PagerDuty incident offset must be a non-negative integer."
+        )
+      }
+      const phase = scope.incidentPhase ?? "recent"
+      assertDateRange(query.since, query.until)
+
+      const url = new URL("/incidents", API_BASE_URLS[scope.region])
+      url.searchParams.set("limit", String(PAGE_SIZE))
+      url.searchParams.set("offset", String(offset))
+      url.searchParams.set("total", "true")
+      if (phase !== "recent") {
+        // Open incidents remain operationally relevant regardless of age.
+        // PagerDuty ignores date bounds when date_range=all.
+        url.searchParams.set("date_range", "all")
+        addRepeatedParams(url, "statuses[]", ["triggered", "acknowledged"])
+      } else {
+        url.searchParams.set("since", query.since)
+        url.searchParams.set("until", query.until)
+      }
+      url.searchParams.set("sort_by", "incident_number:asc")
+      addRepeatedParams(url, "service_ids[]", scope.serviceIds)
+      addRepeatedParams(url, "team_ids[]", scope.teamIds)
+      addRepeatedParams(url, "include[]", [
+        "assignees",
+        "acknowledgers",
+        "priorities",
+        "teams",
+        "escalation_policies",
+        "first_trigger_log_entries",
+        "conference_bridge",
+      ])
+
+      const page = parseOffsetPage(
+        await fetchJson(url),
+        "incidents",
+        offset,
+        validateIncident
+      )
+
+      if (page.total > MAX_PAGERDUTY_OFFSET_RECORDS) {
+        if (phase !== "recent") {
+          throw new Error(
+            `PagerDuty returned more than ${MAX_PAGERDUTY_OFFSET_RECORDS.toLocaleString()} open incidents. ` +
+              "Narrow PAGERDUTY_SERVICE_IDS or PAGERDUTY_TEAM_IDS before retrying."
+          )
+        }
+
+        // Do not let an incomplete range contribute replacement rows. The
+        // next state transition bisects the pinned window and retries at zero.
+        return { ...page, resources: [], requiresWindowSplit: true }
+      }
+
+      return page
+    },
+
+    async fetchServicesPage(
+      scope: PagerDutyScope,
+      offset = 0
+    ): Promise<PagerDutyOffsetPage<PagerDutyService>> {
+      if (!Number.isSafeInteger(offset) || offset < 0) {
+        throw new Error(
+          "PagerDuty service offset must be a non-negative integer."
+        )
+      }
+
+      if (scope.serviceIds.length > 0) {
+        const id = scope.serviceIds[offset]
+        if (!id) {
+          throw new Error(
+            "PagerDuty configured service pagination offset is out of range."
+          )
+        }
+
+        // The collection endpoint has no service_ids filter. Resolve one
+        // explicitly configured service per Worker invocation so the shared
+        // pacer cannot turn one callback into a long sequential request burst.
+        const url = new URL(
+          `/services/${encodeURIComponent(id)}`,
+          API_BASE_URLS[scope.region]
+        )
+        addRepeatedParams(url, "include[]", ["teams", "escalation_policies"])
+        const body = await fetchJson(url)
+        if (!isRecord(body) || !("service" in body)) {
+          throw new Error(`PagerDuty response is missing service ${id}.`)
+        }
+        const service = validateService(body.service, offset)
+        if (service.id !== id) {
+          throw new Error(
+            `PagerDuty returned service ${service.id}; expected ${id}.`
+          )
+        }
+
+        const total = scope.serviceIds.length
+        const more = offset + 1 < total
+        return {
+          resources: [service],
+          offset,
+          limit: 1,
+          total,
+          more,
+          nextOffset: more ? offset + 1 : undefined,
+        }
+      }
+
+      const url = new URL("/services", API_BASE_URLS[scope.region])
+      url.searchParams.set("limit", String(PAGE_SIZE))
+      url.searchParams.set("offset", String(offset))
+      url.searchParams.set("total", "true")
+      url.searchParams.set("sort_by", "name:asc")
+      addRepeatedParams(url, "include[]", ["teams", "escalation_policies"])
+
+      const page = parseOffsetPage(
+        await fetchJson(url),
+        "services",
+        offset,
+        validateService
+      )
+      if (page.total > MAX_PAGERDUTY_OFFSET_RECORDS) {
+        throw new Error(
+          `PagerDuty returned more than ${MAX_PAGERDUTY_OFFSET_RECORDS.toLocaleString()} services. ` +
+            "Set PAGERDUTY_SERVICE_IDS to the services this Worker should sync."
+        )
+      }
+      return page
+    },
+
+    async fetchCurrentOnCalls(
+      scope: PagerDutyScope,
+      escalationPolicyIds: string[],
+      observedAt: string
+    ): Promise<PagerDutyOnCall[]> {
+      if (
+        typeof observedAt !== "string" ||
+        !observedAt.trim() ||
+        !Number.isFinite(Date.parse(observedAt))
+      ) {
+        throw new Error(
+          "PagerDuty on-call observation time must be a valid ISO 8601 timestamp."
+        )
+      }
+
+      const policyIds: string[] = []
+      const requestedPolicyIds = new Set<string>()
+      for (const value of escalationPolicyIds) {
+        if (typeof value !== "string" || !value.trim()) {
+          throw new Error(
+            "PagerDuty on-call escalation policy IDs must be non-empty strings."
+          )
+        }
+        const id = value.trim()
+        if (!requestedPolicyIds.has(id)) {
+          requestedPolicyIds.add(id)
+          policyIds.push(id)
+        }
+      }
+      if (policyIds.length === 0) return []
+
+      const initial = await fetchOnCallTraversal(
+        scope,
+        policyIds,
+        requestedPolicyIds,
+        observedAt
+      )
+      if (initial.pageCount === 1) {
+        return deduplicateOnCalls(initial.onCalls)
+      }
+
+      const confirmation = await fetchOnCallTraversal(
+        scope,
+        policyIds,
+        requestedPolicyIds,
+        observedAt
+      )
+      if (confirmation.total !== initial.total) {
+        throw new Error(
+          `PagerDuty current on-call total changed between confirmation traversals (${initial.total} to ${confirmation.total}).`
+        )
+      }
+      if (
+        confirmation.identities.length !== initial.identities.length ||
+        confirmation.identities.some(
+          (identity, index) => identity !== initial.identities[index]
+        )
+      ) {
+        throw new Error(
+          "PagerDuty current on-call identities changed between confirmation traversals."
+        )
+      }
+
+      return deduplicateOnCalls(confirmation.onCalls)
+    },
+  }
+}

--- a/workers/pagerduty-sync/src/pagerduty.ts
+++ b/workers/pagerduty-sync/src/pagerduty.ts
@@ -14,6 +14,8 @@ export const MAX_PAGERDUTY_OFFSET_RECORDS = 10_000
 const DEFAULT_LOOKBACK_DAYS = 90
 const MAX_LOOKBACK_DAYS = 180
 const DEFAULT_RATE_LIMIT_DELAY_SECONDS = 60
+const MAX_PAGERDUTY_ID_CHARACTERS = 255
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u
 
 export type PagerDutyRegion = keyof typeof API_BASE_URLS
 export type IncidentSyncPhase = "open" | "openConfirm" | "recent"
@@ -209,7 +211,11 @@ export type PagerDutyClient = {
 
 type Environment = Record<string, string | undefined>
 
-function parseIdList(name: string, raw: string | undefined): string[] {
+function parseIdList(
+  name: string,
+  raw: string | undefined,
+  { usedAsPathSegment = false }: { usedAsPathSegment?: boolean } = {}
+): string[] {
   if (!raw?.trim()) return []
 
   const ids: string[] = []
@@ -217,8 +223,20 @@ function parseIdList(name: string, raw: string | undefined): string[] {
   for (const part of raw.split(",")) {
     const id = part.trim()
     if (!id) continue
-    if (!/^P[A-Z0-9]{6}$/.test(id)) {
-      throw new Error(`${name} contains an invalid PagerDuty ID: "${id}"`)
+    if (CONTROL_CHARACTERS.test(id)) {
+      throw new Error(
+        `${name} contains a PagerDuty ID with control characters.`
+      )
+    }
+    if (usedAsPathSegment && (id === "." || id === "..")) {
+      throw new Error(
+        `${name} contains a PagerDuty ID that cannot be used as a URL path segment.`
+      )
+    }
+    if (Array.from(id).length > MAX_PAGERDUTY_ID_CHARACTERS) {
+      throw new Error(
+        `${name} contains a PagerDuty ID longer than ${MAX_PAGERDUTY_ID_CHARACTERS} characters.`
+      )
     }
     if (!seen.has(id)) {
       ids.push(id)
@@ -258,7 +276,11 @@ export function getPagerDutyConfig(
     incidentLookbackDays: parseLookbackDays(
       env.PAGERDUTY_INCIDENT_LOOKBACK_DAYS
     ),
-    serviceIds: parseIdList("PAGERDUTY_SERVICE_IDS", env.PAGERDUTY_SERVICE_IDS),
+    serviceIds: parseIdList(
+      "PAGERDUTY_SERVICE_IDS",
+      env.PAGERDUTY_SERVICE_IDS,
+      { usedAsPathSegment: true }
+    ),
     teamIds: parseIdList("PAGERDUTY_TEAM_IDS", env.PAGERDUTY_TEAM_IDS),
   }
 }

--- a/workers/pagerduty-sync/src/services.ts
+++ b/workers/pagerduty-sync/src/services.ts
@@ -1,0 +1,262 @@
+// PagerDuty services — ownership and incident-routing configuration at a
+// glance. Keep schema and transform property order exactly aligned.
+
+import * as Schema from "@notionhq/workers/schema"
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+
+import type { PagerDutyOnCall, PagerDutyService } from "./pagerduty.js"
+import {
+  boundedText,
+  dateTime,
+  humanizeEnum,
+  MAX_RICH_TEXT_CHARACTERS,
+  plainTextPageContent,
+  positiveMinutes,
+  referenceName,
+  referenceNames,
+  safeWebUrl,
+  supportHoursLabel,
+  urgencyRuleLabel,
+} from "./helpers.js"
+
+export const INITIAL_TITLE = "PagerDuty Services"
+export const PRIMARY_KEY = "PagerDuty Service ID"
+
+export const serviceSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("server", "blue"),
+  properties: {
+    Name: Schema.title(),
+
+    "Response State": Schema.select([
+      { name: "No Open Incidents" },
+      { name: "Response in Progress" },
+      { name: "Awaiting Response" },
+      { name: "Maintenance" },
+      { name: "Disabled" },
+    ]),
+
+    "Primary On Call": Schema.multiSelect([]),
+
+    "Primary Coverage": Schema.select([
+      { name: "Covered" },
+      { name: "No Primary On Call" },
+      { name: "No Escalation Policy" },
+      { name: "Not Applicable" },
+    ]),
+
+    Teams: Schema.multiSelect([]),
+
+    "Service Link": Schema.url(),
+
+    "Coverage Checked": Schema.date(),
+
+    Integrations: Schema.multiSelect([]),
+
+    "Integration Count": Schema.number(),
+
+    "Support Hours": Schema.richText(),
+
+    "Last Incident": Schema.date(),
+
+    "Escalation Policy": Schema.select([]),
+
+    Description: Schema.richText(),
+
+    // Support-hours rules are composed summaries rather than a stable enum.
+    "Urgency Rule": Schema.richText(),
+
+    "Auto Resolve (min)": Schema.number(),
+
+    "Re-trigger After Ack (min)": Schema.number(),
+
+    Created: Schema.date(),
+
+    "PagerDuty Service ID": Schema.richText(),
+  },
+}
+
+export type ServiceOperationalContextEntry = {
+  covered: boolean
+  primaryOnCall: readonly string[]
+}
+
+export type ServiceOperationalContext = ReadonlyMap<
+  string,
+  ServiceOperationalContextEntry
+>
+
+/**
+ * Build a complete level-one coverage snapshot. Requested policies are seeded
+ * as uncovered so a missing row means a real empty result, not an unqueried
+ * policy. On-calls outside that explicit scope are ignored.
+ */
+export function buildServiceOperationalContext(
+  requestedPolicyIds: readonly string[],
+  onCalls: ReadonlyArray<PagerDutyOnCall>
+): ServiceOperationalContext {
+  const mutable = new Map<
+    string,
+    { covered: boolean; primaryOnCall: Set<string> }
+  >()
+
+  for (const rawPolicyId of requestedPolicyIds) {
+    const policyId = rawPolicyId.trim()
+    if (policyId && !mutable.has(policyId)) {
+      mutable.set(policyId, { covered: false, primaryOnCall: new Set() })
+    }
+  }
+
+  for (const onCall of onCalls) {
+    if (onCall.escalation_level !== 1) continue
+    const policyId = onCall.escalation_policy?.id.trim()
+    if (!policyId) continue
+
+    const entry = mutable.get(policyId)
+    if (!entry) continue
+    entry.covered = true
+
+    const user = referenceName(onCall.user)
+    if (user) entry.primaryOnCall.add(user)
+  }
+
+  return new Map(
+    [...mutable].map(([policyId, entry]) => [
+      policyId,
+      {
+        covered: entry.covered,
+        primaryOnCall: [...entry.primaryOnCall].sort(),
+      },
+    ])
+  )
+}
+
+const RESPONSE_STATE_LABELS: Record<string, string> = {
+  active: "No Open Incidents",
+  warning: "Response in Progress",
+  critical: "Awaiting Response",
+  maintenance: "Maintenance",
+  disabled: "Disabled",
+}
+
+function coverageForService(
+  service: PagerDutyService,
+  operationalContext: ServiceOperationalContext
+): {
+  label:
+    | "Covered"
+    | "No Primary On Call"
+    | "No Escalation Policy"
+    | "Not Applicable"
+  primaryOnCall: readonly string[]
+} {
+  const status = service.status.trim().toLowerCase()
+  const policyId = service.escalation_policy?.id.trim()
+  const entry = policyId ? operationalContext.get(policyId) : undefined
+
+  if (status === "disabled") {
+    return {
+      label: "Not Applicable",
+      primaryOnCall: entry?.primaryOnCall ?? [],
+    }
+  }
+  if (!policyId) {
+    return { label: "No Escalation Policy", primaryOnCall: [] }
+  }
+  if (!entry) {
+    throw new Error(
+      `PagerDuty service ${service.id} uses escalation policy ${policyId}, but that policy is absent from the on-call coverage snapshot.`
+    )
+  }
+
+  return {
+    label: entry.covered ? "Covered" : "No Primary On Call",
+    primaryOnCall: entry.primaryOnCall,
+  }
+}
+
+/**
+ * Services do not expose an updated timestamp. The sync passes one observation
+ * time per polling cycle so configuration and status changes are reconsidered.
+ */
+export function serviceToChange(
+  service: PagerDutyService,
+  observedAt: string,
+  operationalContext: ServiceOperationalContext
+) {
+  const name = boundedText(service.name, MAX_RICH_TEXT_CHARACTERS) ?? service.id
+  const statusValue = service.status.trim().toLowerCase()
+  const responseState =
+    RESPONSE_STATE_LABELS[statusValue] ?? humanizeEnum(service.status)
+  const coverage = coverageForService(service, operationalContext)
+  const teams = referenceNames(service.teams)
+  const serviceLink = safeWebUrl(service.html_url)
+  const integrations = referenceNames(service.integrations)
+  const integrationCount = service.integrations
+    ? new Set(
+        service.integrations
+          .map((integration) => integration.id.trim())
+          .filter(Boolean)
+      ).size
+    : null
+  const supportHours = supportHoursLabel(service.support_hours)
+  const lastIncident = dateTime(service.last_incident_timestamp)
+  const escalationPolicy = referenceName(service.escalation_policy)
+  const description = boundedText(service.description, MAX_RICH_TEXT_CHARACTERS)
+  const descriptionPageContent = plainTextPageContent(service.description)
+  const urgencyRule = urgencyRuleLabel(service.incident_urgency_rule)
+  const autoResolveMinutes = positiveMinutes(service.auto_resolve_timeout)
+  const retriggerMinutes = positiveMinutes(service.acknowledgement_timeout)
+  const created = dateTime(service.created_at)
+
+  return {
+    type: "upsert" as const,
+    key: service.id,
+    upstreamUpdatedAt: observedAt,
+    ...(descriptionPageContent
+      ? { pageContentMarkdown: descriptionPageContent }
+      : {}),
+    properties: {
+      Name: Builder.title(name),
+      ...(responseState
+        ? { "Response State": Builder.select(responseState) }
+        : {}),
+      ...(coverage.primaryOnCall.length > 0
+        ? {
+            "Primary On Call": Builder.multiSelect(...coverage.primaryOnCall),
+          }
+        : {}),
+      "Primary Coverage": Builder.select(coverage.label),
+      ...(teams.length > 0 ? { Teams: Builder.multiSelect(...teams) } : {}),
+      ...(serviceLink ? { "Service Link": Builder.url(serviceLink) } : {}),
+      "Coverage Checked": Builder.dateTime(observedAt),
+      ...(integrations.length > 0
+        ? { Integrations: Builder.multiSelect(...integrations) }
+        : {}),
+      ...(integrationCount != null
+        ? { "Integration Count": Builder.number(integrationCount) }
+        : {}),
+      ...(supportHours
+        ? { "Support Hours": Builder.richText(supportHours) }
+        : {}),
+      ...(lastIncident
+        ? { "Last Incident": Builder.dateTime(lastIncident) }
+        : {}),
+      ...(escalationPolicy
+        ? { "Escalation Policy": Builder.select(escalationPolicy) }
+        : {}),
+      ...(description ? { Description: Builder.richText(description) } : {}),
+      ...(urgencyRule ? { "Urgency Rule": Builder.richText(urgencyRule) } : {}),
+      ...(autoResolveMinutes != null
+        ? { "Auto Resolve (min)": Builder.number(autoResolveMinutes) }
+        : {}),
+      ...(retriggerMinutes != null
+        ? {
+            "Re-trigger After Ack (min)": Builder.number(retriggerMinutes),
+          }
+        : {}),
+      ...(created ? { Created: Builder.dateTime(created) } : {}),
+      "PagerDuty Service ID": Builder.richText(service.id),
+    },
+  }
+}

--- a/workers/pagerduty-sync/src/services.ts
+++ b/workers/pagerduty-sync/src/services.ts
@@ -3,7 +3,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 
 import type { PagerDutyOnCall, PagerDutyService } from "./pagerduty.js"
 import {
@@ -13,8 +13,10 @@ import {
   MAX_RICH_TEXT_CHARACTERS,
   plainTextPageContent,
   positiveMinutes,
-  referenceName,
-  referenceNames,
+  providerOptionLabel,
+  providerOptionLabels,
+  referenceOptionName,
+  referenceOptionNames,
   safeWebUrl,
   supportHoursLabel,
   urgencyRuleLabel,
@@ -23,7 +25,7 @@ import {
 export const INITIAL_TITLE = "PagerDuty Services"
 export const PRIMARY_KEY = "PagerDuty Service ID"
 
-export const serviceSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const serviceSchema = {
   databaseIcon: notionIcon("server", "blue"),
   properties: {
     Name: Schema.title(),
@@ -74,7 +76,7 @@ export const serviceSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "PagerDuty Service ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 export type ServiceOperationalContextEntry = {
   covered: boolean
@@ -116,7 +118,7 @@ export function buildServiceOperationalContext(
     if (!entry) continue
     entry.covered = true
 
-    const user = referenceName(onCall.user)
+    const user = referenceOptionName(onCall.user)
     if (user) entry.primaryOnCall.add(user)
   }
 
@@ -183,15 +185,23 @@ export function serviceToChange(
   service: PagerDutyService,
   observedAt: string,
   operationalContext: ServiceOperationalContext
-) {
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof serviceSchema.properties> {
   const name = boundedText(service.name, MAX_RICH_TEXT_CHARACTERS) ?? service.id
   const statusValue = service.status.trim().toLowerCase()
-  const responseState =
+  const responseState = providerOptionLabel(
     RESPONSE_STATE_LABELS[statusValue] ?? humanizeEnum(service.status)
+  )
   const coverage = coverageForService(service, operationalContext)
-  const teams = referenceNames(service.teams)
+  const primaryOnCall = providerOptionLabels(
+    "Primary On Call",
+    coverage.primaryOnCall
+  )
+  const teams = referenceOptionNames("Teams", service.teams)
   const serviceLink = safeWebUrl(service.html_url)
-  const integrations = referenceNames(service.integrations)
+  const integrations = referenceOptionNames(
+    "Integrations",
+    service.integrations
+  )
   const integrationCount = service.integrations
     ? new Set(
         service.integrations
@@ -201,7 +211,7 @@ export function serviceToChange(
     : null
   const supportHours = supportHoursLabel(service.support_hours)
   const lastIncident = dateTime(service.last_incident_timestamp)
-  const escalationPolicy = referenceName(service.escalation_policy)
+  const escalationPolicy = referenceOptionName(service.escalation_policy)
   const description = boundedText(service.description, MAX_RICH_TEXT_CHARACTERS)
   const descriptionPageContent = plainTextPageContent(service.description)
   const urgencyRule = urgencyRuleLabel(service.incident_urgency_rule)
@@ -213,49 +223,32 @@ export function serviceToChange(
     type: "upsert" as const,
     key: service.id,
     upstreamUpdatedAt: observedAt,
-    ...(descriptionPageContent
-      ? { pageContentMarkdown: descriptionPageContent }
-      : {}),
+    pageContentMarkdown: descriptionPageContent ?? "",
     properties: {
       Name: Builder.title(name),
-      ...(responseState
-        ? { "Response State": Builder.select(responseState) }
-        : {}),
-      ...(coverage.primaryOnCall.length > 0
-        ? {
-            "Primary On Call": Builder.multiSelect(...coverage.primaryOnCall),
-          }
-        : {}),
+      "Response State": responseState ? Builder.select(responseState) : [],
+      "Primary On Call":
+        primaryOnCall.length > 0 ? Builder.multiSelect(...primaryOnCall) : [],
       "Primary Coverage": Builder.select(coverage.label),
-      ...(teams.length > 0 ? { Teams: Builder.multiSelect(...teams) } : {}),
-      ...(serviceLink ? { "Service Link": Builder.url(serviceLink) } : {}),
+      Teams: teams.length > 0 ? Builder.multiSelect(...teams) : [],
+      "Service Link": serviceLink ? Builder.url(serviceLink) : [],
       "Coverage Checked": Builder.dateTime(observedAt),
-      ...(integrations.length > 0
-        ? { Integrations: Builder.multiSelect(...integrations) }
-        : {}),
-      ...(integrationCount != null
-        ? { "Integration Count": Builder.number(integrationCount) }
-        : {}),
-      ...(supportHours
-        ? { "Support Hours": Builder.richText(supportHours) }
-        : {}),
-      ...(lastIncident
-        ? { "Last Incident": Builder.dateTime(lastIncident) }
-        : {}),
-      ...(escalationPolicy
-        ? { "Escalation Policy": Builder.select(escalationPolicy) }
-        : {}),
-      ...(description ? { Description: Builder.richText(description) } : {}),
-      ...(urgencyRule ? { "Urgency Rule": Builder.richText(urgencyRule) } : {}),
-      ...(autoResolveMinutes != null
-        ? { "Auto Resolve (min)": Builder.number(autoResolveMinutes) }
-        : {}),
-      ...(retriggerMinutes != null
-        ? {
-            "Re-trigger After Ack (min)": Builder.number(retriggerMinutes),
-          }
-        : {}),
-      ...(created ? { Created: Builder.dateTime(created) } : {}),
+      Integrations:
+        integrations.length > 0 ? Builder.multiSelect(...integrations) : [],
+      "Integration Count":
+        integrationCount != null ? Builder.number(integrationCount) : [],
+      "Support Hours": supportHours ? Builder.richText(supportHours) : [],
+      "Last Incident": lastIncident ? Builder.dateTime(lastIncident) : [],
+      "Escalation Policy": escalationPolicy
+        ? Builder.select(escalationPolicy)
+        : [],
+      Description: description ? Builder.richText(description) : [],
+      "Urgency Rule": urgencyRule ? Builder.richText(urgencyRule) : [],
+      "Auto Resolve (min)":
+        autoResolveMinutes != null ? Builder.number(autoResolveMinutes) : [],
+      "Re-trigger After Ack (min)":
+        retriggerMinutes != null ? Builder.number(retriggerMinutes) : [],
+      Created: created ? Builder.dateTime(created) : [],
       "PagerDuty Service ID": Builder.richText(service.id),
     },
   }

--- a/workers/pagerduty-sync/src/sync-state.ts
+++ b/workers/pagerduty-sync/src/sync-state.ts
@@ -1,6 +1,12 @@
 // Serializable state transitions for PagerDuty offset pagination. The REST
 // API does not provide snapshot cursors, so each transition validates totals,
 // ordering, and progress instead of silently accepting a partial traversal.
+//
+// Incidents: open -> openConfirm -> recent window(s) -> complete
+// Services: discover -> publish -> complete
+// Configured services begin directly in publish. The state transitions below
+// are pure; index.ts performs I/O, and the Workers runtime persists nextState
+// between callbacks.
 
 import type {
   IncidentSyncPhase,

--- a/workers/pagerduty-sync/src/sync-state.ts
+++ b/workers/pagerduty-sync/src/sync-state.ts
@@ -36,11 +36,14 @@ export type IncidentSyncState = {
 }
 
 export type ServiceSyncState = {
+  phase: "discover" | "publish"
   scope: PagerDutyScope
   observedAt: string
   offset: number
   expectedTotal?: number
   seenServiceIds: string[]
+  /** Complete unscoped discovery set, or the explicitly configured IDs. */
+  expectedServiceIds: string[]
 }
 
 function scopeFromConfig(
@@ -418,14 +421,20 @@ export function initialServiceSyncState(
   now: Date | string = new Date()
 ): ServiceSyncState {
   return {
+    phase: config.serviceIds.length > 0 ? "publish" : "discover",
     scope: scopeFromConfig(config),
     observedAt: iso(timestamp(now)),
     offset: 0,
     seenServiceIds: [],
+    expectedServiceIds: [...config.serviceIds],
   }
 }
 
-/** Track IDs because the service endpoint can only sort by mutable name. */
+/**
+ * Discover then publish unscoped services because the endpoint can only use
+ * live offset pagination ordered by mutable name. The publish pass must
+ * reproduce the complete discovered identity set before replacement commits.
+ */
 export function nextServiceSyncState(
   state: ServiceSyncState,
   page: PagerDutyOffsetPage<PagerDutyService>
@@ -445,9 +454,23 @@ export function nextServiceSyncState(
     page.total,
     "service"
   )
+  const expectedServiceIds = new Set(state.expectedServiceIds)
+  if (
+    state.phase === "publish" &&
+    page.total !== state.expectedServiceIds.length
+  ) {
+    throw new Error(
+      `PagerDuty service membership changed between discovery and publish (${state.expectedServiceIds.length} to ${page.total}).`
+    )
+  }
   const seen = new Set(state.seenServiceIds)
 
   for (const service of page.resources) {
+    if (state.phase === "publish" && !expectedServiceIds.has(service.id)) {
+      throw new Error(
+        `PagerDuty service ${service.id} appeared after service discovery.`
+      )
+    }
     if (seen.has(service.id)) {
       throw new Error(
         `PagerDuty service pagination repeated service ${service.id}.`
@@ -478,6 +501,26 @@ export function nextServiceSyncState(
   if (seenServiceIds.length !== expectedTotal) {
     throw new Error(
       `PagerDuty service pagination saw ${seenServiceIds.length} of ${expectedTotal} unique services.`
+    )
+  }
+
+  if (state.phase === "discover") {
+    return {
+      ...state,
+      phase: "publish",
+      offset: 0,
+      expectedTotal: undefined,
+      seenServiceIds: [],
+      expectedServiceIds: [...seenServiceIds].sort(),
+    }
+  }
+
+  if (
+    seenServiceIds.some((serviceId) => !expectedServiceIds.has(serviceId)) ||
+    state.expectedServiceIds.some((serviceId) => !seen.has(serviceId))
+  ) {
+    throw new Error(
+      "PagerDuty service identities changed between discovery and publish."
     )
   }
   return undefined

--- a/workers/pagerduty-sync/src/sync-state.ts
+++ b/workers/pagerduty-sync/src/sync-state.ts
@@ -1,0 +1,484 @@
+// Serializable state transitions for PagerDuty offset pagination. The REST
+// API does not provide snapshot cursors, so each transition validates totals,
+// ordering, and progress instead of silently accepting a partial traversal.
+
+import type {
+  IncidentSyncPhase,
+  PagerDutyConfig,
+  PagerDutyIncident,
+  PagerDutyOffsetPage,
+  PagerDutyScope,
+  PagerDutyService,
+} from "./pagerduty.js"
+import { MAX_PAGERDUTY_OFFSET_RECORDS } from "./pagerduty.js"
+
+const DAY_MS = 24 * 60 * 60 * 1_000
+export const INCIDENT_WINDOW_DAYS = 7
+const INCIDENT_WINDOW_MS = INCIDENT_WINDOW_DAYS * DAY_MS
+export const MIN_INCIDENT_WINDOW_MS = 60_000
+
+export type IncidentSyncState = {
+  phase: IncidentSyncPhase
+  scope: PagerDutyScope
+  cycleSince: string
+  cycleUntil: string
+  windowSince: string
+  windowUntil: string
+  offset: number
+  processed: number
+  /** Right-hand boundaries waiting after an oversized window is bisected. */
+  pendingWindowUntils: string[]
+  /** First-pass IDs that the second all-open pass must reproduce exactly. */
+  openIncidentIds: string[]
+  expectedTotal?: number
+  lastIncidentId?: string
+  lastIncidentNumber?: number
+}
+
+export type ServiceSyncState = {
+  scope: PagerDutyScope
+  observedAt: string
+  offset: number
+  expectedTotal?: number
+  seenServiceIds: string[]
+}
+
+function scopeFromConfig(
+  config: PagerDutyConfig,
+  incidentPhase?: IncidentSyncPhase
+): PagerDutyScope {
+  return {
+    region: config.region,
+    serviceIds: [...config.serviceIds],
+    teamIds: [...config.teamIds],
+    ...(incidentPhase ? { incidentPhase } : {}),
+  }
+}
+
+function timestamp(value: Date | string): number {
+  const milliseconds =
+    value instanceof Date ? value.getTime() : Date.parse(value)
+  if (!Number.isFinite(milliseconds)) {
+    throw new Error("PagerDuty sync state requires a valid observation time.")
+  }
+  return milliseconds
+}
+
+function iso(milliseconds: number): string {
+  return new Date(milliseconds).toISOString()
+}
+
+function minTimestamp(left: number, right: number): number {
+  return left < right ? left : right
+}
+
+export function initialIncidentSyncState(
+  config: PagerDutyConfig,
+  now: Date | string = new Date()
+): IncidentSyncState {
+  const cycleUntilMs = timestamp(now)
+  const cycleSinceMs = cycleUntilMs - config.incidentLookbackDays * DAY_MS
+  const windowUntilMs = minTimestamp(
+    cycleSinceMs + INCIDENT_WINDOW_MS,
+    cycleUntilMs
+  )
+
+  return {
+    phase: "open",
+    scope: scopeFromConfig(config, "open"),
+    cycleSince: iso(cycleSinceMs),
+    cycleUntil: iso(cycleUntilMs),
+    windowSince: iso(cycleSinceMs),
+    windowUntil: iso(windowUntilMs),
+    offset: 0,
+    processed: 0,
+    pendingWindowUntils: [],
+    openIncidentIds: [],
+  }
+}
+
+function checkedExpectedTotal(
+  previous: number | undefined,
+  actual: number,
+  resource: string
+): number {
+  if (previous !== undefined && previous !== actual) {
+    throw new Error(
+      `PagerDuty ${resource} total changed during pagination (${previous} to ${actual}).`
+    )
+  }
+  return previous ?? actual
+}
+
+function checkedNextOffset(
+  currentOffset: number,
+  nextOffset: number | undefined,
+  resource: string
+): number {
+  if (
+    nextOffset === undefined ||
+    !Number.isSafeInteger(nextOffset) ||
+    nextOffset <= currentOffset
+  ) {
+    throw new Error(`PagerDuty ${resource} pagination did not advance.`)
+  }
+  return nextOffset
+}
+
+/**
+ * Re-read the last record of the previous page. A changing live offset set can
+ * otherwise shift an unseen record behind the next offset without changing
+ * the reported total.
+ */
+function checkedOverlappingNextOffset(
+  currentOffset: number,
+  naturalNextOffset: number | undefined,
+  resource: string
+): number {
+  const nextOffset =
+    checkedNextOffset(currentOffset, naturalNextOffset, resource) - 1
+  if (nextOffset <= currentOffset) {
+    throw new Error(
+      `PagerDuty ${resource} pages are too small for boundary overlap.`
+    )
+  }
+  return nextOffset
+}
+
+function assertPageOffset(
+  expected: number,
+  actual: number,
+  resource: string
+): void {
+  if (actual !== expected) {
+    throw new Error(
+      `PagerDuty ${resource} page offset ${actual} did not match state ${expected}.`
+    )
+  }
+}
+
+function splitRecentIncidentWindow(
+  state: IncidentSyncState
+): IncidentSyncState {
+  const windowSinceMs = timestamp(state.windowSince)
+  const windowUntilMs = timestamp(state.windowUntil)
+  const durationMs = windowUntilMs - windowSinceMs
+
+  if (durationMs <= MIN_INCIDENT_WINDOW_MS) {
+    throw new Error(
+      `PagerDuty returned more than ${MAX_PAGERDUTY_OFFSET_RECORDS.toLocaleString()} incidents in a one-minute window. ` +
+        "Narrow PAGERDUTY_SERVICE_IDS or PAGERDUTY_TEAM_IDS before retrying."
+    )
+  }
+
+  // Prefer an even split, but keep the left side at least as wide as this
+  // recipe's minimum. Adjacent windows still share the exact boundary.
+  const midpointMs = Math.max(
+    windowSinceMs + MIN_INCIDENT_WINDOW_MS,
+    windowSinceMs + Math.floor(durationMs / 2)
+  )
+  if (midpointMs >= windowUntilMs) {
+    throw new Error("PagerDuty incident time window could not be narrowed.")
+  }
+
+  return {
+    phase: "recent",
+    scope: { ...state.scope, incidentPhase: "recent" },
+    cycleSince: state.cycleSince,
+    cycleUntil: state.cycleUntil,
+    windowSince: state.windowSince,
+    windowUntil: iso(midpointMs),
+    offset: 0,
+    processed: 0,
+    pendingWindowUntils: [
+      state.windowUntil,
+      ...(state.pendingWindowUntils ?? []),
+    ],
+    openIncidentIds: [],
+  }
+}
+
+/**
+ * Advance within the open scan or one pinned recent subwindow. Adjacent recent
+ * windows intentionally share one exact boundary timestamp. Duplicate upserts
+ * are harmless; advancing by a guessed precision could miss a record.
+ */
+export function nextIncidentSyncState(
+  state: IncidentSyncState,
+  page: PagerDutyOffsetPage<PagerDutyIncident>
+): IncidentSyncState | undefined {
+  assertPageOffset(state.offset, page.offset, "incident")
+  if (state.scope.incidentPhase !== state.phase) {
+    throw new Error("PagerDuty incident phase does not match its pinned scope.")
+  }
+
+  if (page.total > MAX_PAGERDUTY_OFFSET_RECORDS) {
+    if (state.phase !== "recent") {
+      throw new Error(
+        `PagerDuty returned more than ${MAX_PAGERDUTY_OFFSET_RECORDS.toLocaleString()} open incidents. ` +
+          "Narrow PAGERDUTY_SERVICE_IDS or PAGERDUTY_TEAM_IDS before retrying."
+      )
+    }
+    if (!page.requiresWindowSplit || page.resources.length > 0) {
+      throw new Error(
+        "PagerDuty oversized incident window returned resources before splitting."
+      )
+    }
+    if (state.offset !== 0 || state.processed !== 0) {
+      throw new Error(
+        "PagerDuty incident window exceeded the offset limit after pagination began."
+      )
+    }
+    return splitRecentIncidentWindow(state)
+  }
+  if (page.requiresWindowSplit) {
+    throw new Error(
+      "PagerDuty incident page requested a split below the offset limit."
+    )
+  }
+
+  const expectedTotal = checkedExpectedTotal(
+    state.expectedTotal,
+    page.total,
+    "incident"
+  )
+
+  const expectsBoundary = state.offset > 0
+  if (
+    expectsBoundary !==
+    (state.lastIncidentId !== undefined &&
+      state.lastIncidentNumber !== undefined)
+  ) {
+    throw new Error(
+      "PagerDuty incident pagination is missing its overlap boundary."
+    )
+  }
+
+  let firstNewResource = 0
+  let lastIncidentNumber = state.lastIncidentNumber
+  if (expectsBoundary) {
+    const boundary = page.resources[0]
+    if (
+      !boundary ||
+      boundary.id !== state.lastIncidentId ||
+      boundary.incident_number !== state.lastIncidentNumber
+    ) {
+      throw new Error(
+        "PagerDuty incident membership shifted across the page boundary."
+      )
+    }
+    firstNewResource = 1
+  }
+
+  for (const incident of page.resources.slice(firstNewResource)) {
+    if (
+      !Number.isSafeInteger(incident.incident_number) ||
+      (lastIncidentNumber !== undefined &&
+        incident.incident_number <= lastIncidentNumber)
+    ) {
+      throw new Error(
+        "PagerDuty incidents were not strictly ordered by incident_number."
+      )
+    }
+    lastIncidentNumber = incident.incident_number
+  }
+
+  const processed = state.processed + page.resources.length - firstNewResource
+  if (processed > expectedTotal) {
+    throw new Error(
+      "PagerDuty incident pagination exceeded its reported total."
+    )
+  }
+
+  const newResources = page.resources.slice(firstNewResource)
+  const firstPassIds = state.openIncidentIds ?? []
+  if (state.phase === "openConfirm") {
+    if (page.total !== firstPassIds.length) {
+      throw new Error(
+        "PagerDuty open incident total changed between confirmation passes."
+      )
+    }
+    for (const [index, incident] of newResources.entries()) {
+      if (firstPassIds[state.processed + index] !== incident.id) {
+        throw new Error(
+          "PagerDuty open incident identities changed between confirmation passes."
+        )
+      }
+    }
+  }
+  const openIncidentIds =
+    state.phase === "open"
+      ? [...firstPassIds, ...newResources.map((incident) => incident.id)]
+      : firstPassIds
+
+  if (page.more) {
+    if (page.resources.length !== page.limit) {
+      throw new Error(
+        "PagerDuty incident pagination returned a partial continuing page."
+      )
+    }
+    if (processed >= expectedTotal) {
+      throw new Error(
+        "PagerDuty incident pagination reported more after reaching its total."
+      )
+    }
+    const boundary = page.resources.at(-1)
+    if (!boundary) {
+      throw new Error("PagerDuty incident pagination has no page boundary.")
+    }
+    return {
+      ...state,
+      offset: checkedOverlappingNextOffset(
+        state.offset,
+        page.nextOffset,
+        "incident"
+      ),
+      processed,
+      expectedTotal,
+      openIncidentIds,
+      lastIncidentId: boundary.id,
+      lastIncidentNumber: boundary.incident_number,
+    }
+  }
+
+  if (processed !== expectedTotal) {
+    throw new Error(
+      `PagerDuty incident pagination processed ${processed} of ${expectedTotal} records.`
+    )
+  }
+
+  if (state.phase === "open") {
+    // A second full identity pass catches equal-count membership substitutions
+    // that can happen entirely before a single overlapped page boundary.
+    return {
+      phase: "openConfirm",
+      scope: { ...state.scope, incidentPhase: "openConfirm" },
+      cycleSince: state.cycleSince,
+      cycleUntil: state.cycleUntil,
+      windowSince: state.cycleSince,
+      windowUntil: state.windowUntil,
+      offset: 0,
+      processed: 0,
+      pendingWindowUntils: [],
+      openIncidentIds,
+    }
+  }
+
+  if (state.phase === "openConfirm") {
+    if (processed !== firstPassIds.length) {
+      throw new Error(
+        "PagerDuty open incident confirmation did not reproduce every identity."
+      )
+    }
+    // Reset every open-pass invariant before replaying recent history. Open
+    // incidents inside the lookback are harmless idempotent upserts.
+    return {
+      phase: "recent",
+      scope: { ...state.scope, incidentPhase: "recent" },
+      cycleSince: state.cycleSince,
+      cycleUntil: state.cycleUntil,
+      windowSince: state.cycleSince,
+      windowUntil: state.windowUntil,
+      offset: 0,
+      processed: 0,
+      pendingWindowUntils: [],
+      openIncidentIds: [],
+    }
+  }
+
+  const currentWindowUntilMs = timestamp(state.windowUntil)
+  const cycleUntilMs = timestamp(state.cycleUntil)
+  if (currentWindowUntilMs >= cycleUntilMs) return undefined
+
+  const [pendingWindowUntil, ...remainingPendingWindowUntils] =
+    state.pendingWindowUntils ?? []
+  const nextWindowUntilMs = pendingWindowUntil
+    ? timestamp(pendingWindowUntil)
+    : minTimestamp(currentWindowUntilMs + INCIDENT_WINDOW_MS, cycleUntilMs)
+  if (nextWindowUntilMs <= currentWindowUntilMs) {
+    throw new Error("PagerDuty incident time window did not advance.")
+  }
+
+  return {
+    phase: "recent",
+    scope: state.scope,
+    cycleSince: state.cycleSince,
+    cycleUntil: state.cycleUntil,
+    windowSince: state.windowUntil,
+    windowUntil: iso(nextWindowUntilMs),
+    offset: 0,
+    processed: 0,
+    pendingWindowUntils: remainingPendingWindowUntils,
+    openIncidentIds: [],
+  }
+}
+
+export function initialServiceSyncState(
+  config: PagerDutyConfig,
+  now: Date | string = new Date()
+): ServiceSyncState {
+  return {
+    scope: scopeFromConfig(config),
+    observedAt: iso(timestamp(now)),
+    offset: 0,
+    seenServiceIds: [],
+  }
+}
+
+/** Track IDs because the service endpoint can only sort by mutable name. */
+export function nextServiceSyncState(
+  state: ServiceSyncState,
+  page: PagerDutyOffsetPage<PagerDutyService>
+): ServiceSyncState | undefined {
+  assertPageOffset(state.offset, page.offset, "service")
+  if (
+    state.scope.serviceIds.length === 0 &&
+    page.total > MAX_PAGERDUTY_OFFSET_RECORDS
+  ) {
+    throw new Error(
+      `PagerDuty returned more than ${MAX_PAGERDUTY_OFFSET_RECORDS.toLocaleString()} services. ` +
+        "Set PAGERDUTY_SERVICE_IDS to the services this Worker should sync."
+    )
+  }
+  const expectedTotal = checkedExpectedTotal(
+    state.expectedTotal,
+    page.total,
+    "service"
+  )
+  const seen = new Set(state.seenServiceIds)
+
+  for (const service of page.resources) {
+    if (seen.has(service.id)) {
+      throw new Error(
+        `PagerDuty service pagination repeated service ${service.id}.`
+      )
+    }
+    seen.add(service.id)
+  }
+
+  const seenServiceIds = [...seen]
+  if (seenServiceIds.length > expectedTotal) {
+    throw new Error("PagerDuty service pagination exceeded its reported total.")
+  }
+
+  if (page.more) {
+    if (seenServiceIds.length >= expectedTotal) {
+      throw new Error(
+        "PagerDuty service pagination reported more after reaching its total."
+      )
+    }
+    return {
+      ...state,
+      offset: checkedNextOffset(state.offset, page.nextOffset, "service"),
+      expectedTotal,
+      seenServiceIds,
+    }
+  }
+
+  if (seenServiceIds.length !== expectedTotal) {
+    throw new Error(
+      `PagerDuty service pagination saw ${seenServiceIds.length} of ${expectedTotal} unique services.`
+    )
+  }
+  return undefined
+}

--- a/workers/pagerduty-sync/test.ts
+++ b/workers/pagerduty-sync/test.ts
@@ -13,6 +13,7 @@ import {
   MAX_MULTI_SELECT_OPTIONS,
   MAX_OPTION_NAME_CHARACTERS,
   MAX_PAGE_CONTENT_CHARACTERS,
+  MAX_URL_CHARACTERS,
   nextAutomaticAction,
   providerOptionLabel,
   providerOptionLabels,
@@ -501,6 +502,12 @@ test("incident operational helpers are deterministic and omit unsafe values", ()
     safeWebUrl("https://meet.example.com/room#war-room"),
     "https://meet.example.com/room#war-room"
   )
+  const urlPrefix = "https://example.com/"
+  const maximumLengthUrl = `${urlPrefix}${"a".repeat(
+    MAX_URL_CHARACTERS - urlPrefix.length
+  )}`
+  assert.equal(safeWebUrl(maximumLengthUrl), maximumLengthUrl)
+  assert.equal(safeWebUrl(`${maximumLengthUrl}a`), null)
 
   const unsafeConference = incidentToChange({
     ...minimalIncident,
@@ -907,14 +914,14 @@ test("configuration defaults, normalizes filters, and selects the EU host", () =
     getPagerDutyConfig({
       PAGERDUTY_REGION: " EU ",
       PAGERDUTY_INCIDENT_LOOKBACK_DAYS: "30",
-      PAGERDUTY_SERVICE_IDS: "PSVC001, PSVC002,PSVC001",
-      PAGERDUTY_TEAM_IDS: "PTEAM01,PTEAM01, PTEAM02",
+      PAGERDUTY_SERVICE_IDS: "service-prod/v2, x,service-prod/v2",
+      PAGERDUTY_TEAM_IDS: "team:platform,team:platform, team_lowercase",
     }),
     config({
       region: "eu",
       incidentLookbackDays: 30,
-      serviceIds: ["PSVC001", "PSVC002"],
-      teamIds: ["PTEAM01", "PTEAM02"],
+      serviceIds: ["service-prod/v2", "x"],
+      teamIds: ["team:platform", "team_lowercase"],
     })
   )
 
@@ -930,18 +937,35 @@ test("configuration defaults, normalizes filters, and selects the EU host", () =
     () => getPagerDutyConfig({ PAGERDUTY_INCIDENT_LOOKBACK_DAYS: "181" }),
     /integer from 1 to 180/
   )
-  assert.throws(
-    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "bad/id" }),
-    /invalid PagerDuty ID/
+  const maximumLengthId = "x".repeat(255)
+  assert.deepEqual(
+    getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: maximumLengthId }).serviceIds,
+    [maximumLengthId]
   )
   assert.throws(
-    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "PSVC01" }),
-    /invalid PagerDuty ID/
+    () =>
+      getPagerDutyConfig({
+        PAGERDUTY_SERVICE_IDS: `${maximumLengthId}x`,
+      }),
+    /longer than 255 characters/
   )
   assert.throws(
-    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "psvc001" }),
-    /invalid PagerDuty ID/
+    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "service\nid" }),
+    /control characters/
   )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "service\u0085id" }),
+    /control characters/
+  )
+  for (const id of [".", ".."]) {
+    assert.throws(
+      () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: id }),
+      /URL path segment/
+    )
+  }
+  assert.deepEqual(getPagerDutyConfig({ PAGERDUTY_TEAM_IDS: "." }).teamIds, [
+    ".",
+  ])
   assert.throws(
     () => getPagerDutyConfig({ PAGERDUTY_TEAM_IDS: ",," }),
     /at least one PagerDuty ID/

--- a/workers/pagerduty-sync/test.ts
+++ b/workers/pagerduty-sync/test.ts
@@ -7,7 +7,6 @@ import { test } from "node:test"
 import { RateLimitError } from "@notionhq/workers"
 
 import {
-  boundedSafeJson,
   durationMinutes,
   humanizeEnum,
   incidentPageContent,
@@ -789,16 +788,6 @@ test("display and content helpers preserve unknowns while protecting secrets", (
   )
   assert.equal(INCIDENT_WINDOW_DAYS, 7)
 
-  const json = boundedSafeJson({
-    value: "safe",
-    headers: { Authorization: "secret" },
-    api_token: "secret",
-  })
-  assert.ok(json)
-  assert.match(json, /safe/)
-  assert.match(json, /\[REDACTED\]/)
-  assert.doesNotMatch(json, /"secret"/)
-
   const content = incidentPageContent({
     first_trigger_log_entry: {
       event_details: { description: "Safe trigger summary" },
@@ -1535,7 +1524,7 @@ test("execute functions wire client, state, and transforms end to end", async ()
           scope.incidentPhase,
           incidentRequest === 1 ? "open" : "openConfirm"
         )
-        return incidentPage([], { total: 0 })
+        return incidentPage([fullIncident])
       }
 
       assert.equal(scope.incidentPhase, "recent")
@@ -1560,7 +1549,7 @@ test("execute functions wire client, state, and transforms end to end", async ()
     config({ incidentLookbackDays: 1 })
   )
   assert.equal(openBatch.hasMore, true)
-  assert.deepEqual(openBatch.changes, [])
+  assert.equal(openBatch.changes[0]?.key, "PINC001")
   assert.equal(openBatch.nextState.phase, "openConfirm")
 
   const confirmBatch = await executeIncidents(

--- a/workers/pagerduty-sync/test.ts
+++ b/workers/pagerduty-sync/test.ts
@@ -1,0 +1,1777 @@
+// Deterministic offline tests for the PagerDuty sync worker.
+// Run from this directory with `npm test`.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { RateLimitError } from "@notionhq/workers"
+
+import {
+  boundedSafeJson,
+  durationMinutes,
+  humanizeEnum,
+  incidentPageContent,
+  MAX_PAGE_CONTENT_CHARACTERS,
+  nextAutomaticAction,
+  referenceName,
+  safeWebUrl,
+  supportHoursLabel,
+  urgencyRuleLabel,
+} from "./src/helpers.js"
+import { incidentSchema, incidentToChange } from "./src/incidents.js"
+import worker, { executeIncidents, executeServices } from "./src/index.js"
+import {
+  createPagerDutyClient,
+  getPagerDutyConfig,
+  parseRetryAfterSeconds,
+  rateLimitRetryAfterSeconds,
+  type PagerDutyConfig,
+  type PagerDutyClient,
+  type PagerDutyIncident,
+  type PagerDutyOnCall,
+  type PagerDutyOffsetPage,
+  type PagerDutyService,
+} from "./src/pagerduty.js"
+import {
+  buildServiceOperationalContext,
+  serviceSchema,
+  serviceToChange,
+} from "./src/services.js"
+import {
+  INCIDENT_WINDOW_DAYS,
+  initialIncidentSyncState,
+  initialServiceSyncState,
+  nextIncidentSyncState,
+  nextServiceSyncState,
+} from "./src/sync-state.js"
+
+const TEST_TOKEN = "pagerduty-test-token"
+
+function propertyText(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function assertPropertyContains(value: unknown, expected: string): void {
+  assert.match(
+    propertyText(value),
+    new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  )
+}
+
+const fullIncident: PagerDutyIncident = {
+  id: "PINC001",
+  incident_number: 4321,
+  title: "Checkout latency above SLO",
+  html_url: "https://acme.pagerduty.com/incidents/PINC001",
+  status: "acknowledged",
+  urgency: "high",
+  priority: { id: "PPRI001", summary: "P1" },
+  service: { id: "PSVC001", summary: "Checkout API" },
+  assignments: [
+    {
+      at: "2026-07-02T12:01:00Z",
+      assignee: { id: "PUSR001", summary: "Ada Lovelace" },
+    },
+    {
+      at: "2026-07-02T12:02:00Z",
+      assignee: { id: "PUSR001", summary: "Ada Lovelace" },
+    },
+    {
+      at: "2026-07-02T12:03:00Z",
+      assignee: { id: "PUSR002", name: "Grace Hopper" },
+    },
+  ],
+  assigned_via: "direct_assignment",
+  last_status_change_at: "2026-07-02T12:05:00Z",
+  last_status_change_by: {
+    id: "PAGENT1",
+    type: "integration_reference",
+    summary: "PagerDuty Automation",
+  },
+  resolved_at: null,
+  incident_type: { name: "major_incident" },
+  pending_actions: [
+    { type: "resolve", at: "2026-07-02T12:30:00Z" },
+    { type: "urgency_change", at: "2026-07-02T12:15:00Z", to: "high" },
+    { type: "escalate", at: "2026-07-02T12:15:00Z" },
+  ],
+  conference_bridge: {
+    conference_url: "https://meet.example.com/checkout",
+    conference_number: "+1 415-555-1212,,,,1234#",
+  },
+  first_trigger_log_entry: {
+    event_details: { description: "Latency breached the checkout SLO." },
+    channel: {
+      type: "email",
+      body: "<p>Investigate the <strong>database</strong>.</p>",
+      body_content_type: "text/html",
+    },
+    contexts: [
+      {
+        type: "link",
+        text: "Runbook",
+        href: "https://runbooks.example.com/checkout",
+      },
+      {
+        type: "link",
+        text: "Unsafe",
+        href: "https://example.com/?access_token=must-not-appear",
+      },
+    ],
+  },
+  alert_counts: { all: 8, triggered: 2, resolved: 6 },
+  escalation_policy: {
+    id: "PPOL001",
+    summary: "Commerce escalation",
+  },
+  teams: [
+    { id: "PTEAM01", summary: "Commerce" },
+    { id: "PTEAM01", summary: "Commerce" },
+    { id: "PTEAM02", name: "SRE" },
+  ],
+  acknowledgements: [
+    {
+      at: "2026-07-02T12:04:00Z",
+      acknowledger: { id: "PUSR001", summary: "Ada Lovelace" },
+    },
+    {
+      at: "2026-07-02T12:06:00Z",
+      acknowledger: { id: "PUSR001", summary: "Ada Lovelace" },
+    },
+  ],
+  created_at: "2026-07-02T12:00:00Z",
+  updated_at: "2026-07-02T12:45:30Z",
+}
+
+const minimalIncident: PagerDutyIncident = {
+  id: "PINC002",
+  incident_number: 4322,
+  title: "  Unknown workflow state  ",
+  html_url: null,
+  status: "custom_new_state",
+  urgency: null,
+  priority: { id: "PPRI002" },
+  service: null,
+  assignments: [
+    {
+      at: "2026-07-02T13:00:00Z",
+      assignee: { id: "PUSR003" },
+    },
+  ],
+  assigned_via: null,
+  last_status_change_at: null,
+  resolved_at: null,
+  first_trigger_log_entry: null,
+  alert_counts: null,
+  escalation_policy: null,
+  teams: [],
+  acknowledgements: [],
+  created_at: "2026-07-02T13:00:00Z",
+  updated_at: "2026-07-02T13:01:00Z",
+}
+
+const fullService: PagerDutyService = {
+  id: "PSVC001",
+  name: "Checkout API",
+  description: `Owns checkout *and* payment routing. ${"x".repeat(2_100)}`,
+  html_url: "https://acme.pagerduty.com/service-directory/PSVC001",
+  status: "critical",
+  created_at: "2024-01-02T03:04:05Z",
+  last_incident_timestamp: "2026-07-02T12:00:00Z",
+  escalation_policy: {
+    id: "PPOL001",
+    summary: "Commerce escalation",
+  },
+  teams: [
+    { id: "PTEAM01", summary: "Commerce" },
+    { id: "PTEAM01", summary: "Commerce" },
+  ],
+  integrations: [
+    { id: "PINT001", summary: "Datadog" },
+    { id: "PINT002", name: "CloudWatch" },
+    { id: "PINT002", name: "CloudWatch" },
+    { id: "PINT003" },
+  ],
+  auto_resolve_timeout: 14_400,
+  acknowledgement_timeout: 600,
+  incident_urgency_rule: {
+    type: "use_support_hours",
+    during_support_hours: { urgency: "high" },
+    outside_support_hours: { urgency: "low" },
+  },
+  support_hours: {
+    type: "fixed_time_per_day",
+    time_zone: "America/New_York",
+    days_of_week: [5, 1, 2, 3, 4, 2],
+    start_time: "09:00:00",
+    end_time: "17:00:00",
+  },
+}
+
+const minimalService: PagerDutyService = {
+  id: "PSVC002",
+  name: "Internal tools",
+  description: null,
+  html_url: null,
+  status: "experimental_state",
+  created_at: "2025-02-03T04:05:06Z",
+  last_incident_timestamp: null,
+  escalation_policy: null,
+  teams: [],
+  integrations: [],
+  auto_resolve_timeout: 0,
+  acknowledgement_timeout: null,
+  incident_urgency_rule: null,
+  support_hours: null,
+}
+
+function numberedIncident(index: number): PagerDutyIncident {
+  return {
+    ...fullIncident,
+    id: `P${String(100_000 + index)}`,
+    incident_number: 10_000 + index,
+  }
+}
+
+function numberedService(index: number): PagerDutyService {
+  return {
+    ...fullService,
+    id: `P${String(200_000 + index)}`,
+    name: `Service ${index}`,
+  }
+}
+
+function onCall(overrides: Partial<PagerDutyOnCall> = {}): PagerDutyOnCall {
+  return {
+    escalation_policy: { id: "PPOL001", summary: "Commerce escalation" },
+    user: { id: "PUSR001", summary: "Ada Lovelace" },
+    schedule: { id: "PSCHED1", summary: "Primary rotation" },
+    escalation_level: 1,
+    start: "2026-07-02T08:00:00Z",
+    end: "2026-07-02T16:00:00Z",
+    ...overrides,
+  }
+}
+
+function fullOperationalContext() {
+  return buildServiceOperationalContext(
+    ["PPOL001"],
+    [
+      onCall({ user: { id: "PUSR002", summary: "Grace Hopper" } }),
+      onCall({ user: { id: "PUSR001", summary: "Ada Lovelace" } }),
+      onCall({ user: { id: "PUSR003", summary: "Ada Lovelace" } }),
+      onCall({
+        escalation_level: 2,
+        user: { id: "PUSR004", summary: "Ignored Level Two" },
+      }),
+    ]
+  )
+}
+
+function config(overrides: Partial<PagerDutyConfig> = {}): PagerDutyConfig {
+  return {
+    region: "us",
+    incidentLookbackDays: 90,
+    serviceIds: [],
+    teamIds: [],
+    ...overrides,
+  }
+}
+
+function incidentPage(
+  resources: PagerDutyIncident[],
+  options: Partial<PagerDutyOffsetPage<PagerDutyIncident>> = {}
+): PagerDutyOffsetPage<PagerDutyIncident> {
+  return {
+    resources,
+    offset: 0,
+    limit: 100,
+    total: resources.length,
+    more: false,
+    nextOffset: undefined,
+    ...options,
+  }
+}
+
+function servicePage(
+  resources: PagerDutyService[],
+  options: Partial<PagerDutyOffsetPage<PagerDutyService>> = {}
+): PagerDutyOffsetPage<PagerDutyService> {
+  return {
+    resources,
+    offset: 0,
+    limit: 100,
+    total: resources.length,
+    more: false,
+    nextOffset: undefined,
+    ...options,
+  }
+}
+
+test("worker manifest preserves user-first schemas, schedules, and shared pacing", () => {
+  assert.deepEqual(
+    worker.manifest.databases.map((database) => ({
+      key: database.key,
+      title: database.config.initialTitle,
+      primaryKey: database.config.primaryKeyProperty,
+      icon: database.config.schema.databaseIcon,
+      firstSix: Object.keys(database.config.schema.properties).slice(0, 6),
+    })),
+    [
+      {
+        key: "incidents",
+        title: "PagerDuty Incidents",
+        primaryKey: "PagerDuty Incident ID",
+        icon: { type: "notion", icon: "alarm", color: "red" },
+        firstSix: [
+          "Title",
+          "Status",
+          "Urgency",
+          "Assigned To",
+          "Incident Link",
+          "Service",
+        ],
+      },
+      {
+        key: "services",
+        title: "PagerDuty Services",
+        primaryKey: "PagerDuty Service ID",
+        icon: { type: "notion", icon: "server", color: "blue" },
+        firstSix: [
+          "Name",
+          "Response State",
+          "Primary On Call",
+          "Primary Coverage",
+          "Teams",
+          "Service Link",
+        ],
+      },
+    ]
+  )
+
+  type SyncConfig = {
+    databaseKey: string
+    mode: string
+    schedule: { type: string; intervalMs: number }
+  }
+  assert.deepEqual(
+    worker.manifest.capabilities.map((capability) => {
+      assert.equal(capability._tag, "sync")
+      const sync = capability.config as SyncConfig
+      return {
+        key: capability.key,
+        databaseKey: sync.databaseKey,
+        mode: sync.mode,
+        intervalMs: sync.schedule.intervalMs,
+      }
+    }),
+    [
+      {
+        key: "incidentsSync",
+        databaseKey: "incidents",
+        mode: "replace",
+        intervalMs: 5 * 60_000,
+      },
+      {
+        key: "servicesSync",
+        databaseKey: "services",
+        mode: "replace",
+        intervalMs: 5 * 60_000,
+      },
+    ]
+  )
+  assert.deepEqual(worker.manifest.pacers, [
+    {
+      key: "pagerduty",
+      config: { allowedRequests: 120, intervalMs: 60_000 },
+    },
+  ])
+})
+
+test("acknowledged incident maps available properties in schema order", () => {
+  const change = incidentToChange(fullIncident)
+
+  assert.equal(change.key, "PINC001")
+  assert.equal(change.upstreamUpdatedAt, fullIncident.updated_at)
+  assert.deepEqual(
+    Object.keys(change.properties),
+    Object.keys(incidentSchema.properties).filter(
+      (property) =>
+        property !== "Resolved" && property !== "Resolution Duration (min)"
+    )
+  )
+  assertPropertyContains(change.properties.Title, "Checkout latency above SLO")
+  assertPropertyContains(change.properties.Status, "Acknowledged")
+  assertPropertyContains(change.properties["Assigned To"], "Ada Lovelace")
+  assertPropertyContains(change.properties["Assigned To"], "Grace Hopper")
+  assert.equal(
+    propertyText(change.properties["Assigned To"]).match(/Ada Lovelace/g)
+      ?.length,
+    1
+  )
+  assertPropertyContains(change.properties.Service, "PSVC001")
+  assertPropertyContains(change.properties["Incident Type"], "Major Incident")
+  assertPropertyContains(
+    change.properties["Last Changed By"],
+    "PagerDuty Automation"
+  )
+  assertPropertyContains(change.properties["Next Automatic Action"], "Escalate")
+  assertPropertyContains(change.properties["Next Action At"], "12:15")
+  assertPropertyContains(
+    change.properties["Conference Link"],
+    "https://meet.example.com/checkout"
+  )
+  assertPropertyContains(
+    change.properties["Conference Dial-in"],
+    "+1 415-555-1212,,,,1234#"
+  )
+  assertPropertyContains(change.properties.Teams, "Commerce")
+  assertPropertyContains(change.properties.Teams, "SRE")
+  assertPropertyContains(change.properties["Assigned Via"], "Direct Assignment")
+  assertPropertyContains(change.properties["Total Alert Count"], "8")
+  assertPropertyContains(change.properties["Active Alert Count"], "2")
+  assertPropertyContains(change.properties["Last Acknowledged"], "12:06")
+
+  assert.ok(change.pageContentMarkdown)
+  assert.match(change.pageContentMarkdown, /checkout SLO/)
+  assert.match(change.pageContentMarkdown, /database/)
+  assert.match(change.pageContentMarkdown, /Runbook/)
+  assert.doesNotMatch(change.pageContentMarkdown, /must-not-appear/)
+  assert.doesNotMatch(change.pageContentMarkdown, /<strong>/)
+  assert.ok(change.pageContentMarkdown.length <= MAX_PAGE_CONTENT_CHARACTERS)
+
+  const visible = propertyText(change.properties)
+  assert.doesNotMatch(
+    visible,
+    /PUSR001|PUSR002|PTEAM01|PTEAM02|PPOL001|PAGENT1/
+  )
+})
+
+test("resolved incident maps its resolution without stale current ownership", () => {
+  const change = incidentToChange({
+    ...fullIncident,
+    status: "resolved",
+    assignments: [],
+    acknowledgements: [],
+    resolved_at: "2026-07-02T12:45:00Z",
+  })
+
+  assertPropertyContains(change.properties.Resolved, "12:45")
+  assertPropertyContains(change.properties["Resolution Duration (min)"], "45")
+  assert.equal("Assigned To" in change.properties, false)
+  assert.equal("Acknowledged By" in change.properties, false)
+  assert.equal("Last Acknowledged" in change.properties, false)
+})
+
+test("incident operational helpers are deterministic and omit unsafe values", () => {
+  assert.deepEqual(
+    nextAutomaticAction([
+      { type: "urgency_change", at: "2026-07-02T12:10:00Z", to: "low" },
+      { type: "urgency_change", at: "2026-07-02T12:10:00Z", to: "high" },
+      { type: "resolve", at: "2026-07-02T12:20:00Z" },
+      { type: "ignored", at: "not-a-date" },
+    ]),
+    {
+      label: "Urgency Change to High",
+      at: "2026-07-02T12:10:00Z",
+    }
+  )
+  assert.equal(
+    durationMinutes("2026-07-02T12:00:00Z", "2026-07-02T12:01:30Z"),
+    1.5
+  )
+  assert.equal(
+    durationMinutes("2026-07-02T12:01:00Z", "2026-07-02T12:00:00Z"),
+    null
+  )
+  assert.equal(safeWebUrl("javascript:alert(1)"), null)
+  assert.equal(
+    safeWebUrl("https://meet.example.com/room?access_token=secret"),
+    null
+  )
+  assert.equal(
+    safeWebUrl("https://meet.example.com/room#access_token=secret"),
+    null
+  )
+  assert.equal(
+    safeWebUrl("https://meet.example.com/room#access%5Ftoken%3Dsecret"),
+    null
+  )
+  assert.equal(
+    safeWebUrl("https://meet.example.com/room#war-room"),
+    "https://meet.example.com/room#war-room"
+  )
+
+  const unsafeConference = incidentToChange({
+    ...minimalIncident,
+    html_url: "https://acme.pagerduty.com/incidents/PINC002#api_token=secret",
+    conference_bridge: {
+      conference_url: "https://user:password@meet.example.com/room",
+      conference_number: "+1 212-555-0199",
+    },
+    resolved_at: "2026-07-02T12:59:00Z",
+  })
+  assert.equal("Conference Link" in unsafeConference.properties, false)
+  assert.equal("Incident Link" in unsafeConference.properties, false)
+  assertPropertyContains(
+    unsafeConference.properties["Conference Dial-in"],
+    "+1 212-555-0199"
+  )
+  assert.equal(
+    "Resolution Duration (min)" in unsafeConference.properties,
+    false
+  )
+})
+
+test("incident alert counts preserve meaningful zero values", () => {
+  const change = incidentToChange({
+    ...minimalIncident,
+    alert_counts: { all: 0, triggered: 0, resolved: 0 },
+  })
+
+  assertPropertyContains(change.properties["Total Alert Count"], "0")
+  assertPropertyContains(change.properties["Active Alert Count"], "0")
+})
+
+test("minimal incident omits unresolved and absent optional values", () => {
+  const change = incidentToChange(minimalIncident)
+
+  assert.deepEqual(Object.keys(change.properties), [
+    "Title",
+    "Status",
+    "Updated",
+    "Created",
+    "Incident Number",
+    "PagerDuty Incident ID",
+  ])
+  assertPropertyContains(change.properties.Title, "Unknown workflow state")
+  assertPropertyContains(change.properties.Status, "Custom New State")
+  assert.equal("pageContentMarkdown" in change, false)
+  assert.equal("Incident Link" in change.properties, false)
+  assert.equal("Assigned To" in change.properties, false)
+  assert.equal("Acknowledged By" in change.properties, false)
+  assert.equal("Priority" in change.properties, false)
+})
+
+test("service transform preserves ownership, bounded content, and timeouts", () => {
+  const observedAt = "2026-07-02T14:00:00.000Z"
+  const change = serviceToChange(
+    fullService,
+    observedAt,
+    fullOperationalContext()
+  )
+
+  assert.equal(change.key, "PSVC001")
+  assert.equal(change.upstreamUpdatedAt, observedAt)
+  assert.deepEqual(
+    Object.keys(change.properties),
+    Object.keys(serviceSchema.properties)
+  )
+  assertPropertyContains(
+    change.properties["Response State"],
+    "Awaiting Response"
+  )
+  assertPropertyContains(change.properties["Primary Coverage"], "Covered")
+  const primaryOnCall = propertyText(change.properties["Primary On Call"])
+  assert.match(primaryOnCall, /Ada Lovelace/)
+  assert.match(primaryOnCall, /Grace Hopper/)
+  assert.equal(primaryOnCall.match(/Ada Lovelace/g)?.length, 1)
+  assert.ok(
+    primaryOnCall.indexOf("Ada Lovelace") <
+      primaryOnCall.indexOf("Grace Hopper")
+  )
+  assert.doesNotMatch(primaryOnCall, /Ignored Level Two/)
+  assertPropertyContains(change.properties.Teams, "Commerce")
+  assertPropertyContains(change.properties.Integrations, "Datadog")
+  assertPropertyContains(change.properties.Integrations, "CloudWatch")
+  assert.equal(
+    propertyText(change.properties.Integrations).match(/CloudWatch/g)?.length,
+    1
+  )
+  assertPropertyContains(change.properties["Integration Count"], "3")
+  assertPropertyContains(
+    change.properties["Support Hours"],
+    "Mon–Fri 09:00–17:00 (America/New_York)"
+  )
+  assertPropertyContains(
+    change.properties["Urgency Rule"],
+    "High During Support Hours / Low Outside"
+  )
+  assertPropertyContains(change.properties["Auto Resolve (min)"], "240")
+  assertPropertyContains(change.properties["Re-trigger After Ack (min)"], "10")
+  assertPropertyContains(change.properties.Description, "truncated")
+  assert.ok(change.pageContentMarkdown)
+  assert.match(change.pageContentMarkdown, /\\\*and\\\*/)
+})
+
+test("minimal service omits disabled timeouts and missing context", () => {
+  const change = serviceToChange(
+    {
+      ...minimalService,
+      html_url:
+        "https://acme.pagerduty.com/service-directory/PSVC002?api_token=secret",
+    },
+    "2026-07-02T14:00:00.000Z",
+    new Map()
+  )
+
+  assert.deepEqual(Object.keys(change.properties), [
+    "Name",
+    "Response State",
+    "Primary Coverage",
+    "Coverage Checked",
+    "Integration Count",
+    "Created",
+    "PagerDuty Service ID",
+  ])
+  assertPropertyContains(
+    change.properties["Response State"],
+    "Experimental State"
+  )
+  assertPropertyContains(
+    change.properties["Primary Coverage"],
+    "No Escalation Policy"
+  )
+  assertPropertyContains(change.properties["Integration Count"], "0")
+  assert.equal("pageContentMarkdown" in change, false)
+  assert.equal("Service Link" in change.properties, false)
+  assert.equal("Auto Resolve (min)" in change.properties, false)
+})
+
+test("service response state and coverage distinguish every operational case", () => {
+  const covered = fullOperationalContext()
+  const gap = buildServiceOperationalContext(["PPOL001"], [])
+
+  assert.deepEqual(covered.get("PPOL001"), {
+    covered: true,
+    primaryOnCall: ["Ada Lovelace", "Grace Hopper"],
+  })
+  assert.deepEqual(gap.get("PPOL001"), {
+    covered: false,
+    primaryOnCall: [],
+  })
+
+  const states = [
+    ["active", "No Open Incidents"],
+    ["warning", "Response in Progress"],
+    ["critical", "Awaiting Response"],
+    ["maintenance", "Maintenance"],
+  ] as const
+  for (const [status, expected] of states) {
+    const change = serviceToChange(
+      { ...fullService, status },
+      "2026-07-02T14:00:00Z",
+      covered
+    )
+    assertPropertyContains(change.properties["Response State"], expected)
+    assertPropertyContains(change.properties["Primary Coverage"], "Covered")
+  }
+
+  const gapChange = serviceToChange(
+    { ...fullService, status: "active" },
+    "2026-07-02T14:00:00Z",
+    gap
+  )
+  assertPropertyContains(
+    gapChange.properties["Primary Coverage"],
+    "No Primary On Call"
+  )
+  assert.equal("Primary On Call" in gapChange.properties, false)
+
+  const disabled = serviceToChange(
+    { ...fullService, status: "disabled" },
+    "2026-07-02T14:00:00Z",
+    new Map()
+  )
+  assertPropertyContains(disabled.properties["Response State"], "Disabled")
+  assertPropertyContains(
+    disabled.properties["Primary Coverage"],
+    "Not Applicable"
+  )
+
+  assert.throws(
+    () => serviceToChange(fullService, "2026-07-02T14:00:00Z", new Map()),
+    /absent from the on-call coverage snapshot/
+  )
+  assert.equal(
+    supportHoursLabel(fullService.support_hours),
+    "Mon–Fri 09:00–17:00 (America/New_York)"
+  )
+})
+
+test("display and content helpers preserve unknowns while protecting secrets", () => {
+  assert.equal(humanizeEnum("api"), "API")
+  assert.equal(humanizeEnum("future_status"), "Future Status")
+  assert.equal(referenceName({ id: "PUSR004" }), null)
+  assert.equal(referenceName({ id: "PUSR004", name: "Named" }), "Named")
+  assert.equal(
+    urgencyRuleLabel({ type: "constant", urgency: "high" }),
+    "Always High"
+  )
+  assert.equal(INCIDENT_WINDOW_DAYS, 7)
+
+  const json = boundedSafeJson({
+    value: "safe",
+    headers: { Authorization: "secret" },
+    api_token: "secret",
+  })
+  assert.ok(json)
+  assert.match(json, /safe/)
+  assert.match(json, /\[REDACTED\]/)
+  assert.doesNotMatch(json, /"secret"/)
+
+  const content = incidentPageContent({
+    first_trigger_log_entry: {
+      event_details: { description: "Safe trigger summary" },
+      channel: {
+        type: "api",
+        description: "Safe monitoring description",
+        details: {
+          host: "sensitive-hostname",
+          api_token: "must-not-appear",
+        },
+      },
+      contexts: [
+        {
+          type: "link",
+          text: "Credential URL",
+          href: "https://user:password@example.com/runbook",
+        },
+      ],
+    },
+  })
+  assert.match(content, /Safe trigger summary/)
+  assert.match(content, /Safe monitoring description/)
+  assert.doesNotMatch(content, /user:password/)
+  assert.doesNotMatch(content, /sensitive-hostname|must-not-appear/)
+
+  const webContent = incidentPageContent({
+    first_trigger_log_entry: {
+      channel: {
+        type: "web_trigger",
+        details: "Operator reported degraded checkout.",
+      },
+    },
+  })
+  assert.equal(webContent, "")
+})
+
+test("configuration defaults, normalizes filters, and selects the EU host", () => {
+  assert.deepEqual(getPagerDutyConfig({}), config())
+  assert.deepEqual(
+    getPagerDutyConfig({
+      PAGERDUTY_REGION: " EU ",
+      PAGERDUTY_INCIDENT_LOOKBACK_DAYS: "30",
+      PAGERDUTY_SERVICE_IDS: "PSVC001, PSVC002,PSVC001",
+      PAGERDUTY_TEAM_IDS: "PTEAM01,PTEAM01, PTEAM02",
+    }),
+    config({
+      region: "eu",
+      incidentLookbackDays: 30,
+      serviceIds: ["PSVC001", "PSVC002"],
+      teamIds: ["PTEAM01", "PTEAM02"],
+    })
+  )
+
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_REGION: "ap" }),
+    /either "us" or "eu"/
+  )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_INCIDENT_LOOKBACK_DAYS: "180.5" }),
+    /integer from 1 to 180/
+  )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_INCIDENT_LOOKBACK_DAYS: "181" }),
+    /integer from 1 to 180/
+  )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "bad/id" }),
+    /invalid PagerDuty ID/
+  )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "PSVC01" }),
+    /invalid PagerDuty ID/
+  )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_SERVICE_IDS: "psvc001" }),
+    /invalid PagerDuty ID/
+  )
+  assert.throws(
+    () => getPagerDutyConfig({ PAGERDUTY_TEAM_IDS: ",," }),
+    /at least one PagerDuty ID/
+  )
+})
+
+test("incident client sends pinned scope, embeds, auth, and pacing", async () => {
+  let requestUrl: URL | undefined
+  let requestInit: RequestInit | undefined
+  let paced = 0
+  const client = createPagerDutyClient({
+    beforeRequest: async () => {
+      paced++
+    },
+    getApiToken: () => TEST_TOKEN,
+    fetch: async (input, init) => {
+      requestUrl = new URL(String(input))
+      requestInit = init
+      return Response.json({
+        incidents: [fullIncident],
+        offset: 0,
+        limit: 100,
+        total: 1,
+        more: false,
+      })
+    },
+  })
+  const scope = config({
+    region: "eu",
+    serviceIds: ["PSVC001", "PSVC002"],
+    teamIds: ["PTEAM01"],
+  })
+
+  const page = await client.fetchIncidentsPage(scope, {
+    since: "2026-07-01T00:00:00.000Z",
+    until: "2026-07-02T00:00:00.000Z",
+  })
+
+  assert.equal(paced, 1)
+  assert.equal(page.resources[0].id, "PINC001")
+  assert.equal(page.nextOffset, undefined)
+  assert.equal(requestUrl?.origin, "https://api.eu.pagerduty.com")
+  assert.equal(requestUrl?.pathname, "/incidents")
+  assert.equal(requestUrl?.searchParams.get("limit"), "100")
+  assert.equal(requestUrl?.searchParams.get("total"), "true")
+  assert.equal(requestUrl?.searchParams.get("date_range"), null)
+  assert.deepEqual(requestUrl?.searchParams.getAll("statuses[]"), [])
+  assert.equal(requestUrl?.searchParams.get("sort_by"), "incident_number:asc")
+  assert.deepEqual(requestUrl?.searchParams.getAll("service_ids[]"), [
+    "PSVC001",
+    "PSVC002",
+  ])
+  assert.deepEqual(requestUrl?.searchParams.getAll("team_ids[]"), ["PTEAM01"])
+  assert.deepEqual(requestUrl?.searchParams.getAll("include[]"), [
+    "assignees",
+    "acknowledgers",
+    "priorities",
+    "teams",
+    "escalation_policies",
+    "first_trigger_log_entries",
+    "conference_bridge",
+  ])
+
+  const headers = new Headers(requestInit?.headers)
+  assert.equal(headers.get("authorization"), `Token token=${TEST_TOKEN}`)
+  assert.equal(
+    headers.get("accept"),
+    "application/vnd.pagerduty+json;version=2"
+  )
+  assert.equal(requestInit?.redirect, "error")
+})
+
+test("open incident traversal ignores age while retaining operational statuses", async () => {
+  let requestUrl: URL | undefined
+  const client = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async (input) => {
+      requestUrl = new URL(String(input))
+      return Response.json({
+        incidents: [fullIncident],
+        offset: 0,
+        limit: 100,
+        total: 1,
+        more: false,
+      })
+    },
+  })
+
+  await client.fetchIncidentsPage(config({ incidentPhase: "open" }), {
+    since: "2026-01-01T00:00:00.000Z",
+    until: "2026-07-02T00:00:00.000Z",
+  })
+
+  assert.equal(requestUrl?.searchParams.get("date_range"), "all")
+  assert.deepEqual(requestUrl?.searchParams.getAll("statuses[]"), [
+    "triggered",
+    "acknowledged",
+  ])
+  assert.equal(requestUrl?.searchParams.get("since"), null)
+  assert.equal(requestUrl?.searchParams.get("until"), null)
+})
+
+test("service client requests stable ordering and total counts", async () => {
+  let requestUrl: URL | undefined
+  const client = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async (input) => {
+      requestUrl = new URL(String(input))
+      return Response.json({
+        services: Array.from({ length: 100 }, (_, index) =>
+          numberedService(index)
+        ),
+        offset: 100,
+        limit: 100,
+        total: 201,
+        more: true,
+      })
+    },
+  })
+
+  const page = await client.fetchServicesPage(
+    config({ teamIds: ["PTEAM01"] }),
+    100
+  )
+  assert.equal(page.nextOffset, 200)
+  assert.equal(requestUrl?.searchParams.get("sort_by"), "name:asc")
+  // Service team ownership is current state, while incident team membership is
+  // historical. Do not filter services by team or old incidents can lose their
+  // relation target after a service moves between teams.
+  assert.deepEqual(requestUrl?.searchParams.getAll("team_ids[]"), [])
+  assert.deepEqual(requestUrl?.searchParams.getAll("include[]"), [
+    "teams",
+    "escalation_policies",
+  ])
+  assert.deepEqual(requestUrl?.searchParams.getAll("service_ids[]"), [])
+})
+
+test("configured services use bounded show requests instead of an account scan", async () => {
+  const requestUrls: URL[] = []
+  const client = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async (input) => {
+      requestUrls.push(new URL(String(input)))
+      return Response.json({ service: fullService })
+    },
+  })
+
+  const page = await client.fetchServicesPage(
+    config({ serviceIds: ["PSVC001"] })
+  )
+
+  assert.equal(page.total, 1)
+  assert.equal(page.more, false)
+  assert.deepEqual(
+    page.resources.map((service) => service.id),
+    ["PSVC001"]
+  )
+  assert.equal(requestUrls.length, 1)
+  assert.equal(requestUrls[0].pathname, "/services/PSVC001")
+  assert.deepEqual(requestUrls[0].searchParams.getAll("include[]"), [
+    "teams",
+    "escalation_policies",
+  ])
+})
+
+test("current on-calls use one pinned regional snapshot and complete pagination", async () => {
+  const observedAt = "2026-07-02T14:00:00.000Z"
+  const requestUrls: URL[] = []
+  let paced = 0
+  const firstPage = Array.from({ length: 100 }, (_, index) =>
+    onCall({
+      escalation_policy: {
+        id: index % 2 === 0 ? "PPOL001" : "PPOL002",
+        summary: `Policy ${index % 2}`,
+      },
+      user: {
+        id: `PUSR${String(index).padStart(3, "0")}`,
+        summary: `User ${index}`,
+      },
+      ...(index === 0 ? { schedule: null, start: null, end: null } : {}),
+    })
+  )
+  const client = createPagerDutyClient({
+    beforeRequest: async () => {
+      paced++
+    },
+    getApiToken: () => TEST_TOKEN,
+    fetch: async (input) => {
+      const url = new URL(String(input))
+      requestUrls.push(url)
+      const offset = Number(url.searchParams.get("offset"))
+      return Response.json(
+        offset === 0
+          ? {
+              oncalls: firstPage,
+              offset: 0,
+              limit: 100,
+              total: 101,
+              more: true,
+            }
+          : {
+              // A stable duplicate may represent two indistinguishable rules.
+              oncalls: [firstPage[0]],
+              offset: 100,
+              limit: 100,
+              total: 101,
+              more: false,
+            }
+      )
+    },
+  })
+
+  const current = await client.fetchCurrentOnCalls(
+    config({ region: "eu" }),
+    ["PPOL002", "PPOL001", "PPOL002"],
+    observedAt
+  )
+
+  assert.equal(paced, 4)
+  assert.equal(current.length, 100)
+  assert.equal(current[0].start, null)
+  assert.equal(current[0].end, null)
+  assert.equal(requestUrls.length, 4)
+  assert.deepEqual(
+    requestUrls.map((url) => url.origin),
+    Array(4).fill("https://api.eu.pagerduty.com")
+  )
+  assert.deepEqual(
+    requestUrls.map((url) => url.pathname),
+    Array(4).fill("/oncalls")
+  )
+  assert.deepEqual(
+    requestUrls.map((url) => url.searchParams.get("offset")),
+    ["0", "100", "0", "100"]
+  )
+  for (const url of requestUrls) {
+    assert.equal(url.searchParams.get("limit"), "100")
+    assert.equal(url.searchParams.get("total"), "true")
+    assert.equal(url.searchParams.get("since"), observedAt)
+    assert.equal(url.searchParams.get("until"), observedAt)
+    assert.deepEqual(url.searchParams.getAll("escalation_policy_ids[]"), [
+      "PPOL002",
+      "PPOL001",
+    ])
+    assert.deepEqual(url.searchParams.getAll("include[]"), [])
+  }
+
+  let onePageRequests = 0
+  const onePage = createPagerDutyClient({
+    beforeRequest: async () => {
+      onePageRequests++
+    },
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        oncalls: [onCall()],
+        offset: 0,
+        limit: 100,
+        total: 1,
+        more: false,
+      }),
+  })
+  assert.equal(
+    (await onePage.fetchCurrentOnCalls(config(), ["PPOL001"], observedAt))
+      .length,
+    1
+  )
+  assert.equal(onePageRequests, 1)
+
+  let emptyRequests = 0
+  const empty = createPagerDutyClient({
+    beforeRequest: async () => {
+      throw new Error("Empty policy scope must not pace an HTTP request.")
+    },
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () => {
+      emptyRequests++
+      throw new Error("Empty policy scope must not fetch.")
+    },
+  })
+  assert.deepEqual(
+    await empty.fetchCurrentOnCalls(config(), [], observedAt),
+    []
+  )
+  assert.equal(emptyRequests, 0)
+})
+
+test("current on-call traversal fails closed on malformed or shifting pages", async () => {
+  const observedAt = "2026-07-02T14:00:00Z"
+  const malformedEntry = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        oncalls: [onCall({ escalation_level: 0 })],
+        offset: 0,
+        limit: 100,
+        total: 1,
+        more: false,
+      }),
+  })
+  await assert.rejects(
+    () => malformedEntry.fetchCurrentOnCalls(config(), ["PPOL001"], observedAt),
+    /invalid escalation_level/
+  )
+
+  const malformedPagination = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        oncalls: [onCall()],
+        offset: 0,
+        limit: 100,
+        total: null,
+        more: false,
+      }),
+  })
+  await assert.rejects(
+    () =>
+      malformedPagination.fetchCurrentOnCalls(
+        config(),
+        ["PPOL001"],
+        observedAt
+      ),
+    /invalid total/
+  )
+
+  let changingPage = 0
+  const changingTotal = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () => {
+      changingPage++
+      if (changingPage === 1) {
+        return Response.json({
+          oncalls: Array.from({ length: 100 }, (_, index) =>
+            onCall({ user: { id: `PUSR${index}`, summary: `User ${index}` } })
+          ),
+          offset: 0,
+          limit: 100,
+          total: 102,
+          more: true,
+        })
+      }
+      return Response.json({
+        oncalls: [
+          onCall({ user: { id: "PUSR100", summary: "User 100" } }),
+          onCall({ user: { id: "PUSR101", summary: "User 101" } }),
+          onCall({ user: { id: "PUSR102", summary: "User 102" } }),
+        ],
+        offset: 100,
+        limit: 100,
+        total: 103,
+        more: false,
+      })
+    },
+  })
+  await assert.rejects(
+    () => changingTotal.fetchCurrentOnCalls(config(), ["PPOL001"], observedAt),
+    /total changed during pagination \(102 to 103\)/
+  )
+
+  let confirmationCall = 0
+  const shiftingIdentity = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async (input) => {
+      confirmationCall++
+      const offset = Number(new URL(String(input)).searchParams.get("offset"))
+      if (offset === 0) {
+        return Response.json({
+          oncalls: Array.from({ length: 100 }, (_, index) =>
+            onCall({
+              user: { id: `PUSR${index}`, summary: `User ${index}` },
+            })
+          ),
+          offset: 0,
+          limit: 100,
+          total: 101,
+          more: true,
+        })
+      }
+      return Response.json({
+        oncalls: [
+          onCall({
+            user:
+              confirmationCall === 2
+                ? { id: "PUSR100", summary: "User 100" }
+                : { id: "PUSR999", summary: "Shifted user" },
+          }),
+        ],
+        offset: 100,
+        limit: 100,
+        total: 101,
+        more: false,
+      })
+    },
+  })
+  await assert.rejects(
+    () =>
+      shiftingIdentity.fetchCurrentOnCalls(config(), ["PPOL001"], observedAt),
+    /identities changed between confirmation traversals/
+  )
+  assert.equal(confirmationCall, 4)
+
+  const oversized = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        oncalls: Array.from({ length: 100 }, (_, index) =>
+          onCall({ user: { id: `PUSR${index}`, summary: `User ${index}` } })
+        ),
+        offset: 0,
+        limit: 100,
+        total: 10_001,
+        more: true,
+      }),
+  })
+  await assert.rejects(
+    () => oversized.fetchCurrentOnCalls(config(), ["PPOL001"], observedAt),
+    /more than 10,000 current on-call entries/
+  )
+
+  await assert.rejects(
+    () => oversized.fetchCurrentOnCalls(config(), ["PPOL001"], "not-a-date"),
+    /valid ISO 8601 timestamp/
+  )
+})
+
+test("client fails explicitly above PagerDuty classic-pagination limits", async () => {
+  const oversizedIncidents = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        incidents: Array.from({ length: 100 }, (_, index) =>
+          numberedIncident(index)
+        ),
+        offset: 0,
+        limit: 100,
+        total: 10_001,
+        more: true,
+      }),
+  })
+  await assert.rejects(
+    () =>
+      oversizedIncidents.fetchIncidentsPage(config({ incidentPhase: "open" }), {
+        since: "2026-07-01T00:00:00.000Z",
+        until: "2026-07-02T00:00:00.000Z",
+      }),
+    /more than 10,000 open incidents/
+  )
+
+  const oversizedServices = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        services: Array.from({ length: 100 }, (_, index) =>
+          numberedService(index)
+        ),
+        offset: 0,
+        limit: 100,
+        total: 10_001,
+        more: true,
+      }),
+  })
+  await assert.rejects(
+    () => oversizedServices.fetchServicesPage(config()),
+    /more than 10,000 services/
+  )
+})
+
+test("rate-limit parsing honors the longest PagerDuty delay", async () => {
+  const now = Date.parse("2026-07-02T12:00:00Z")
+  assert.equal(parseRetryAfterSeconds("7", now), 7)
+  assert.equal(parseRetryAfterSeconds("Thu, 02 Jul 2026 12:00:09 GMT", now), 9)
+  assert.equal(
+    rateLimitRetryAfterSeconds(
+      new Headers({ "Retry-After": "7", "ratelimit-reset": "11" }),
+      now
+    ),
+    11
+  )
+
+  const client = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      new Response("", {
+        status: 429,
+        headers: { "Retry-After": "13" },
+      }),
+  })
+  await assert.rejects(
+    () => client.fetchServicesPage(config()),
+    (error: unknown) => {
+      assert.ok(error instanceof RateLimitError)
+      assert.equal(error.retryAfter, 13)
+      return true
+    }
+  )
+})
+
+test("client fails closed on malformed pagination, JSON, and API errors", async () => {
+  const malformed = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        services: [fullService],
+        offset: 1,
+        limit: 100,
+        total: null,
+        more: false,
+      }),
+  })
+  await assert.rejects(
+    () => malformed.fetchServicesPage(config()),
+    /invalid total/
+  )
+
+  const partialPage = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () =>
+      Response.json({
+        services: [fullService],
+        offset: 0,
+        limit: 100,
+        total: 101,
+        more: true,
+      }),
+  })
+  await assert.rejects(
+    () => partialPage.fetchServicesPage(config()),
+    /partial page while more records remained/
+  )
+
+  const invalidJson = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () => new Response("not json", { status: 200 }),
+  })
+  await assert.rejects(
+    () => invalidJson.fetchServicesPage(config()),
+    /invalid JSON/
+  )
+
+  const apiError = createPagerDutyClient({
+    beforeRequest: async () => {},
+    getApiToken: () => TEST_TOKEN,
+    fetch: async () => new Response(`bad token ${TEST_TOKEN}`, { status: 403 }),
+  })
+  await assert.rejects(
+    () => apiError.fetchServicesPage(config()),
+    (error: unknown) => {
+      assert.ok(error instanceof Error)
+      assert.doesNotMatch(error.message, new RegExp(TEST_TOKEN))
+      assert.match(error.message, /Unexpected non-JSON error response/)
+      return true
+    }
+  )
+})
+
+test("execute functions wire client, state, and transforms end to end", async () => {
+  let incidentRequest = 0
+  let onCallRequests = 0
+  const client: PagerDutyClient = {
+    async fetchIncidentsPage(scope) {
+      incidentRequest++
+      if (incidentRequest <= 2) {
+        assert.equal(
+          scope.incidentPhase,
+          incidentRequest === 1 ? "open" : "openConfirm"
+        )
+        return incidentPage([], { total: 0 })
+      }
+
+      assert.equal(scope.incidentPhase, "recent")
+      return incidentPage([fullIncident])
+    },
+    async fetchServicesPage(scope, offset) {
+      assert.equal(scope.region, "us")
+      assert.equal(offset, 0)
+      return servicePage([fullService])
+    },
+    async fetchCurrentOnCalls(scope, escalationPolicyIds, observedAt) {
+      onCallRequests++
+      assert.equal(scope.region, "us")
+      assert.deepEqual(escalationPolicyIds, ["PPOL001"])
+      assert.equal(observedAt, "2026-07-02T14:00:00.000Z")
+      return [onCall()]
+    },
+  }
+
+  const openBatch = await executeIncidents(undefined, client, () =>
+    config({ incidentLookbackDays: 1 })
+  )
+  assert.equal(openBatch.hasMore, true)
+  assert.deepEqual(openBatch.changes, [])
+  assert.equal(openBatch.nextState.phase, "openConfirm")
+
+  const confirmBatch = await executeIncidents(
+    openBatch.nextState,
+    client,
+    () => {
+      throw new Error("Pinned state should not re-read configuration.")
+    }
+  )
+  assert.equal(confirmBatch.hasMore, true)
+  assert.deepEqual(confirmBatch.changes, [])
+  assert.equal(confirmBatch.nextState.phase, "recent")
+
+  const recentBatch = await executeIncidents(
+    confirmBatch.nextState,
+    client,
+    () => {
+      throw new Error("Pinned state should not re-read configuration.")
+    }
+  )
+  assert.equal(recentBatch.hasMore, false)
+  assert.equal(recentBatch.changes[0].key, "PINC001")
+
+  const serviceState = initialServiceSyncState(config(), "2026-07-02T14:00:00Z")
+  const serviceBatch = await executeServices(serviceState, client, () => {
+    throw new Error("Pinned state should not re-read configuration.")
+  })
+  assert.equal(serviceBatch.hasMore, false)
+  assert.equal(onCallRequests, 1)
+  assert.equal(serviceBatch.changes[0].key, "PSVC001")
+  assert.equal(
+    serviceBatch.changes[0].upstreamUpdatedAt,
+    "2026-07-02T14:00:00.000Z"
+  )
+  assertPropertyContains(
+    serviceBatch.changes[0].properties["Primary Coverage"],
+    "Covered"
+  )
+  assertPropertyContains(
+    serviceBatch.changes[0].properties["Primary On Call"],
+    "Ada Lovelace"
+  )
+})
+
+test("incident state traverses open incidents before pinned recent windows", () => {
+  const initial = initialIncidentSyncState(
+    config({
+      incidentLookbackDays: 14,
+      serviceIds: ["PSVC001"],
+      teamIds: ["PTEAM01"],
+    }),
+    "2026-07-02T12:00:00Z"
+  )
+  assert.equal(initial.cycleSince, "2026-06-18T12:00:00.000Z")
+  assert.equal(initial.cycleUntil, "2026-07-02T12:00:00.000Z")
+  assert.equal(initial.windowUntil, "2026-06-25T12:00:00.000Z")
+  assert.equal(initial.phase, "open")
+  assert.deepEqual(initial.scope.serviceIds, ["PSVC001"])
+
+  const first = nextIncidentSyncState(
+    initial,
+    incidentPage(
+      [
+        { ...fullIncident, incident_number: 10 },
+        { ...minimalIncident, incident_number: 11 },
+      ],
+      {
+        limit: 2,
+        total: 3,
+        more: true,
+        nextOffset: 2,
+      }
+    )
+  )
+  assert.ok(first)
+  assert.equal(first.offset, 1)
+  assert.equal(first.expectedTotal, 3)
+  assert.equal(first.lastIncidentId, "PINC002")
+  assert.equal(first.lastIncidentNumber, 11)
+
+  const confirmation = nextIncidentSyncState(
+    first,
+    incidentPage(
+      [
+        { ...minimalIncident, incident_number: 11 },
+        { ...fullIncident, id: "PINC003", incident_number: 12 },
+      ],
+      {
+        offset: 1,
+        limit: 2,
+        total: 3,
+      }
+    )
+  )
+  assert.ok(confirmation)
+  assert.equal(confirmation.phase, "openConfirm")
+  assert.deepEqual(confirmation.openIncidentIds, [
+    "PINC001",
+    "PINC002",
+    "PINC003",
+  ])
+
+  const confirmationFirst = nextIncidentSyncState(
+    confirmation,
+    incidentPage(
+      [
+        { ...fullIncident, incident_number: 10 },
+        { ...minimalIncident, incident_number: 11 },
+      ],
+      {
+        limit: 2,
+        total: 3,
+        more: true,
+        nextOffset: 2,
+      }
+    )
+  )
+  assert.ok(confirmationFirst)
+
+  const recent = nextIncidentSyncState(
+    confirmationFirst,
+    incidentPage(
+      [
+        { ...minimalIncident, incident_number: 11 },
+        { ...fullIncident, id: "PINC003", incident_number: 12 },
+      ],
+      {
+        offset: 1,
+        limit: 2,
+        total: 3,
+      }
+    )
+  )
+  assert.ok(recent)
+  assert.equal(recent.phase, "recent")
+  assert.equal(recent.windowSince, initial.cycleSince)
+  assert.equal(recent.windowUntil, initial.windowUntil)
+  assert.equal(recent.offset, 0)
+  assert.equal(recent.expectedTotal, undefined)
+
+  const nextWindow = nextIncidentSyncState(
+    recent,
+    incidentPage([], { total: 0 })
+  )
+  assert.ok(nextWindow)
+  assert.equal(nextWindow.windowSince, initial.windowUntil)
+  assert.equal(nextWindow.windowUntil, initial.cycleUntil)
+  assert.equal(nextWindow.offset, 0)
+  assert.equal(nextWindow.expectedTotal, undefined)
+
+  const oneDayInitial = initialIncidentSyncState(
+    config({ incidentLookbackDays: 1 }),
+    "2026-07-02T12:00:00Z"
+  )
+  const oneDayRecent = nextIncidentSyncState(
+    oneDayInitial,
+    incidentPage([], { total: 0 })
+  )
+  assert.ok(oneDayRecent)
+  assert.equal(oneDayRecent.phase, "openConfirm")
+  const oneDayHistory = nextIncidentSyncState(
+    oneDayRecent,
+    incidentPage([], { total: 0 })
+  )
+  assert.ok(oneDayHistory)
+  assert.equal(oneDayHistory.phase, "recent")
+  assert.equal(
+    nextIncidentSyncState(oneDayHistory, incidentPage([], { total: 0 })),
+    undefined
+  )
+})
+
+test("oversized recent windows bisect and retain their pending boundary", () => {
+  const initial = initialIncidentSyncState(
+    config({ incidentLookbackDays: 7 }),
+    "2026-07-02T12:00:00Z"
+  )
+  const confirmation = nextIncidentSyncState(
+    initial,
+    incidentPage([], { total: 0 })
+  )
+  assert.ok(confirmation)
+  const recent = nextIncidentSyncState(
+    confirmation,
+    incidentPage([], { total: 0 })
+  )
+  assert.ok(recent)
+
+  const split = nextIncidentSyncState(
+    recent,
+    incidentPage([], {
+      total: 10_001,
+      more: true,
+      nextOffset: 100,
+      requiresWindowSplit: true,
+    })
+  )
+  assert.ok(split)
+  assert.equal(split.windowSince, recent.windowSince)
+  assert.ok(Date.parse(split.windowUntil) < Date.parse(recent.windowUntil))
+  assert.deepEqual(split.pendingWindowUntils, [recent.windowUntil])
+
+  const rightHalf = nextIncidentSyncState(split, incidentPage([], { total: 0 }))
+  assert.ok(rightHalf)
+  assert.equal(rightHalf.windowSince, split.windowUntil)
+  assert.equal(rightHalf.windowUntil, recent.windowUntil)
+  assert.deepEqual(rightHalf.pendingWindowUntils, [])
+})
+
+test("open confirmation rejects equal-count identity substitutions", () => {
+  const initial = initialIncidentSyncState(
+    config({ incidentLookbackDays: 1 }),
+    "2026-07-02T12:00:00Z"
+  )
+  const confirmation = nextIncidentSyncState(
+    initial,
+    incidentPage([fullIncident])
+  )
+  assert.ok(confirmation)
+  assert.equal(confirmation.phase, "openConfirm")
+
+  assert.throws(
+    () => nextIncidentSyncState(confirmation, incidentPage([minimalIncident])),
+    /identities changed between confirmation passes/
+  )
+})
+
+test("incident state rejects reordering, changing totals, and stalled offsets", () => {
+  const initial = initialIncidentSyncState(
+    config({ incidentLookbackDays: 1 }),
+    "2026-07-02T12:00:00Z"
+  )
+  const first = nextIncidentSyncState(
+    initial,
+    incidentPage(
+      [
+        { ...fullIncident, incident_number: 20 },
+        { ...minimalIncident, incident_number: 21 },
+      ],
+      {
+        limit: 2,
+        total: 3,
+        more: true,
+        nextOffset: 2,
+      }
+    )
+  )
+  assert.ok(first)
+
+  assert.throws(
+    () =>
+      nextIncidentSyncState(
+        first,
+        incidentPage(
+          [
+            { ...minimalIncident, incident_number: 21 },
+            { ...fullIncident, id: "PINC003", incident_number: 19 },
+          ],
+          {
+            offset: 1,
+            limit: 2,
+            total: 3,
+          }
+        )
+      ),
+    /not strictly ordered/
+  )
+  assert.throws(
+    () =>
+      nextIncidentSyncState(
+        first,
+        incidentPage(
+          [
+            { ...fullIncident, incident_number: 20 },
+            { ...minimalIncident, incident_number: 22 },
+          ],
+          { offset: 1, limit: 2, total: 3 }
+        )
+      ),
+    /membership shifted across the page boundary/
+  )
+  assert.throws(
+    () =>
+      nextIncidentSyncState(
+        first,
+        incidentPage(
+          [
+            { ...minimalIncident, incident_number: 21 },
+            { ...fullIncident, id: "PINC003", incident_number: 22 },
+          ],
+          { offset: 1, limit: 2, total: 4 }
+        )
+      ),
+    /total changed/
+  )
+  assert.throws(
+    () =>
+      nextIncidentSyncState(
+        initial,
+        incidentPage(
+          [
+            { ...fullIncident, incident_number: 20 },
+            { ...minimalIncident, incident_number: 21 },
+          ],
+          {
+            limit: 2,
+            total: 3,
+            more: true,
+            nextOffset: 1,
+          }
+        )
+      ),
+    /too small for boundary overlap/
+  )
+})
+
+test("service state counts unique IDs and rejects mutable-order duplicates", () => {
+  const initial = initialServiceSyncState(
+    config({ serviceIds: ["PSVC001"] }),
+    "2026-07-02T12:00:00Z"
+  )
+  assert.equal(initial.observedAt, "2026-07-02T12:00:00.000Z")
+  assert.deepEqual(initial.scope.serviceIds, ["PSVC001"])
+
+  const first = nextServiceSyncState(
+    initial,
+    servicePage([fullService], {
+      limit: 1,
+      total: 2,
+      more: true,
+      nextOffset: 1,
+    })
+  )
+  assert.ok(first)
+  assert.deepEqual(first.seenServiceIds, ["PSVC001"])
+
+  assert.equal(
+    nextServiceSyncState(
+      first,
+      servicePage([minimalService], {
+        offset: 1,
+        limit: 1,
+        total: 2,
+      })
+    ),
+    undefined
+  )
+  assert.throws(
+    () =>
+      nextServiceSyncState(
+        first,
+        servicePage([fullService], {
+          offset: 1,
+          limit: 1,
+          total: 2,
+        })
+      ),
+    /repeated service PSVC001/
+  )
+  assert.throws(
+    () =>
+      nextServiceSyncState(
+        first,
+        servicePage([minimalService], {
+          offset: 1,
+          limit: 1,
+          total: 3,
+        })
+      ),
+    /total changed/
+  )
+})

--- a/workers/pagerduty-sync/test.ts
+++ b/workers/pagerduty-sync/test.ts
@@ -11,8 +11,12 @@ import {
   durationMinutes,
   humanizeEnum,
   incidentPageContent,
+  MAX_MULTI_SELECT_OPTIONS,
+  MAX_OPTION_NAME_CHARACTERS,
   MAX_PAGE_CONTENT_CHARACTERS,
   nextAutomaticAction,
+  providerOptionLabel,
+  providerOptionLabels,
   referenceName,
   safeWebUrl,
   supportHoursLabel,
@@ -395,10 +399,7 @@ test("acknowledged incident maps available properties in schema order", () => {
   assert.equal(change.upstreamUpdatedAt, fullIncident.updated_at)
   assert.deepEqual(
     Object.keys(change.properties),
-    Object.keys(incidentSchema.properties).filter(
-      (property) =>
-        property !== "Resolved" && property !== "Resolution Duration (min)"
-    )
+    Object.keys(incidentSchema.properties)
   )
   assertPropertyContains(change.properties.Title, "Checkout latency above SLO")
   assertPropertyContains(change.properties.Status, "Acknowledged")
@@ -458,9 +459,9 @@ test("resolved incident maps its resolution without stale current ownership", ()
 
   assertPropertyContains(change.properties.Resolved, "12:45")
   assertPropertyContains(change.properties["Resolution Duration (min)"], "45")
-  assert.equal("Assigned To" in change.properties, false)
-  assert.equal("Acknowledged By" in change.properties, false)
-  assert.equal("Last Acknowledged" in change.properties, false)
+  assert.deepEqual(change.properties["Assigned To"], [])
+  assert.deepEqual(change.properties["Acknowledged By"], [])
+  assert.deepEqual(change.properties["Last Acknowledged"], [])
 })
 
 test("incident operational helpers are deterministic and omit unsafe values", () => {
@@ -511,16 +512,13 @@ test("incident operational helpers are deterministic and omit unsafe values", ()
     },
     resolved_at: "2026-07-02T12:59:00Z",
   })
-  assert.equal("Conference Link" in unsafeConference.properties, false)
-  assert.equal("Incident Link" in unsafeConference.properties, false)
+  assert.deepEqual(unsafeConference.properties["Conference Link"], [])
+  assert.deepEqual(unsafeConference.properties["Incident Link"], [])
   assertPropertyContains(
     unsafeConference.properties["Conference Dial-in"],
     "+1 212-555-0199"
   )
-  assert.equal(
-    "Resolution Duration (min)" in unsafeConference.properties,
-    false
-  )
+  assert.deepEqual(unsafeConference.properties["Resolution Duration (min)"], [])
 })
 
 test("incident alert counts preserve meaningful zero values", () => {
@@ -533,24 +531,21 @@ test("incident alert counts preserve meaningful zero values", () => {
   assertPropertyContains(change.properties["Active Alert Count"], "0")
 })
 
-test("minimal incident omits unresolved and absent optional values", () => {
+test("minimal incident explicitly clears unresolved and absent values", () => {
   const change = incidentToChange(minimalIncident)
 
-  assert.deepEqual(Object.keys(change.properties), [
-    "Title",
-    "Status",
-    "Updated",
-    "Created",
-    "Incident Number",
-    "PagerDuty Incident ID",
-  ])
+  assert.deepEqual(
+    Object.keys(change.properties),
+    Object.keys(incidentSchema.properties)
+  )
   assertPropertyContains(change.properties.Title, "Unknown workflow state")
   assertPropertyContains(change.properties.Status, "Custom New State")
-  assert.equal("pageContentMarkdown" in change, false)
-  assert.equal("Incident Link" in change.properties, false)
-  assert.equal("Assigned To" in change.properties, false)
-  assert.equal("Acknowledged By" in change.properties, false)
-  assert.equal("Priority" in change.properties, false)
+  assert.equal(change.pageContentMarkdown, "")
+  assert.deepEqual(change.properties["Incident Link"], [])
+  assert.deepEqual(change.properties["Assigned To"], [])
+  assert.deepEqual(change.properties["Acknowledged By"], [])
+  assert.deepEqual(change.properties.Priority, [])
+  assert.deepEqual(change.properties.Service, [])
 })
 
 test("service transform preserves ownership, bounded content, and timeouts", () => {
@@ -604,7 +599,7 @@ test("service transform preserves ownership, bounded content, and timeouts", () 
   assert.match(change.pageContentMarkdown, /\\\*and\\\*/)
 })
 
-test("minimal service omits disabled timeouts and missing context", () => {
+test("minimal service explicitly clears timeouts and missing context", () => {
   const change = serviceToChange(
     {
       ...minimalService,
@@ -615,15 +610,10 @@ test("minimal service omits disabled timeouts and missing context", () => {
     new Map()
   )
 
-  assert.deepEqual(Object.keys(change.properties), [
-    "Name",
-    "Response State",
-    "Primary Coverage",
-    "Coverage Checked",
-    "Integration Count",
-    "Created",
-    "PagerDuty Service ID",
-  ])
+  assert.deepEqual(
+    Object.keys(change.properties),
+    Object.keys(serviceSchema.properties)
+  )
   assertPropertyContains(
     change.properties["Response State"],
     "Experimental State"
@@ -633,9 +623,98 @@ test("minimal service omits disabled timeouts and missing context", () => {
     "No Escalation Policy"
   )
   assertPropertyContains(change.properties["Integration Count"], "0")
-  assert.equal("pageContentMarkdown" in change, false)
-  assert.equal("Service Link" in change.properties, false)
-  assert.equal("Auto Resolve (min)" in change.properties, false)
+  assert.equal(change.pageContentMarkdown, "")
+  assert.deepEqual(change.properties["Service Link"], [])
+  assert.deepEqual(change.properties["Auto Resolve (min)"], [])
+  assert.deepEqual(change.properties["Primary On Call"], [])
+  assert.deepEqual(change.properties.Integrations, [])
+  assert.deepEqual(change.properties["Support Hours"], [])
+  assert.deepEqual(change.properties.Description, [])
+})
+
+test("complete upserts clear values that disappear from the same records", () => {
+  const clearedIncident = incidentToChange({
+    ...fullIncident,
+    html_url: null,
+    urgency: null,
+    service: null,
+    assignments: [],
+    priority: null,
+    incident_type: null,
+    last_status_change_by: null,
+    last_status_change_at: null,
+    pending_actions: [],
+    conference_bridge: null,
+    teams: [],
+    escalation_policy: null,
+    alert_counts: null,
+    acknowledgements: [],
+    assigned_via: null,
+    first_trigger_log_entry: null,
+  })
+  assert.equal(clearedIncident.key, fullIncident.id)
+  assert.equal(clearedIncident.pageContentMarkdown, "")
+  for (const property of [
+    "Urgency",
+    "Assigned To",
+    "Incident Link",
+    "Service",
+    "Incident Type",
+    "Last Changed By",
+    "Next Automatic Action",
+    "Next Action At",
+    "Conference Link",
+    "Conference Dial-in",
+    "Resolution Duration (min)",
+    "Priority",
+    "Teams",
+    "Escalation Policy",
+    "Last Status Change",
+    "Total Alert Count",
+    "Active Alert Count",
+    "Acknowledged By",
+    "Last Acknowledged",
+    "Assigned Via",
+    "Resolved",
+  ] as const) {
+    assert.deepEqual(clearedIncident.properties[property], [])
+  }
+
+  const clearedService = serviceToChange(
+    {
+      ...fullService,
+      html_url: null,
+      teams: [],
+      escalation_policy: null,
+      description: null,
+      integrations: [],
+      support_hours: null,
+      last_incident_timestamp: null,
+      incident_urgency_rule: null,
+      auto_resolve_timeout: null,
+      acknowledgement_timeout: null,
+    },
+    "2026-07-02T14:00:00.000Z",
+    new Map()
+  )
+  assert.equal(clearedService.key, fullService.id)
+  assert.equal(clearedService.pageContentMarkdown, "")
+  for (const property of [
+    "Primary On Call",
+    "Teams",
+    "Service Link",
+    "Integrations",
+    "Support Hours",
+    "Last Incident",
+    "Escalation Policy",
+    "Description",
+    "Urgency Rule",
+    "Auto Resolve (min)",
+    "Re-trigger After Ack (min)",
+  ] as const) {
+    assert.deepEqual(clearedService.properties[property], [])
+  }
+  assertPropertyContains(clearedService.properties["Integration Count"], "0")
 })
 
 test("service response state and coverage distinguish every operational case", () => {
@@ -676,7 +755,7 @@ test("service response state and coverage distinguish every operational case", (
     gapChange.properties["Primary Coverage"],
     "No Primary On Call"
   )
-  assert.equal("Primary On Call" in gapChange.properties, false)
+  assert.deepEqual(gapChange.properties["Primary On Call"], [])
 
   const disabled = serviceToChange(
     { ...fullService, status: "disabled" },
@@ -754,6 +833,83 @@ test("display and content helpers preserve unknowns while protecting secrets", (
     },
   })
   assert.equal(webContent, "")
+})
+
+test("provider option labels satisfy Notion option constraints", () => {
+  assert.equal(providerOptionLabel("  Payments,   US  "), "Payments， US")
+  assert.equal(providerOptionLabel("ＡＰＩ"), "API")
+  const forward = providerOptionLabels("Teams", [
+    "sre",
+    "Payments, US",
+    "SRE",
+    "  payments,   us ",
+  ])
+  const reverse = providerOptionLabels("Teams", [
+    "  payments,   us ",
+    "SRE",
+    "Payments, US",
+    "sre",
+  ])
+  assert.deepEqual(forward, reverse)
+  assert.deepEqual(forward, ["Payments， US", "SRE"])
+  assert.deepEqual(
+    providerOptionLabels("Teams", ["Payments, US", "Payments · US"]),
+    ["Payments · US", "Payments， US"]
+  )
+
+  const sharedPrefix = "Long option ".repeat(20)
+  const longA = providerOptionLabel(`${sharedPrefix}alpha`)
+  const longB = providerOptionLabel(`${sharedPrefix}beta`)
+  assert.ok(longA)
+  assert.ok(longB)
+  assert.notEqual(longA, longB)
+  assert.equal(Array.from(longA).length, MAX_OPTION_NAME_CHARACTERS)
+  assert.equal(Array.from(longB).length, MAX_OPTION_NAME_CHARACTERS)
+  assert.equal(providerOptionLabel(`${sharedPrefix}alpha`), longA)
+
+  assert.equal(
+    providerOptionLabels(
+      "Teams",
+      Array.from(
+        { length: MAX_MULTI_SELECT_OPTIONS },
+        (_, index) => `Team ${index}`
+      )
+    ).length,
+    MAX_MULTI_SELECT_OPTIONS
+  )
+  assert.throws(
+    () =>
+      providerOptionLabels(
+        "Teams",
+        Array.from(
+          { length: MAX_MULTI_SELECT_OPTIONS + 1 },
+          (_, index) => `Team ${index}`
+        )
+      ),
+    /at most 100 options/
+  )
+
+  const normalizedIncident = incidentToChange({
+    ...minimalIncident,
+    assignments: [
+      {
+        at: "2026-07-02T13:00:00Z",
+        assignee: { id: "PUSR001", summary: "Doe, Jane" },
+      },
+      {
+        at: "2026-07-02T13:01:00Z",
+        assignee: { id: "PUSR002", summary: "doe, jane" },
+      },
+    ],
+  })
+  assertPropertyContains(
+    normalizedIncident.properties["Assigned To"],
+    "Doe， Jane"
+  )
+  assert.doesNotMatch(
+    propertyText(normalizedIncident.properties["Assigned To"]),
+    /doe， jane/
+  )
 })
 
 test("configuration defaults, normalizes filters, and selects the EU host", () => {
@@ -1369,6 +1525,7 @@ test("client fails closed on malformed pagination, JSON, and API errors", async 
 
 test("execute functions wire client, state, and transforms end to end", async () => {
   let incidentRequest = 0
+  let serviceRequests = 0
   let onCallRequests = 0
   const client: PagerDutyClient = {
     async fetchIncidentsPage(scope) {
@@ -1385,6 +1542,7 @@ test("execute functions wire client, state, and transforms end to end", async ()
       return incidentPage([fullIncident])
     },
     async fetchServicesPage(scope, offset) {
+      serviceRequests++
       assert.equal(scope.region, "us")
       assert.equal(offset, 0)
       return servicePage([fullService])
@@ -1427,10 +1585,23 @@ test("execute functions wire client, state, and transforms end to end", async ()
   assert.equal(recentBatch.changes[0].key, "PINC001")
 
   const serviceState = initialServiceSyncState(config(), "2026-07-02T14:00:00Z")
-  const serviceBatch = await executeServices(serviceState, client, () => {
+  const serviceDiscovery = await executeServices(serviceState, client, () => {
     throw new Error("Pinned state should not re-read configuration.")
   })
+  assert.equal(serviceDiscovery.hasMore, true)
+  assert.deepEqual(serviceDiscovery.changes, [])
+  assert.equal(serviceDiscovery.nextState.phase, "publish")
+  assert.equal(onCallRequests, 0)
+
+  const serviceBatch = await executeServices(
+    serviceDiscovery.nextState,
+    client,
+    () => {
+      throw new Error("Pinned state should not re-read configuration.")
+    }
+  )
   assert.equal(serviceBatch.hasMore, false)
+  assert.equal(serviceRequests, 2)
   assert.equal(onCallRequests, 1)
   assert.equal(serviceBatch.changes[0].key, "PSVC001")
   assert.equal(
@@ -1719,13 +1890,15 @@ test("incident state rejects reordering, changing totals, and stalled offsets", 
   )
 })
 
-test("service state counts unique IDs and rejects mutable-order duplicates", () => {
+test("configured service state publishes directly and rejects duplicates", () => {
   const initial = initialServiceSyncState(
-    config({ serviceIds: ["PSVC001"] }),
+    config({ serviceIds: ["PSVC001", "PSVC002"] }),
     "2026-07-02T12:00:00Z"
   )
   assert.equal(initial.observedAt, "2026-07-02T12:00:00.000Z")
-  assert.deepEqual(initial.scope.serviceIds, ["PSVC001"])
+  assert.equal(initial.phase, "publish")
+  assert.deepEqual(initial.scope.serviceIds, ["PSVC001", "PSVC002"])
+  assert.deepEqual(initial.expectedServiceIds, ["PSVC001", "PSVC002"])
 
   const first = nextServiceSyncState(
     initial,
@@ -1773,5 +1946,107 @@ test("service state counts unique IDs and rejects mutable-order duplicates", () 
         })
       ),
     /total changed/
+  )
+})
+
+test("unscoped service discovery requires the same complete publish set", () => {
+  const initial = initialServiceSyncState(config(), "2026-07-02T12:00:00Z")
+  assert.equal(initial.phase, "discover")
+  assert.deepEqual(initial.expectedServiceIds, [])
+
+  const publish = nextServiceSyncState(
+    initial,
+    servicePage([fullService, minimalService], { total: 2 })
+  )
+  assert.ok(publish)
+  assert.equal(publish.phase, "publish")
+  assert.equal(publish.offset, 0)
+  assert.equal(publish.expectedTotal, undefined)
+  assert.deepEqual(publish.seenServiceIds, [])
+  assert.deepEqual(publish.expectedServiceIds, ["PSVC001", "PSVC002"])
+
+  // Membership is set-based: a harmless name-order change still converges.
+  assert.equal(
+    nextServiceSyncState(
+      publish,
+      servicePage([minimalService, fullService], { total: 2 })
+    ),
+    undefined
+  )
+
+  assert.throws(
+    () =>
+      nextServiceSyncState(
+        publish,
+        servicePage(
+          [
+            fullService,
+            { ...minimalService, id: "PSVC003", name: "New service" },
+          ],
+          { total: 2 }
+        )
+      ),
+    /PSVC003 appeared after service discovery/
+  )
+  assert.throws(
+    () =>
+      nextServiceSyncState(publish, servicePage([fullService], { total: 1 })),
+    /membership changed between discovery and publish \(2 to 1\)/
+  )
+})
+
+test("empty service discovery publishes one confirmed empty snapshot", () => {
+  const initial = initialServiceSyncState(config(), "2026-07-02T12:00:00Z")
+  const publish = nextServiceSyncState(initial, servicePage([]))
+  assert.ok(publish)
+  assert.equal(publish.phase, "publish")
+  assert.deepEqual(publish.expectedServiceIds, [])
+  assert.equal(nextServiceSyncState(publish, servicePage([])), undefined)
+})
+
+test("service publish rejects a late equal-count substitution across pages", () => {
+  const initial = initialServiceSyncState(config(), "2026-07-02T12:00:00Z")
+  const discoveryPageTwo = nextServiceSyncState(
+    initial,
+    servicePage([fullService, minimalService], {
+      limit: 2,
+      total: 3,
+      more: true,
+      nextOffset: 2,
+    })
+  )
+  assert.ok(discoveryPageTwo)
+  const thirdService = {
+    ...minimalService,
+    id: "PSVC003",
+    name: "Third service",
+  }
+  const publish = nextServiceSyncState(
+    discoveryPageTwo,
+    servicePage([thirdService], { offset: 2, limit: 2, total: 3 })
+  )
+  assert.ok(publish)
+  assert.equal(publish.phase, "publish")
+
+  const publishPageTwo = nextServiceSyncState(
+    publish,
+    servicePage([fullService, minimalService], {
+      limit: 2,
+      total: 3,
+      more: true,
+      nextOffset: 2,
+    })
+  )
+  assert.ok(publishPageTwo)
+  assert.throws(
+    () =>
+      nextServiceSyncState(
+        publishPageTwo,
+        servicePage(
+          [{ ...thirdService, id: "PSVC004", name: "Replacement service" }],
+          { offset: 2, limit: 2, total: 3 }
+        )
+      ),
+    /PSVC004 appeared after service discovery/
   )
 })

--- a/workers/pagerduty-sync/tsconfig.json
+++ b/workers/pagerduty-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/pagerduty-sync/tsconfig.test.json
+++ b/workers/pagerduty-sync/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What this adds

- A new `workers/pagerduty-sync` recipe with two related managed databases:
  **PagerDuty Incidents** and **PagerDuty Services**.
- Five-minute replacement syncs for all open incidents, recent incident
  history, service response state, current primary coverage, ownership,
  integrations, and support hours.
- A Notion workflow for operational awareness, handoff, readiness, and durable
  incident review while PagerDuty remains the paging and response system of
  record.
- Catalog and cookbook landing-page entries, plus a value-first
  [setup and extension guide](workers/pagerduty-sync/README.md).

## Reliability and safety

- Uses immutable PagerDuty IDs for row identity and Incident → Service
  relations.
- Emits complete, exactly typed upserts so values removed in PagerDuty are
  explicitly cleared in Notion rather than becoming stale.
- Protects replacement completeness across PagerDuty's live offset pagination:
  open incidents use an identity confirmation pass, while unscoped services use
  discovery followed by a publish pass that must reproduce the same identity
  set.
- Pins and splits recent-history windows, validates totals, offsets, ordering,
  and response shapes, and fails visibly at PagerDuty's 10,000-record offset
  boundary.
- Normalizes provider-authored Notion option values, bounds long labels, and
  enforces Notion's per-row multi-select limit without silently dropping data.
- Shares one PagerDuty request pacer, honors provider rate-limit delays, accepts
  only safe web URLs, redacts credential-like error details, and performs only
  read requests against PagerDuty.

## Validation

- `cd workers/pagerduty-sync && npm run check`
- `cd workers/pagerduty-sync && npm test` — 31 tests passed
- `cd workers/pagerduty-sync && npm run build`
- `npm run verify`
- `git diff --check`
