### PR TITLE
feat(workers): add Sentry sync example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ directory.
   [GitHub](workers/github-sync/), [HubSpot](workers/hubspot-sync/),
   [Intercom](workers/intercom-sync/), [Jira](workers/jira-sync/),
   [Linear](workers/linear-sync/), [PagerDuty](workers/pagerduty-sync/),
-  [Salesforce](workers/salesforce-sync/), [Snowflake](workers/snowflake-sync/), or
-  [Zendesk](workers/zendesk-sync/).
+  [Salesforce](workers/salesforce-sync/), [Sentry](workers/sentry-sync/),
+  [Snowflake](workers/snowflake-sync/), or [Zendesk](workers/zendesk-sync/).
 - **Give a Notion agent a new tool:** connect it to
   [Airflow](workers/airflow/), [CloudWatch Logs](workers/cloudwatch-logs/),
   [Postgres](workers/postgres-query/), or one of the other Worker tools below.
@@ -62,6 +62,7 @@ and a **webhook** handles events from another service. See the complete
 | Sync projects, issues, and initiatives                      | [Linear sync](workers/linear-sync/)         | Linear     |
 | Monitor PagerDuty incidents and service readiness in Notion | [PagerDuty sync](workers/pagerduty-sync/)   | PagerDuty  |
 | Sync accounts and opportunities                             | [Salesforce sync](workers/salesforce-sync/) | Salesforce |
+| Triage errors and review recent issue impact                | [Sentry sync](workers/sentry-sync/)         | Sentry     |
 | Sync the result of a warehouse query                        | [Snowflake sync](workers/snowflake-sync/)   | Snowflake  |
 | Sync tickets, users, organizations, and support metrics     | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and a **webhook** handles events from another service. See the complete
 | Sync projects, issues, and initiatives                      | [Linear sync](workers/linear-sync/)         | Linear     |
 | Monitor PagerDuty incidents and service readiness in Notion | [PagerDuty sync](workers/pagerduty-sync/)   | PagerDuty  |
 | Sync accounts and opportunities                             | [Salesforce sync](workers/salesforce-sync/) | Salesforce |
-| Triage errors and review recent issue impact                | [Sentry sync](workers/sentry-sync/)         | Sentry     |
+| Coordinate issue triage, service risk, and rollout health   | [Sentry sync](workers/sentry-sync/)         | Sentry     |
 | Sync the result of a warehouse query                        | [Snowflake sync](workers/snowflake-sync/)   | Snowflake  |
 | Sync tickets, users, organizations, and support metrics     | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
 

--- a/catalog.json
+++ b/catalog.json
@@ -407,7 +407,7 @@
     {
       "id": "sentry-sync",
       "title": "Sentry sync",
-      "summary": "Sync a rolling 30-day view of Sentry issues, ownership, lifecycle signals, and impact into a managed Notion database.",
+      "summary": "Sync Sentry issue triage, project reliability trends, and recent release health into three managed Notion databases.",
       "path": "workers/sentry-sync",
       "kind": "worker-sync",
       "status": "ready",

--- a/catalog.json
+++ b/catalog.json
@@ -405,6 +405,25 @@
       }
     },
     {
+      "id": "sentry-sync",
+      "title": "Sentry sync",
+      "summary": "Sync a rolling 30-day view of Sentry issues, ownership, lifecycle signals, and impact into a managed Notion database.",
+      "path": "workers/sentry-sync",
+      "kind": "worker-sync",
+      "status": "ready",
+      "language": "typescript",
+      "runtime": "node",
+      "integrations": ["notion-workers", "sentry"],
+      "entrypoints": ["src/index.ts"],
+      "commands": {
+        "install": "npm install",
+        "check": "npm run check",
+        "test": "npm test",
+        "build": "npm run build",
+        "deploy": "ntn workers deploy --name sentry-sync"
+      }
+    },
+    {
       "id": "snowflake-query",
       "title": "Snowflake query agent tool",
       "summary": "Let a Notion agent discover Snowflake tables and execute bounded, read-only SQL queries.",

--- a/workers/README.md
+++ b/workers/README.md
@@ -24,6 +24,7 @@ For local programs built directly on the Notion API, see the
 | [Linear sync](linear-sync/)         | Linear projects, issues, and initiatives.                                                                              |
 | [PagerDuty sync](pagerduty-sync/)   | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.     |
 | [Salesforce sync](salesforce-sync/) | Salesforce accounts and opportunities, with related account context.                                                   |
+| [Sentry sync](sentry-sync/)         | A rolling 30-day issue view with lifecycle, ownership, and impact signals for operational triage.                      |
 | [Snowflake sync](snowflake-sync/)   | Rows returned by a configurable Snowflake query.                                                                       |
 | [Zendesk sync](zendesk-sync/)       | Tickets, organizations, users, CSAT responses, ticket metrics, and SLA policies.                                       |
 

--- a/workers/README.md
+++ b/workers/README.md
@@ -24,7 +24,7 @@ For local programs built directly on the Notion API, see the
 | [Linear sync](linear-sync/)         | Linear projects, issues, and initiatives.                                                                              |
 | [PagerDuty sync](pagerduty-sync/)   | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.     |
 | [Salesforce sync](salesforce-sync/) | Salesforce accounts and opportunities, with related account context.                                                   |
-| [Sentry sync](sentry-sync/)         | A rolling 30-day issue view with lifecycle, ownership, and impact signals for operational triage.                      |
+| [Sentry sync](sentry-sync/)         | Issue triage, project reliability trends, and recent release health for cross-functional follow-up.                    |
 | [Snowflake sync](snowflake-sync/)   | Rows returned by a configurable Snowflake query.                                                                       |
 | [Zendesk sync](zendesk-sync/)       | Tickets, organizations, users, CSAT responses, ticket metrics, and SLA policies.                                       |
 

--- a/workers/sentry-sync/.env.example
+++ b/workers/sentry-sync/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to `.env` and fill in your own values for local testing.
+# `.env` is gitignored — never commit real credentials.
+# For a deployed Worker, use `ntn workers env set KEY=value` instead.
+
+# Required: an internal-integration token with event:read access.
+SENTRY_AUTH_TOKEN=
+
+# Required: the organization slug from your Sentry URL.
+SENTRY_ORG_SLUG=
+
+# Optional: comma-separated project IDs or slugs. Omit to include every
+# project the token can access.
+SENTRY_PROJECTS=
+
+# Optional: comma-separated Sentry environment names.
+SENTRY_ENVIRONMENTS=
+
+# Optional: HTTPS root URL for a self-hosted Sentry installation.
+# Plain HTTP is accepted only for a loopback development server.
+# SENTRY_BASE_URL=https://sentry.example.com

--- a/workers/sentry-sync/.env.example
+++ b/workers/sentry-sync/.env.example
@@ -2,7 +2,8 @@
 # `.env` is gitignored — never commit real credentials.
 # For a deployed Worker, use `ntn workers env set KEY=value` instead.
 
-# Required: an internal-integration token with event:read access.
+# Required: an internal-integration token with event:read, org:read, and
+# project:releases access so all three default syncs can run.
 SENTRY_AUTH_TOKEN=
 
 # Required: the organization slug from your Sentry URL.

--- a/workers/sentry-sync/.gitignore
+++ b/workers/sentry-sync/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit these
+.env
+workers.json
+workers.*.json
+
+# Build output and dependencies
+dist/
+node_modules/

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -31,17 +31,17 @@ cd workers/sentry-sync
 npm install
 ntn login
 ntn workers deploy --name sentry-sync
-ntn workers env set SENTRY_AUTH_TOKEN=your-token
-ntn workers env set SENTRY_ORG_SLUG=your-organization-slug
+ntn workers env set \
+  SENTRY_AUTH_TOKEN=your-token \
+  SENTRY_ORG_SLUG=your-organization-slug \
+  SENTRY_PROJECTS=checkout-api \
+  SENTRY_ENVIRONMENTS=production
 ```
 
-For the first run, scope to one or two production projects. Replace the example
-slug with a Sentry project ID or slug:
-
-```sh
-ntn workers env set SENTRY_PROJECTS=checkout-api
-ntn workers env set SENTRY_ENVIRONMENTS=production
-```
+Apply the credentials and initial scope together before the first run so they
+are not saved as separate partial environment updates. Start with one or two
+production projects; replace `checkout-api` with a comma-separated list of
+Sentry project IDs or slugs.
 
 Create and populate all three databases while streaming each run:
 
@@ -50,6 +50,11 @@ ntn workers exec issuesSync --stream
 ntn workers exec projectsSync --stream
 ntn workers exec releasesSync --stream
 ```
+
+After all three commands complete, the workspace contains managed databases
+named **Sentry Issues**, **Sentry Projects**, and **Sentry Releases**, populated
+with any records matching the configured scope. Subsequent runs update those
+databases on the schedules below.
 
 ## What you can answer
 
@@ -70,11 +75,11 @@ details, investigation, alerting, and mutations.
 
 ### Databases and schedules
 
-| Database            | Sync           | Mode    | Schedule     | Membership                                               |
-| ------------------- | -------------- | ------- | ------------ | -------------------------------------------------------- |
-| **Sentry Issues**   | `issuesSync`   | replace | Every 15 min | Every issue status seen in the pinned prior 30 days      |
-| **Sentry Projects** | `projectsSync` | replace | Daily        | Visible projects, enriched from the pinned prior 30 days |
-| **Sentry Releases** | `releasesSync` | replace | Every 15 min | The 100 most recent releases across the configured scope |
+| Database            | Sync           | Mode    | Schedule     | Membership                                                    |
+| ------------------- | -------------- | ------- | ------------ | ------------------------------------------------------------- |
+| **Sentry Issues**   | `issuesSync`   | replace | Every 15 min | Every issue status seen in the pinned prior 30 days           |
+| **Sentry Projects** | `projectsSync` | replace | Daily        | Visible projects, enriched from the pinned prior 30 days      |
+| **Sentry Releases** | `releasesSync` | replace | Every 15 min | The first 100 rows returned by the configured release request |
 
 `replace` means complete reconciliation. The Worker updates stable rows and
 removes rows absent from a completed refresh; it does not delete and recreate
@@ -178,7 +183,8 @@ metrics.
 - **Rollout watch:** sort releases by Released At descending, then Crash-Free
   Sessions and Sessions (7d).
 - **Missing release telemetry:** filter Health Data (7d) unchecked. Empty means
-  the sessions endpoint was unavailable on that Sentry installation.
+  Sentry returned no health row, no session telemetry exists, or the sessions
+  request used the Worker's 404 fallback described below.
 
 ## How it works
 
@@ -220,9 +226,13 @@ rather than truncating the snapshot or returning invalid continuation state.
 
 The release refresh deliberately requests only the first 100 releases from the
 endpoint's most-recent-first default order, so this is an explicit useful set
-rather than accidental pagination truncation. Project and environment filters
-scope both release membership and health. An explicit empty `status=` includes
-recently archived releases instead of Sentry's default open-only set.
+rather than accidental pagination truncation. The Worker sends configured
+project and environment filters plus an explicit empty `status=` to the release
+request. Sentry's public list-releases reference documents the project filter,
+but not environment or status for this endpoint. Their effect on release
+membership is therefore compatibility behavior, not a portable guarantee
+across Sentry SaaS and self-hosted versions. The separate Release Health query
+always applies the explicit project and environment scope shown in Notion.
 
 One additional sessions request groups the prior seven days by release across
 the configured project and environment scope, requests totals without
@@ -234,10 +244,13 @@ that conservative request also remains below Sentry's documented
 10,000-data-point constraint even if the service computes series before
 omitting them from the response.
 
-An empty health result is valid and clears unavailable metrics. A 404 from the
-sessions endpoint on an older self-hosted installation also preserves release
-metadata. Authentication, authorization, malformed data, timeouts, 429s, and
-other API errors remain visible failures.
+An empty health result is valid and clears unavailable metrics. The Worker also
+treats any 404 from the sessions endpoint as unavailable health and preserves
+release metadata. That fallback does not prove that the Sentry installation is
+too old: if health was expected, check the organization, route, permissions,
+proxy, and Sentry version. Explicit 401/403 authentication and authorization
+responses, malformed data, timeouts, 429s, and other non-404 API errors remain
+visible failures.
 
 ### Rate limits and request safety
 
@@ -340,6 +353,11 @@ ntn workers exec projectsSync --local --stream
 ntn workers exec releasesSync --local --stream
 ```
 
+Keep generated and machine-local files out of commits. `.env`, `workers.json`,
+`workers.*.json`, `package-lock.json`, `dist/`, and `node_modules/` are
+gitignored; `.env.example` is the tracked configuration template. A test
+deployment does not require committing its generated Worker configuration.
+
 Confirm that recently active resolved and unresolved issues appear; project
 totals match the scoped issue set; current/prior seven-day buckets line up with
 Sentry; newest releases remain one row each with project context; and missing
@@ -348,13 +366,42 @@ creating false zeroes.
 
 ## Customizing the default set
 
-To remove a view from a fork, delete its `worker.database(...)` and
+To remove a database from a fork, delete its `worker.database(...)` and
 `worker.sync(...)` blocks from `src/index.ts`, then remove its schema module if
-unused. No environment flag is required.
+unused. No environment flag is required. This stops future management but does
+not trash a database created by an earlier deployment; archive or trash that
+database manually in Notion after confirming its contents are no longer needed.
 
-When adding fields, retain only the selected provider shape, validate identity
-and null transitions, preserve schema/transform property order, and add
-complete, value-to-missing, zero, future-value, privacy, and pagination tests.
+### Safe extension contract
+
+Follow the complete path for every field or resource rather than editing only
+the visible schema:
+
+1. **Provider contract:** add the narrow response type and runtime parser in
+   `src/sentry.ts`. Build URLs from the validated Sentry base, validate provider
+   pagination with `nextCursorFromLink`, and route every request through
+   `fetchSentryJson` so timeout, redirect, authentication, rate-limit, and
+   response checks remain consistent. Retain only fields the database actually
+   uses.
+2. **Database contract:** update the schema and transform together in
+   `src/issues.ts`, `src/projects.ts`, or `src/releases.ts`. Every upsert must
+   emit every declared schema property; emit the empty property value (`[]`)
+   when an upstream nullable value disappears so Notion clears stale data. Use
+   an immutable provider ID as the primary key.
+3. **Lifecycle contract:** register a new database, sync, and schedule in
+   `src/index.ts`. Pin the time window and `SentryScope` for the full refresh,
+   validate cursor traversal with `nextCursorTraversal`, and pass every
+   continuation through `boundedSyncState` in `src/sync-state.ts`.
+4. **Completeness contract:** exhaustive syncs must follow trusted pagination
+   until a terminal `hasMore: false`; never silently stop and call a partial
+   result complete. If a deliberately bounded snapshot is more useful, as with
+   the newest 100 releases, make the limit part of its membership definition
+   and document it.
+5. **Verification contract:** add complete, minimal, populated-to-missing,
+   explicit-zero, unknown-enum, privacy, cursor, rate-limit, and boundary tests
+   in `test.ts`. Then run the offline checks and exercise the changed endpoint
+   against a small real Sentry scope before deployment.
+
 Keep raw event data out of this base example. A webhook-driven fork can improve
 issue freshness while the full refresh remains reconciliation.
 

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -79,7 +79,8 @@ details, investigation, alerting, and mutations.
 `replace` means complete reconciliation. The Worker updates stable rows and
 removes rows absent from a completed refresh; it does not delete and recreate
 the database. A failed or partial multi-page refresh is not treated as a
-complete snapshot.
+complete snapshot. Every returned row also emits explicit empty property values
+when a Sentry field disappears, so an earlier value cannot remain stale.
 
 ### Issue fields
 
@@ -128,7 +129,7 @@ the complete issue scan. It includes:
 
 The immutable project ID is the primary key. A project with no issue activity
 in the 30-day window still appears with zero issue counts. If any returned
-issue lacks 14-day statistics, the project row omits its seven-day totals and
+issue lacks 14-day statistics, the project row clears its seven-day totals and
 top issue rather than publishing an understated result. The same rule applies
 to an incomplete 30-day event count.
 
@@ -151,8 +152,8 @@ Release Health query adds:
 Sentry reports crash-free rates as percentage points; the transform converts
 them to Notion's percent-property representation without changing their
 meaning. A release without session telemetry still gets a metadata row.
-Absent health values remain absent—never `0`, `100%`, or an invented “Healthy”
-status. Explicit zeroes from Sentry remain zero.
+Absent health values remain empty—never stale, `0`, `100%`, or an invented
+“Healthy” status. Explicit zeroes from Sentry remain zero.
 
 `New Issues`, deploys, and commits remain organization-release values. Projects
 lists every project Sentry associates with the release, while health metrics
@@ -209,9 +210,11 @@ Projects with no matching issues still appear. An issue aggregate whose
 project was deleted or became inaccessible is retained using the issue's
 project metadata so risk does not disappear silently.
 
-The state is capped at 500 active projects. Larger organizations should set
-`SENTRY_PROJECTS`; crossing the boundary fails with an actionable error rather
-than truncating the snapshot.
+Continuation state has a 240 KiB safety budget below Workers' 256 KiB runtime
+limit, plus a secondary cap of 500 active projects. Metadata length varies, so
+the serialized-state budget can be reached first. Larger organizations should
+set `SENTRY_PROJECTS`; crossing either boundary fails with an actionable error
+rather than truncating the snapshot or returning invalid continuation state.
 
 ### Recent rollout health
 
@@ -231,7 +234,7 @@ that conservative request also remains below Sentry's documented
 10,000-data-point constraint even if the service computes series before
 omitting them from the response.
 
-An empty health result is valid and leaves metrics absent. A 404 from the
+An empty health result is valid and clears unavailable metrics. A 404 from the
 sessions endpoint on an older self-hosted installation also preserves release
 metadata. Authentication, authorization, malformed data, timeouts, 429s, and
 other API errors remain visible failures.
@@ -308,8 +311,8 @@ This is a one-way mirror. Changes in Notion do not update Sentry.
 ```text
 src/
 ├── index.ts      — registers all databases, schedules, phases, and shared pacer
-├── sentry.ts     — minimal REST client, strict parsing, pagination, and limits
-├── sync-state.ts — pinned issue windows and reusable cursor-loop safeguards
+├── sentry.ts     — REST client, response validation, pagination, and rate limits
+├── sync-state.ts — pinned windows, cursor safeguards, and continuation limits
 ├── issues.ts     — issue schema and triage transform
 ├── projects.ts   — project schema and truthful issue aggregation
 ├── releases.ts   — release schema and aggregate health merge
@@ -340,7 +343,8 @@ ntn workers exec releasesSync --local --stream
 Confirm that recently active resolved and unresolved issues appear; project
 totals match the scoped issue set; current/prior seven-day buckets line up with
 Sentry; newest releases remain one row each with project context; and missing
-Release Health leaves fields absent rather than creating false zeroes.
+Release Health clears prior fields rather than retaining stale values or
+creating false zeroes.
 
 ## Customizing the default set
 
@@ -349,10 +353,10 @@ To remove a view from a fork, delete its `worker.database(...)` and
 unused. No environment flag is required.
 
 When adding fields, retain only the selected provider shape, validate identity
-and null semantics, preserve schema/transform property order, and add complete,
-missing, zero, future-value, privacy, and pagination tests. Keep raw event data
-out of this base example. A webhook-driven fork can improve issue freshness
-while the full refresh remains reconciliation.
+and null transitions, preserve schema/transform property order, and add
+complete, value-to-missing, zero, future-value, privacy, and pagination tests.
+Keep raw event data out of this base example. A webhook-driven fork can improve
+issue freshness while the full refresh remains reconciliation.
 
 ## Official documentation
 

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -1,21 +1,29 @@
 # Worker sync: Sentry
 
-Bring the Sentry issues that mattered during the last 30 days into Notion for
-triage, operational review, and cross-functional visibility. The Worker keeps
-one approachable **Sentry Issues — Last 30 Days** database current every 15
-minutes, with native lifecycle signals, recent event volume, user impact,
-ownership, and a link back to Sentry.
+Bring Sentry's operational signals into Notion so engineering, product, and
+support can coordinate reliability work without turning Notion into another
+error console. Out of the box, this Worker helps teams see what is breaking,
+which services carry the most unresolved risk, whether ownership gaps are
+growing, and how the newest releases are behaving.
 
-The result is useful immediately: create views for unresolved issues,
-regressions, unassigned high-impact errors, recently active issues that are now
-resolved, or concentrations by project without changing the code.
+The example creates three complementary databases by default:
+
+- **Sentry Issues** keeps a rolling triage view current every 15 minutes.
+- **Sentry Projects** adds a daily service-level reliability summary to the
+  complete project inventory.
+- **Sentry Releases** combines the 100 newest releases with seven-day rollout
+  health every 15 minutes.
+
+All three are registered intentionally. It is easier to remove a database and
+its sync from a fork than to discover and wire up a valuable view later. There
+are no hidden enable flags, relations, invented health scores, or raw-event
+copies.
 
 ## Quickstart
 
-You need Node.js 22+, a Sentry organization, an
-[internal integration token](#create-a-sentry-token) with `event:read` access,
-and permission to read the projects you want to sync. From the repository
-root:
+You need Node.js 22+, a Sentry organization, and an
+[internal integration token](#create-a-sentry-token) with `event:read`,
+`org:read`, and `project:releases`. From the repository root:
 
 ```sh
 npm install --global ntn
@@ -28,155 +36,217 @@ ntn workers env set SENTRY_ORG_SLUG=your-organization-slug
 ```
 
 For the first run, scope to one or two production projects. Replace the example
-slug with your Sentry project ID or slug:
+slug with a Sentry project ID or slug:
 
 ```sh
 ntn workers env set SENTRY_PROJECTS=checkout-api
 ntn workers env set SENTRY_ENVIRONMENTS=production
 ```
 
-Create and populate the database immediately, while streaming the run output:
+Create and populate all three databases while streaming each run:
 
 ```sh
 ntn workers exec issuesSync --stream
+ntn workers exec projectsSync --stream
+ntn workers exec releasesSync --stream
 ```
-
-The Worker refreshes the database every 15 minutes. It includes issues of
-every status that Sentry considers active in the pinned 30-day query window;
-an issue that is no longer returned by that rolling window is removed from the
-managed database after a complete successful refresh.
 
 ## What you can answer
 
-| Question                                                                | Fields to use                                      |
-| ----------------------------------------------------------------------- | -------------------------------------------------- |
-| What is breaking now?                                                   | Status, Priority, Events (24h), Users (30d)        |
-| What is new, regressed, or escalating?                                  | Status Detail, Last Seen                           |
-| Which important or unhandled issues have no owner?                      | Assignee, Priority, Unhandled, Events (30d)        |
-| Which issues are hottest today or have caused the most lifetime impact? | Events (24h), Lifetime Events, Lifetime Users      |
-| Which recently active issues are now resolved or ignored?               | Status, Last Seen                                  |
-| Where are recent issues concentrated?                                   | Project, Platform, Category, Issue Type, Unhandled |
+| Question                                                      | Signals to use                                                          |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| What is breaking now?                                         | Issue status, priority, 24-hour events, 30-day users                    |
+| What is new, regressed, escalating, or unowned?               | Status detail, assignee, unhandled, last seen                           |
+| Which services carry the most current reliability burden?     | Unresolved issues, seven-day events, high-priority and lifecycle counts |
+| Is service activity rising compared with the prior week?      | Events (7d), Previous 7d Events, Event Change vs Prior 7d               |
+| Where are ownership and instrumentation gaps concentrated?    | Unassigned Unresolved (30d), Teams, Has Sessions                        |
+| Are the newest rollouts stable and broadly exercised?         | Crash-Free Sessions, Crash-Free Users, Sessions (7d), Users (7d)        |
+| Which releases introduced new issue groups or lack telemetry? | New Issues, Health Data (7d), First Event, Last Event                   |
+
+These are coordination views. Sentry remains the system of record for event
+details, investigation, alerting, and mutations.
 
 ## Reference
 
-### Database and schedule
+### Databases and schedules
 
-| Database                         | Sync         | Mode    | Schedule     | Membership                             |
-| -------------------------------- | ------------ | ------- | ------------ | -------------------------------------- |
-| **Sentry Issues — Last 30 Days** | `issuesSync` | replace | Every 15 min | Every status seen in the prior 30 days |
+| Database            | Sync           | Mode    | Schedule     | Membership                                               |
+| ------------------- | -------------- | ------- | ------------ | -------------------------------------------------------- |
+| **Sentry Issues**   | `issuesSync`   | replace | Every 15 min | Every issue status seen in the pinned prior 30 days      |
+| **Sentry Projects** | `projectsSync` | replace | Daily        | Visible projects, enriched from the pinned prior 30 days |
+| **Sentry Releases** | `releasesSync` | replace | Every 15 min | The 100 most recent releases across the configured scope |
 
-Here, `replace` means a **complete reconciliation**: the Worker reads every API
-page in one pinned snapshot and Notion reconciles membership only after that
-refresh succeeds. It does not delete and recreate the database. Existing rows
-are updated by immutable Sentry issue ID; rows absent from the completed
-30-day snapshot are removed.
+`replace` means complete reconciliation. The Worker updates stable rows and
+removes rows absent from a completed refresh; it does not delete and recreate
+the database. A failed or partial multi-page refresh is not treated as a
+complete snapshot.
 
-One database is deliberate. Active, regressed, unassigned, resolved, and
-project-specific lists are different views of the same issue data, so separate
-managed databases would duplicate rows and make setup harder. A future
-**Sentry Project Health** database would be worthwhile only with distinct
-aggregates such as unresolved counts, high-priority counts, recent events, and
-affected users—not merely project reference metadata.
+### Issue fields
 
-### Field mapping
+| Notion property | Sentry issue-group field               |
+| --------------- | -------------------------------------- |
+| Issue           | `title`                                |
+| Status          | `status`                               |
+| Assignee        | `assignedTo.name`                      |
+| Issue Link      | `permalink`                            |
+| Last Seen       | `lastSeen`                             |
+| Priority        | `priority`                             |
+| Status Detail   | `substatus`                            |
+| Level           | `level`                                |
+| Unhandled       | `isUnhandled`                          |
+| Events (24h)    | sum of `stats["24h"]`                  |
+| Events (30d)    | query-window `count`                   |
+| Users (30d)     | query-window `userCount`               |
+| Lifetime Events | `lifetime.count`                       |
+| Lifetime Users  | `lifetime.userCount`                   |
+| Project         | `project.name` or `project.slug`       |
+| Category        | `issueCategory`                        |
+| Issue Type      | `issueType`                            |
+| Platform        | issue or project `platform`            |
+| Culprit         | `culprit`                              |
+| First Seen      | `firstSeen`                            |
+| Issue Key       | `shortId` (for example, `CHECKOUT-42`) |
+| Sentry Issue ID | immutable `id`                         |
 
-| Notion property | Sentry issue-group field               | Type     |
-| --------------- | -------------------------------------- | -------- |
-| Issue           | `title`                                | title    |
-| Status          | `status`                               | select   |
-| Assignee        | `assignedTo.name`                      | richText |
-| Issue Link      | `permalink`                            | url      |
-| Last Seen       | `lastSeen`                             | date     |
-| Priority        | `priority`                             | select   |
-| Status Detail   | `substatus`                            | select   |
-| Level           | `level`                                | select   |
-| Unhandled       | `isUnhandled`                          | checkbox |
-| Events (24h)    | sum of `stats["24h"]`                  | number   |
-| Events (30d)    | query-window `count`                   | number   |
-| Users (30d)     | query-window `userCount`               | number   |
-| Lifetime Events | `lifetime.count`                       | number   |
-| Lifetime Users  | `lifetime.userCount`                   | number   |
-| Project         | `project.name` or `project.slug`       | select   |
-| Category        | `issueCategory`                        | select   |
-| Issue Type      | `issueType`                            | select   |
-| Platform        | issue or project `platform`            | select   |
-| Culprit         | `culprit`                              | richText |
-| First Seen      | `firstSeen`                            | date     |
-| Issue Key       | `shortId` (for example, `CHECKOUT-42`) | richText |
-| Sentry Issue ID | immutable `id`                         | richText |
+The immutable Sentry issue ID is the primary key. Each page body contains a
+short, bounded triage snapshot assembled from these same group-level fields.
 
-**Sentry Issue ID** is the primary key. The familiar **Issue Key** remains
-visible for recognition, but it is not used for identity because a display
-identifier is not as durable as Sentry's underlying group ID.
+### Project fields
 
-Each page body contains a short, bounded triage snapshot assembled from these
-same group-level fields: status, ownership, 24-hour, 30-day, and lifetime
-impact, native lifecycle signals, location, first/last seen timestamps, and
-the source link. It does not copy raw event payloads.
+The project database combines Sentry's project inventory with aggregates from
+the complete issue scan. It includes:
 
-### Suggested Notion views
+- unresolved, high-priority, new, regressed, escalating, unhandled, and
+  unassigned issue-group counts;
+- event volume in the current and previous seven-day windows, with the exact
+  change rather than a subjective score;
+- 30-day issue-group and event totals;
+- the most active issue in the current seven-day window and its source link;
+- last activity, team, platform, session-instrumentation, and first-event
+  context;
+- the environment scope used for every issue-derived aggregate.
 
-- **Active triage:** filter Status to Unresolved; sort by Priority, Events
-  (24h), and Users (30d).
-- **New and regressed:** filter Status Detail to New, Regressed, or Escalating;
-  sort by Last Seen descending.
-- **Needs an owner:** filter Status to Unresolved and Assignee empty, then sort
-  by Unhandled, Priority, and Events (24h).
-- **Largest user impact:** sort by Lifetime Users and Lifetime Events.
-- **Recently active resolutions:** filter Status to Resolved or Ignored and
-  sort by Last Seen. Last Seen is event activity—not the resolution timestamp.
-- **Risk by service:** group by Project or Platform, then sort by Events (24h).
+The immutable project ID is the primary key. A project with no issue activity
+in the 30-day window still appears with zero issue counts. If any returned
+issue lacks 14-day statistics, the project row omits its seven-day totals and
+top issue rather than publishing an understated result. The same rule applies
+to an incomplete 30-day event count.
 
-### Project structure
+There is deliberately no project-level affected-users total: one person can
+appear in several issue groups, so summing `userCount` would double-count them.
 
-```text
-src/
-├── index.ts      — registers the managed database, schedule, and shared pacer
-├── sentry.ts     — minimal REST client, trusted pagination, and rate limits
-├── sync-state.ts — pinned 30-day window and cursor-loop safeguards
-├── issues.ts     — Notion schema and issue-group transform
-└── helpers.ts    — labels, safe values, statistics, and page summaries
-```
+### Release fields
 
-### How it works
+Each release row represents one Sentry organization release, keyed by its
+immutable release ID. The newest 100 releases contribute status, projects,
+dates, new issue groups, deploy and commit counts, platforms, version, a direct
+Sentry link, and the provider-supplied external release URL. One aggregate
+Release Health query adds:
 
-1. The Worker calls Sentry's current organization issue-search endpoint,
-   `GET /api/0/organizations/{organization}/issues/`, requesting 100 groups per
-   page. It makes one request per page and performs no per-issue enrichment.
-2. Sentry normally defaults this endpoint to unresolved issues. The client
-   deliberately sends an empty `query=` so the rolling database also includes
-   resolved and ignored issues returned for the window.
-3. The first page fixes an exact `start` and `end` spanning 30 days, plus the
-   base URL, organization, project filters, environment filters, and a
-   non-secret credential fingerprint. That scope remains in serializable sync
-   state through the final page, so a long run cannot slide its window, mix
-   queries, or continue under a newly rotated token with different access.
-   Results use Sentry's `new` sort and request 24-hour group statistics.
-4. Sentry's `Link` header is authoritative. The client continues only when the
-   one `rel="next"` entry declares `results="true"`, extracts its opaque cursor,
-   validates the URL's origin and path, and rebuilds the configured request.
-   Missing links/cursors, duplicate next links, and immediate or longer cursor
-   cycles fail the refresh instead of silently truncating it or looping.
-5. A completed replace-mode run reconciles the whole key set. This catches
-   status, priority, and assignee changes and removes groups that leave the
-   rolling window. Sentry does not expose a reliable general issue mutation
-   timestamp: `lastSeen` records event activity, so it is intentionally not
-   treated as an incremental watermark.
-6. All requests share a conservative 60-request-per-minute client-side pacer.
-   Sentry uses caller- and endpoint-specific frequency and concurrency limits
-   rather than one universal quota. On HTTP 429, the Worker passes usable
-   `Retry-After` and `X-Sentry-Rate-Limit-Reset` delays to the Workers runtime
-   for backoff.
-7. Unknown future enum values remain visible as readable select values. Null
-   values are omitted instead of being mislabeled; meaningful zero counts and
-   a real `false` Unhandled value are preserved.
+- crash-free session and user rates;
+- sessions and unique users in the returned seven-day window;
+- the exact rounded window Sentry evaluated;
+- the configured project and environment scope used for health.
 
-Every scheduled run reads the complete scoped 30-day result—one request for
-each 100 issue groups. That is intentionally correct for status, priority, and
-assignee changes, but a large unscoped organization can generate substantial
-API traffic. Start with production and the projects your team reviews. If you
-fork the example for a very large scope, use a slower schedule or combine a
-webhook path with this full refresh as reconciliation.
+Sentry reports crash-free rates as percentage points; the transform converts
+them to Notion's percent-property representation without changing their
+meaning. A release without session telemetry still gets a metadata row.
+Absent health values remain absent—never `0`, `100%`, or an invented “Healthy”
+status. Explicit zeroes from Sentry remain zero.
+
+`New Issues`, deploys, and commits remain organization-release values. Projects
+lists every project Sentry associates with the release, while health metrics
+are aggregated only over the explicit **Health Project Scope** and
+**Environment Scope**. Keeping both scopes visible prevents a shared release
+from implying that scoped health covers every listed project. The base example
+avoids duplicated rows with misleading per-project copies of release-level
+metrics.
+
+## Suggested Notion views
+
+- **Active triage:** Status is Unresolved; sort by Priority, Events (24h), and
+  Users (30d).
+- **New and regressed:** Status Detail is New, Regressed, or Escalating; sort
+  by Last Seen descending.
+- **Needs an owner:** Status is Unresolved and Assignee is empty; sort by
+  Unhandled, Priority, and Events (24h).
+- **Services needing attention:** sort projects by Unresolved Issues (30d),
+  Events (7d), Event Change vs Prior 7d, and Unassigned Unresolved (30d).
+- **Regression concentration:** sort projects by Regressed Unresolved (30d)
+  and High-Priority Unresolved (30d); group by Team or Platform.
+- **Rollout watch:** sort releases by Released At descending, then Crash-Free
+  Sessions and Sessions (7d).
+- **Missing release telemetry:** filter Health Data (7d) unchecked. Empty means
+  the sessions endpoint was unavailable on that Sentry installation.
+
+## How it works
+
+### Rolling issue triage
+
+The Worker calls Sentry's current organization issue-search endpoint with an
+explicit empty `query=`. Sentry otherwise defaults the endpoint to unresolved
+issues, while this example needs recently active resolved and ignored groups
+for review as well. The first page pins an exact 30-day `start` and `end`, base
+URL, organization, filters, and a non-secret credential fingerprint.
+
+Every page requests 100 groups and 24-hour group statistics. Sentry's `Link`
+header is authoritative: the Worker continues only when the one trusted
+`rel="next"` entry declares `results="true"`. Missing or malformed links,
+untrusted origins/paths, duplicate next links, and cursor cycles fail closed.
+
+### Service-level reliability
+
+The daily project refresh has two phases:
+
+1. Scan the same pinned 30-day issue scope with 14-day statistics and keep only
+   compact per-project counters in serializable state.
+2. Page through the organization project inventory and enrich each project
+   with those aggregates.
+
+Configured project IDs or slugs are applied to issue search and locally to the
+project inventory; configured environments scope the issue-derived signals.
+Projects with no matching issues still appear. An issue aggregate whose
+project was deleted or became inaccessible is retained using the issue's
+project metadata so risk does not disappear silently.
+
+The state is capped at 500 active projects. Larger organizations should set
+`SENTRY_PROJECTS`; crossing the boundary fails with an actionable error rather
+than truncating the snapshot.
+
+### Recent rollout health
+
+The release refresh deliberately requests only the first 100 releases from the
+endpoint's most-recent-first default order, so this is an explicit useful set
+rather than accidental pagination truncation. Project and environment filters
+scope both release membership and health. An explicit empty `status=` includes
+recently archived releases instead of Sentry's default open-only set.
+
+One additional sessions request groups the prior seven days by release across
+the configured project and environment scope, requests totals without
+time-series payloads, and orders by session volume. This avoids per-release
+detail calls. The Worker requests at most 250 groups and fails if Sentry reaches
+that boundary, because treating a potentially capped result as complete could
+remove valid rows or omit health. With four fields and seven daily buckets,
+that conservative request also remains below Sentry's documented
+10,000-data-point constraint even if the service computes series before
+omitting them from the response.
+
+An empty health result is valid and leaves metrics absent. A 404 from the
+sessions endpoint on an older self-hosted installation also preserves release
+metadata. Authentication, authorization, malformed data, timeouts, 429s, and
+other API errors remain visible failures.
+
+### Rate limits and request safety
+
+All three syncs share a conservative 60-request-per-minute pacer. Sentry uses
+caller- and endpoint-specific quotas instead of publishing one universal
+limit. On HTTP 429, the Worker passes usable `Retry-After` and
+`X-Sentry-Rate-Limit-Reset` delays to the Workers runtime.
+
+Requests have a 30-second timeout, reject redirects, and send the bearer token
+only to a validated HTTPS base URL. Loopback HTTP is allowed for local testing.
+The token fingerprint prevents a multi-page refresh from continuing under a
+rotated credential with different access.
 
 ## Sentry access and configuration
 
@@ -184,34 +254,26 @@ webhook path with this full refresh as reconciliation.
 
 Prefer an organization **internal integration** for a deployed Worker:
 
-1. In Sentry, open **Organization Settings > Developer Settings > Internal
+1. Open **Organization Settings > Developer Settings > Internal
    Integrations**.
 2. Create an integration dedicated to this Worker.
-3. Grant the least privilege needed to list issue groups: `event:read`.
-4. Copy its token into `SENTRY_AUTH_TOKEN` and store it only with
-   `ntn workers env set`.
+3. Grant `event:read` for issue groups, `org:read` for projects and aggregate
+   Release Health, and `project:releases` for release metadata.
+4. Store the token only with `ntn workers env set`.
 
-A personal authentication token is convenient for testing, but it follows the
-user's access and lifecycle. The internal integration is easier to scope and
-operate independently. The token can sync only organizations, projects, and
-environments it is allowed to read.
+A broader `project:read` permission also authorizes release listing, but
+`project:releases` is the narrower purpose-specific choice. A personal token is
+convenient for testing but follows that user's access and lifecycle.
 
 ### Environment variables
 
-| Variable              | Required | Description                                                                               |
-| --------------------- | -------- | ----------------------------------------------------------------------------------------- |
-| `SENTRY_AUTH_TOKEN`   | Yes      | Bearer token with `event:read`                                                            |
-| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                     |
-| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; omit for all projects visible to the token          |
-| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environment names, such as `production,staging`                           |
-| `SENTRY_BASE_URL`     | No       | HTTPS root for self-hosted Sentry; defaults to `https://sentry.io` and must omit `/api/0` |
-
-For example, scope a deployed Worker to two services and production:
-
-```sh
-ntn workers env set SENTRY_PROJECTS=checkout-api,billing-api
-ntn workers env set SENTRY_ENVIRONMENTS=production
-```
+| Variable              | Required | Description                                                                          |
+| --------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `SENTRY_AUTH_TOKEN`   | Yes      | Bearer token with `event:read`, `org:read`, and `project:releases`                   |
+| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                |
+| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; scopes issues, projects, releases, and health  |
+| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environments; scopes issues, project aggregates, and release health  |
+| `SENTRY_BASE_URL`     | No       | HTTPS root for self-hosted Sentry; defaults to `https://sentry.io`, without API path |
 
 For self-hosted Sentry:
 
@@ -219,31 +281,44 @@ For self-hosted Sentry:
 ntn workers env set SENTRY_BASE_URL=https://sentry.example.com
 ```
 
-The client requires HTTPS before sending its bearer token; loopback HTTP is
-accepted only for local development. Self-hosted versions can lag Sentry SaaS,
-so the parser accepts absent optional fields and future enum values but fails
-visibly if required identity or pagination contracts are missing.
+Self-hosted versions can lag Sentry SaaS. Optional fields and unknown future
+enum values are tolerated; missing identity, pagination, and completeness
+contracts fail visibly.
 
 ## Privacy and operational boundaries
 
-This example intentionally fetches only Sentry **issue-group metadata**. It
-does not request raw events, stack traces, breadcrumbs, request bodies,
-headers, query strings, tags, attachments, event users, IP addresses, or event
-contexts. The parser retains an assignee's display name but discards email and
-unselected response fields. It also avoids N+1 detail requests.
+The Worker requests issue-group metadata, project metadata, release metadata,
+and aggregate session totals. It does not request raw events, stack traces,
+breadcrumbs, request bodies, headers, query strings, tags, attachments, event
+users, IP addresses, or event contexts. Sentry's standard release response can
+contain owners, release authors, and commit-author metadata; the parser
+discards those fields immediately and never persists them in Notion or sync
+state. The issue parser retains an assignee display name but likewise discards
+email and other unselected response fields.
 
-Issue titles and culprits can still contain customer, code, or infrastructure
-details. Review Sentry's server-side data-scrubbing settings and the Notion
-database's sharing permissions before syncing production data to a broader
-audience.
+Issue titles, culprits, project names, and release versions can still contain
+customer, code, or infrastructure details. Review Sentry's data-scrubbing
+settings and the Notion databases' sharing permissions before syncing
+production data broadly.
 
-This is a one-way mirror. Changes in Notion do not update Sentry. Sentry
-remains the system of record and every row includes a direct source link.
+This is a one-way mirror. Changes in Notion do not update Sentry.
+
+## Project structure
+
+```text
+src/
+├── index.ts      — registers all databases, schedules, phases, and shared pacer
+├── sentry.ts     — minimal REST client, strict parsing, pagination, and limits
+├── sync-state.ts — pinned issue windows and reusable cursor-loop safeguards
+├── issues.ts     — issue schema and triage transform
+├── projects.ts   — project schema and truthful issue aggregation
+├── releases.ts   — release schema and aggregate health merge
+└── helpers.ts    — bounded labels, safe values, statistics, and summaries
+```
 
 ## Local validation
 
-All tests are offline and mock `fetch`; they do not need a Sentry token or
-contact Sentry:
+All tests are offline and mock `fetch`; they do not need a Sentry token:
 
 ```sh
 cd workers/sentry-sync
@@ -253,52 +328,40 @@ npm test
 npm run build
 ```
 
-The suite covers full/minimal transforms, property order, unknown and null
-values, zero counts, bounded Markdown, explicit all-status queries, project
-and environment filters, trusted Link parsing, pinned windows, resource and
-credential scope, longer cursor loops, authentication, malformed responses,
-rate-limit resets, and a concrete Worker execution across pages.
-
 For live verification without writing to Notion, copy `.env.example` to `.env`,
-add credentials for a small test project, and stream one local execution:
+add credentials for a small test project, and run:
 
 ```sh
 ntn workers exec issuesSync --local --stream
+ntn workers exec projectsSync --local --stream
+ntn workers exec releasesSync --local --stream
 ```
 
-Then deploy to a test Worker and use `ntn workers exec issuesSync --stream` for
-an end-to-end managed-database run. Confirm that:
+Confirm that recently active resolved and unresolved issues appear; project
+totals match the scoped issue set; current/prior seven-day buckets line up with
+Sentry; newest releases remain one row each with project context; and missing
+Release Health leaves fields absent rather than creating false zeroes.
 
-- resolved and unresolved groups are both present when Sentry returns both;
-- Events (24h) matches the issue group's 24-hour chart;
-- changing a status, priority, or assignee is reflected after the next run;
-- the second page is reached in an organization with more than 100 matching
-  groups;
-- no raw event data or assignee email appears in the local output.
+## Customizing the default set
 
-## Extending the example
+To remove a view from a fork, delete its `worker.database(...)` and
+`worker.sync(...)` blocks from `src/index.ts`, then remove its schema module if
+unused. No environment flag is required.
 
-To add another issue-group field:
-
-1. Add only the selected API shape to `SentryIssue` and validate it in
-   `parseIssue()` in `src/sentry.ts`.
-2. Add the Notion property to `issueSchema` in `src/issues.ts`.
-3. Add the matching transform property in exactly the same order.
-4. Add complete, null, unknown-value, and privacy regression tests.
-5. Update the mapping and recommended views in this README.
-
-Keep raw event details out of this base example. For faster freshness, a
-separate webhook-driven example can upsert changed groups while this full
-refresh remains the reconciliation path. For a project-level database, first
-compute meaningful health aggregates; do not create relations or thin project
-rows merely because the API exposes them.
+When adding fields, retain only the selected provider shape, validate identity
+and null semantics, preserve schema/transform property order, and add complete,
+missing, zero, future-value, privacy, and pagination tests. Keep raw event data
+out of this base example. A webhook-driven fork can improve issue freshness
+while the full refresh remains reconciliation.
 
 ## Official documentation
 
 - [List an organization's issues](https://docs.sentry.io/api/events/list-an-organizations-issues/)
+- [List an organization's projects](https://docs.sentry.io/api/organizations/list-an-organizations-projects/)
+- [List an organization's releases](https://docs.sentry.io/api/releases/list-an-organizations-releases/)
+- [Retrieve Release Health session statistics](https://docs.sentry.io/api/releases/retrieve-release-health-session-statistics/)
 - [Sentry pagination](https://docs.sentry.io/api/pagination/)
-- [Sentry API rate limits](https://docs.sentry.io/api/ratelimits/)
-- [Sentry API authentication](https://docs.sentry.io/api/auth/)
-- [Sentry API permissions](https://docs.sentry.io/api/permissions/)
+- [Sentry rate limits](https://docs.sentry.io/api/ratelimits/)
+- [Sentry authentication and permissions](https://docs.sentry.io/api/auth/)
 - [Sentry data scrubbing](https://docs.sentry.io/security-legal-pii/scrubbing/)
 - [Notion Workers](https://developers.notion.com/docs/workers)

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -1,0 +1,304 @@
+# Worker sync: Sentry
+
+Bring the Sentry issues that mattered during the last 30 days into Notion for
+triage, operational review, and cross-functional visibility. The Worker keeps
+one approachable **Sentry Issues — Last 30 Days** database current every 15
+minutes, with native lifecycle signals, recent event volume, user impact,
+ownership, and a link back to Sentry.
+
+The result is useful immediately: create views for unresolved issues,
+regressions, unassigned high-impact errors, recently active issues that are now
+resolved, or concentrations by project without changing the code.
+
+## Quickstart
+
+You need Node.js 22+, a Sentry organization, an
+[internal integration token](#create-a-sentry-token) with `event:read` access,
+and permission to read the projects you want to sync. From the repository
+root:
+
+```sh
+npm install --global ntn
+cd workers/sentry-sync
+npm install
+ntn login
+ntn workers deploy --name sentry-sync
+ntn workers env set SENTRY_AUTH_TOKEN=your-token
+ntn workers env set SENTRY_ORG_SLUG=your-organization-slug
+```
+
+For the first run, scope to one or two production projects. Replace the example
+slug with your Sentry project ID or slug:
+
+```sh
+ntn workers env set SENTRY_PROJECTS=checkout-api
+ntn workers env set SENTRY_ENVIRONMENTS=production
+```
+
+Create and populate the database immediately, while streaming the run output:
+
+```sh
+ntn workers exec issuesSync --stream
+```
+
+The Worker refreshes the database every 15 minutes. It includes issues of
+every status that Sentry considers active in the pinned 30-day query window;
+an issue that is no longer returned by that rolling window is removed from the
+managed database after a complete successful refresh.
+
+## What you can answer
+
+| Question                                                                | Fields to use                                      |
+| ----------------------------------------------------------------------- | -------------------------------------------------- |
+| What is breaking now?                                                   | Status, Priority, Events (24h), Users (30d)        |
+| What is new, regressed, or escalating?                                  | Status Detail, Last Seen                           |
+| Which important or unhandled issues have no owner?                      | Assignee, Priority, Unhandled, Events (30d)        |
+| Which issues are hottest today or have caused the most lifetime impact? | Events (24h), Lifetime Events, Lifetime Users      |
+| Which recently active issues are now resolved or ignored?               | Status, Last Seen                                  |
+| Where are recent issues concentrated?                                   | Project, Platform, Category, Issue Type, Unhandled |
+
+## Reference
+
+### Database and schedule
+
+| Database                         | Sync         | Mode    | Schedule     | Membership                             |
+| -------------------------------- | ------------ | ------- | ------------ | -------------------------------------- |
+| **Sentry Issues — Last 30 Days** | `issuesSync` | replace | Every 15 min | Every status seen in the prior 30 days |
+
+Here, `replace` means a **complete reconciliation**: the Worker reads every API
+page in one pinned snapshot and Notion reconciles membership only after that
+refresh succeeds. It does not delete and recreate the database. Existing rows
+are updated by immutable Sentry issue ID; rows absent from the completed
+30-day snapshot are removed.
+
+One database is deliberate. Active, regressed, unassigned, resolved, and
+project-specific lists are different views of the same issue data, so separate
+managed databases would duplicate rows and make setup harder. A future
+**Sentry Project Health** database would be worthwhile only with distinct
+aggregates such as unresolved counts, high-priority counts, recent events, and
+affected users—not merely project reference metadata.
+
+### Field mapping
+
+| Notion property | Sentry issue-group field               | Type     |
+| --------------- | -------------------------------------- | -------- |
+| Issue           | `title`                                | title    |
+| Status          | `status`                               | select   |
+| Assignee        | `assignedTo.name`                      | richText |
+| Issue Link      | `permalink`                            | url      |
+| Last Seen       | `lastSeen`                             | date     |
+| Priority        | `priority`                             | select   |
+| Status Detail   | `substatus`                            | select   |
+| Level           | `level`                                | select   |
+| Unhandled       | `isUnhandled`                          | checkbox |
+| Events (24h)    | sum of `stats["24h"]`                  | number   |
+| Events (30d)    | query-window `count`                   | number   |
+| Users (30d)     | query-window `userCount`               | number   |
+| Lifetime Events | `lifetime.count`                       | number   |
+| Lifetime Users  | `lifetime.userCount`                   | number   |
+| Project         | `project.name` or `project.slug`       | select   |
+| Category        | `issueCategory`                        | select   |
+| Issue Type      | `issueType`                            | select   |
+| Platform        | issue or project `platform`            | select   |
+| Culprit         | `culprit`                              | richText |
+| First Seen      | `firstSeen`                            | date     |
+| Issue Key       | `shortId` (for example, `CHECKOUT-42`) | richText |
+| Sentry Issue ID | immutable `id`                         | richText |
+
+**Sentry Issue ID** is the primary key. The familiar **Issue Key** remains
+visible for recognition, but it is not used for identity because a display
+identifier is not as durable as Sentry's underlying group ID.
+
+Each page body contains a short, bounded triage snapshot assembled from these
+same group-level fields: status, ownership, 24-hour, 30-day, and lifetime
+impact, native lifecycle signals, location, first/last seen timestamps, and
+the source link. It does not copy raw event payloads.
+
+### Suggested Notion views
+
+- **Active triage:** filter Status to Unresolved; sort by Priority, Events
+  (24h), and Users (30d).
+- **New and regressed:** filter Status Detail to New, Regressed, or Escalating;
+  sort by Last Seen descending.
+- **Needs an owner:** filter Status to Unresolved and Assignee empty, then sort
+  by Unhandled, Priority, and Events (24h).
+- **Largest user impact:** sort by Lifetime Users and Lifetime Events.
+- **Recently active resolutions:** filter Status to Resolved or Ignored and
+  sort by Last Seen. Last Seen is event activity—not the resolution timestamp.
+- **Risk by service:** group by Project or Platform, then sort by Events (24h).
+
+### Project structure
+
+```text
+src/
+├── index.ts      — registers the managed database, schedule, and shared pacer
+├── sentry.ts     — minimal REST client, trusted pagination, and rate limits
+├── sync-state.ts — pinned 30-day window and cursor-loop safeguards
+├── issues.ts     — Notion schema and issue-group transform
+└── helpers.ts    — labels, safe values, statistics, and page summaries
+```
+
+### How it works
+
+1. The Worker calls Sentry's current organization issue-search endpoint,
+   `GET /api/0/organizations/{organization}/issues/`, requesting 100 groups per
+   page. It makes one request per page and performs no per-issue enrichment.
+2. Sentry normally defaults this endpoint to unresolved issues. The client
+   deliberately sends an empty `query=` so the rolling database also includes
+   resolved and ignored issues returned for the window.
+3. The first page fixes an exact `start` and `end` spanning 30 days, plus the
+   base URL, organization, project filters, environment filters, and a
+   non-secret credential fingerprint. That scope remains in serializable sync
+   state through the final page, so a long run cannot slide its window, mix
+   queries, or continue under a newly rotated token with different access.
+   Results use Sentry's `new` sort and request 24-hour group statistics.
+4. Sentry's `Link` header is authoritative. The client continues only when the
+   one `rel="next"` entry declares `results="true"`, extracts its opaque cursor,
+   validates the URL's origin and path, and rebuilds the configured request.
+   Missing links/cursors, duplicate next links, and immediate or longer cursor
+   cycles fail the refresh instead of silently truncating it or looping.
+5. A completed replace-mode run reconciles the whole key set. This catches
+   status, priority, and assignee changes and removes groups that leave the
+   rolling window. Sentry does not expose a reliable general issue mutation
+   timestamp: `lastSeen` records event activity, so it is intentionally not
+   treated as an incremental watermark.
+6. All requests share a conservative 60-request-per-minute client-side pacer.
+   Sentry uses caller- and endpoint-specific frequency and concurrency limits
+   rather than one universal quota. On HTTP 429, the Worker passes usable
+   `Retry-After` and `X-Sentry-Rate-Limit-Reset` delays to the Workers runtime
+   for backoff.
+7. Unknown future enum values remain visible as readable select values. Null
+   values are omitted instead of being mislabeled; meaningful zero counts and
+   a real `false` Unhandled value are preserved.
+
+Every scheduled run reads the complete scoped 30-day result—one request for
+each 100 issue groups. That is intentionally correct for status, priority, and
+assignee changes, but a large unscoped organization can generate substantial
+API traffic. Start with production and the projects your team reviews. If you
+fork the example for a very large scope, use a slower schedule or combine a
+webhook path with this full refresh as reconciliation.
+
+## Sentry access and configuration
+
+### Create a Sentry token
+
+Prefer an organization **internal integration** for a deployed Worker:
+
+1. In Sentry, open **Organization Settings > Developer Settings > Internal
+   Integrations**.
+2. Create an integration dedicated to this Worker.
+3. Grant the least privilege needed to list issue groups: `event:read`.
+4. Copy its token into `SENTRY_AUTH_TOKEN` and store it only with
+   `ntn workers env set`.
+
+A personal authentication token is convenient for testing, but it follows the
+user's access and lifecycle. The internal integration is easier to scope and
+operate independently. The token can sync only organizations, projects, and
+environments it is allowed to read.
+
+### Environment variables
+
+| Variable              | Required | Description                                                                               |
+| --------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `SENTRY_AUTH_TOKEN`   | Yes      | Bearer token with `event:read`                                                            |
+| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                     |
+| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; omit for all projects visible to the token          |
+| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environment names, such as `production,staging`                           |
+| `SENTRY_BASE_URL`     | No       | HTTPS root for self-hosted Sentry; defaults to `https://sentry.io` and must omit `/api/0` |
+
+For example, scope a deployed Worker to two services and production:
+
+```sh
+ntn workers env set SENTRY_PROJECTS=checkout-api,billing-api
+ntn workers env set SENTRY_ENVIRONMENTS=production
+```
+
+For self-hosted Sentry:
+
+```sh
+ntn workers env set SENTRY_BASE_URL=https://sentry.example.com
+```
+
+The client requires HTTPS before sending its bearer token; loopback HTTP is
+accepted only for local development. Self-hosted versions can lag Sentry SaaS,
+so the parser accepts absent optional fields and future enum values but fails
+visibly if required identity or pagination contracts are missing.
+
+## Privacy and operational boundaries
+
+This example intentionally fetches only Sentry **issue-group metadata**. It
+does not request raw events, stack traces, breadcrumbs, request bodies,
+headers, query strings, tags, attachments, event users, IP addresses, or event
+contexts. The parser retains an assignee's display name but discards email and
+unselected response fields. It also avoids N+1 detail requests.
+
+Issue titles and culprits can still contain customer, code, or infrastructure
+details. Review Sentry's server-side data-scrubbing settings and the Notion
+database's sharing permissions before syncing production data to a broader
+audience.
+
+This is a one-way mirror. Changes in Notion do not update Sentry. Sentry
+remains the system of record and every row includes a direct source link.
+
+## Local validation
+
+All tests are offline and mock `fetch`; they do not need a Sentry token or
+contact Sentry:
+
+```sh
+cd workers/sentry-sync
+npm install
+npm run check
+npm test
+npm run build
+```
+
+The suite covers full/minimal transforms, property order, unknown and null
+values, zero counts, bounded Markdown, explicit all-status queries, project
+and environment filters, trusted Link parsing, pinned windows, resource and
+credential scope, longer cursor loops, authentication, malformed responses,
+rate-limit resets, and a concrete Worker execution across pages.
+
+For live verification without writing to Notion, copy `.env.example` to `.env`,
+add credentials for a small test project, and stream one local execution:
+
+```sh
+ntn workers exec issuesSync --local --stream
+```
+
+Then deploy to a test Worker and use `ntn workers exec issuesSync --stream` for
+an end-to-end managed-database run. Confirm that:
+
+- resolved and unresolved groups are both present when Sentry returns both;
+- Events (24h) matches the issue group's 24-hour chart;
+- changing a status, priority, or assignee is reflected after the next run;
+- the second page is reached in an organization with more than 100 matching
+  groups;
+- no raw event data or assignee email appears in the local output.
+
+## Extending the example
+
+To add another issue-group field:
+
+1. Add only the selected API shape to `SentryIssue` and validate it in
+   `parseIssue()` in `src/sentry.ts`.
+2. Add the Notion property to `issueSchema` in `src/issues.ts`.
+3. Add the matching transform property in exactly the same order.
+4. Add complete, null, unknown-value, and privacy regression tests.
+5. Update the mapping and recommended views in this README.
+
+Keep raw event details out of this base example. For faster freshness, a
+separate webhook-driven example can upsert changed groups while this full
+refresh remains the reconciliation path. For a project-level database, first
+compute meaningful health aggregates; do not create relations or thin project
+rows merely because the API exposes them.
+
+## Official documentation
+
+- [List an organization's issues](https://docs.sentry.io/api/events/list-an-organizations-issues/)
+- [Sentry pagination](https://docs.sentry.io/api/pagination/)
+- [Sentry API rate limits](https://docs.sentry.io/api/ratelimits/)
+- [Sentry API authentication](https://docs.sentry.io/api/auth/)
+- [Sentry API permissions](https://docs.sentry.io/api/permissions/)
+- [Sentry data scrubbing](https://docs.sentry.io/security-legal-pii/scrubbing/)
+- [Notion Workers](https://developers.notion.com/docs/workers)

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -43,12 +43,12 @@ are not saved as separate partial environment updates. Start with one or two
 production projects; replace `checkout-api` with a comma-separated list of
 Sentry project IDs or slugs.
 
-Create and populate all three databases while streaming each run:
+Create and populate all three databases:
 
 ```sh
-ntn workers exec issuesSync --stream
-ntn workers exec projectsSync --stream
-ntn workers exec releasesSync --stream
+ntn workers sync trigger issuesSync
+ntn workers sync trigger projectsSync
+ntn workers sync trigger releasesSync
 ```
 
 After all three commands complete, the workspace contains managed databases
@@ -183,10 +183,24 @@ metrics.
 - **Rollout watch:** sort releases by Released At descending, then Crash-Free
   Sessions and Sessions (7d).
 - **Missing release telemetry:** filter Health Data (7d) unchecked. Empty means
-  Sentry returned no health row, no session telemetry exists, or the sessions
-  request used the Worker's 404 fallback described below.
+  a successful Sentry response returned no matching health row or no session
+  telemetry exists for that release and scope.
 
 ## How it works
+
+### Contract boundary
+
+All provider calls use the four public Sentry REST endpoints linked below and
+only parameters documented for those endpoints. The example does not use
+Sentry alpha, early-access, internal, or undocumented APIs. Sentry's `/api/0`
+path is its documented public REST namespace, not an API maturity label.
+
+On the Notion side, the example imports only public exports documented for
+`@notionhq/workers`; it does not import SDK internals. The current Notion CLI
+labels Workers as Beta, which is a platform-level constraint shared by Worker
+examples rather than a hidden dependency of this integration. The conservative
+continuation-state budget and explicit property clearing reflect current
+Workers runtime behavior and should be revalidated when upgrading the Beta SDK.
 
 ### Rolling issue triage
 
@@ -194,12 +208,15 @@ The Worker calls Sentry's current organization issue-search endpoint with an
 explicit empty `query=`. Sentry otherwise defaults the endpoint to unresolved
 issues, while this example needs recently active resolved and ignored groups
 for review as well. The first page pins an exact 30-day `start` and `end`, base
-URL, organization, filters, and a non-secret credential fingerprint.
+URL, organization, and filters. Each request reads the currently configured
+token so routine rotation cannot strand an in-progress refresh.
 
 Every page requests 100 groups and 24-hour group statistics. Sentry's `Link`
 header is authoritative: the Worker continues only when the one trusted
 `rel="next"` entry declares `results="true"`. Missing or malformed links,
-untrusted origins/paths, duplicate next links, and cursor cycles fail closed.
+untrusted origins/paths, duplicate next links, and repeated recent cursors fail
+closed. Cursor fingerprints use a fixed-size history so long traversals do not
+grow continuation state or introduce an artificial page limit.
 
 ### Service-level reliability
 
@@ -216,23 +233,27 @@ Projects with no matching issues still appear. An issue aggregate whose
 project was deleted or became inaccessible is retained using the issue's
 project metadata so risk does not disappear silently.
 
-Continuation state has a 240 KiB safety budget below Workers' 256 KiB runtime
-limit, plus a secondary cap of 500 active projects. Metadata length varies, so
-the serialized-state budget can be reached first. Larger organizations should
-set `SENTRY_PROJECTS`; crossing either boundary fails with an actionable error
-rather than truncating the snapshot or returning invalid continuation state.
+Continuation state remains below Workers' 256 KiB runtime limit, with reserved
+headroom for compact cursor history and a secondary cap of 500 active projects.
+Metadata length varies, so the serialized-state budget can be reached first.
+If either aggregation boundary is reached, the Worker checkpoints before any
+project rows are written and asks for a narrower project or environment scope.
+After the configured scope changes, it automatically restarts from a fresh
+window instead of retrying an unrecoverable oversized state. During project
+inventory pagination, emitted aggregates are removed so continuation state
+shrinks while rows are written.
+
+Apply the narrower scope with `ntn workers env set`, then rerun
+`ntn workers sync trigger projectsSync`. No sync-state reset is required.
 
 ### Recent rollout health
 
-The release refresh deliberately requests only the first 100 releases from the
-endpoint's most-recent-first default order, so this is an explicit useful set
-rather than accidental pagination truncation. The Worker sends configured
-project and environment filters plus an explicit empty `status=` to the release
-request. Sentry's public list-releases reference documents the project filter,
-but not environment or status for this endpoint. Their effect on release
-membership is therefore compatibility behavior, not a portable guarantee
-across Sentry SaaS and self-hosted versions. The separate Release Health query
-always applies the explicit project and environment scope shown in Notion.
+The release refresh deliberately requests the maximum 100 releases from
+Sentry's documented most-recent-first organization endpoint, so this is an
+explicit useful set rather than accidental pagination truncation. The Worker
+uses only the endpoint's documented project and environment filters. The
+separate Release Health query applies the same explicit project and environment
+scope shown in Notion.
 
 One additional sessions request groups the prior seven days by release across
 the configured project and environment scope, requests totals without
@@ -244,13 +265,11 @@ that conservative request also remains below Sentry's documented
 10,000-data-point constraint even if the service computes series before
 omitting them from the response.
 
-An empty health result is valid and clears unavailable metrics. The Worker also
-treats any 404 from the sessions endpoint as unavailable health and preserves
-release metadata. That fallback does not prove that the Sentry installation is
-too old: if health was expected, check the organization, route, permissions,
-proxy, and Sentry version. Explicit 401/403 authentication and authorization
-responses, malformed data, timeouts, 429s, and other non-404 API errors remain
-visible failures.
+A successful empty health result is valid and clears unavailable metrics. API
+errors, including 404s, remain visible failures rather than being interpreted
+as absent telemetry. Because the release sync uses replacement semantics, a
+failed health request does not publish a partial snapshot or clear previously
+valid rows.
 
 ### Rate limits and request safety
 
@@ -261,14 +280,17 @@ limit. On HTTP 429, the Worker passes usable `Retry-After` and
 
 Requests have a 30-second timeout, reject redirects, and send the bearer token
 only to a validated HTTPS base URL. Loopback HTTP is allowed for local testing.
-The token fingerprint prevents a multi-page refresh from continuing under a
-rotated credential with different access.
+Authentication and authorization errors remain visible rather than being
+reinterpreted as empty provider data.
 
 ## Sentry access and configuration
 
 ### Create a Sentry token
 
 Prefer an organization **internal integration** for a deployed Worker:
+
+“Internal integration” is Sentry's name for an organization-owned credential;
+it does not mean this example calls an internal or alpha API.
 
 1. Open **Organization Settings > Developer Settings > Internal
    Integrations**.
@@ -283,13 +305,13 @@ convenient for testing but follows that user's access and lifecycle.
 
 ### Environment variables
 
-| Variable              | Required | Description                                                                          |
-| --------------------- | -------- | ------------------------------------------------------------------------------------ |
-| `SENTRY_AUTH_TOKEN`   | Yes      | Bearer token with `event:read`, `org:read`, and `project:releases`                   |
-| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                |
-| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; scopes issues, projects, releases, and health  |
-| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environments; scopes issues, project aggregates, and release health  |
-| `SENTRY_BASE_URL`     | No       | HTTPS root for self-hosted Sentry; defaults to `https://sentry.io`, without API path |
+| Variable              | Required | Description                                                                           |
+| --------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `SENTRY_AUTH_TOKEN`   | Yes      | Bearer token with `event:read`, `org:read`, and `project:releases`                    |
+| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                 |
+| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; scopes issues, projects, releases, and health   |
+| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environments; scopes issues, project aggregates, releases, and health |
+| `SENTRY_BASE_URL`     | No       | HTTPS root for self-hosted Sentry; defaults to `https://sentry.io`, without API path  |
 
 For self-hosted Sentry:
 
@@ -348,9 +370,9 @@ For live verification without writing to Notion, copy `.env.example` to `.env`,
 add credentials for a small test project, and run:
 
 ```sh
-ntn workers exec issuesSync --local --stream
-ntn workers exec projectsSync --local --stream
-ntn workers exec releasesSync --local --stream
+ntn workers sync trigger issuesSync --local --preview
+ntn workers sync trigger projectsSync --local --preview
+ntn workers sync trigger releasesSync --local --preview
 ```
 
 Keep generated and machine-local files out of commits. `.env`, `workers.json`,
@@ -360,9 +382,9 @@ deployment does not require committing its generated Worker configuration.
 
 Confirm that recently active resolved and unresolved issues appear; project
 totals match the scoped issue set; current/prior seven-day buckets line up with
-Sentry; newest releases remain one row each with project context; and missing
-Release Health clears prior fields rather than retaining stale values or
-creating false zeroes.
+Sentry; newest releases remain one row each with project context; and a
+successful health response without a matching release group clears prior
+metrics rather than retaining stale values or creating false zeroes.
 
 ## Customizing the default set
 
@@ -390,8 +412,10 @@ the visible schema:
    an immutable provider ID as the primary key.
 3. **Lifecycle contract:** register a new database, sync, and schedule in
    `src/index.ts`. Pin the time window and `SentryScope` for the full refresh,
-   validate cursor traversal with `nextCursorTraversal`, and pass every
-   continuation through `boundedSyncState` in `src/sync-state.ts`.
+   validate cursor traversal with `nextCursorTraversal`, and enforce the
+   continuation limits in `src/sync-state.ts`. If state can grow before any
+   rows are emitted, prefer a small recoverable checkpoint like the projects
+   sync rather than stranding an oversized continuation.
 4. **Completeness contract:** exhaustive syncs must follow trusted pagination
    until a terminal `hasMore: false`; never silently stop and call a partial
    result complete. If a deliberately bounded snapshot is more useful, as with
@@ -415,4 +439,6 @@ issue freshness while the full refresh remains reconciliation.
 - [Sentry rate limits](https://docs.sentry.io/api/ratelimits/)
 - [Sentry authentication and permissions](https://docs.sentry.io/api/auth/)
 - [Sentry data scrubbing](https://docs.sentry.io/security-legal-pii/scrubbing/)
-- [Notion Workers](https://developers.notion.com/docs/workers)
+- [Notion Workers overview](https://developers.notion.com/workers/get-started/overview)
+- [Workers SDK reference](https://developers.notion.com/workers/reference/sdk)
+- [Workers sync guide](https://developers.notion.com/workers/guides/syncs)

--- a/workers/sentry-sync/package.json
+++ b/workers/sentry-sync/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@notion-cookbook/sentry-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --project tsconfig.test.json",
+    "test": "node --import tsx --test test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": "^0.4.0"
+  }
+}

--- a/workers/sentry-sync/src/helpers.ts
+++ b/workers/sentry-sync/src/helpers.ts
@@ -1,0 +1,190 @@
+const MAX_TITLE_CHARACTERS = 2_000
+const MAX_PROPERTY_CHARACTERS = 2_000
+const MAX_SELECT_CHARACTERS = 100
+const MAX_PAGE_VALUE_CHARACTERS = 500
+
+function unicodeSlice(value: string, limit: number): string {
+  const characters = Array.from(value)
+  if (characters.length <= limit) return value
+  return `${characters.slice(0, Math.max(0, limit - 1)).join("")}…`
+}
+
+export function titleText(value: string | null | undefined): string {
+  const text = value?.trim() || "Untitled Sentry issue"
+  return unicodeSlice(text, MAX_TITLE_CHARACTERS)
+}
+
+export function propertyText(value: string | null | undefined): string | null {
+  const text = value?.trim()
+  return text ? unicodeSlice(text, MAX_PROPERTY_CHARACTERS) : null
+}
+
+export function selectText(value: string | null | undefined): string | null {
+  const text = value?.trim()
+  return text
+    ? unicodeSlice(formatSentryLabel(text), MAX_SELECT_CHARACTERS)
+    : null
+}
+
+export function formatSentryLabel(value: string): string {
+  const spaced = value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+
+  return spaced.replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+export function dateTime(value: string | null | undefined): string | null {
+  const timestamp = value?.trim()
+  return timestamp && Number.isFinite(Date.parse(timestamp)) ? timestamp : null
+}
+
+export function nonnegativeNumber(
+  value: string | number | null | undefined
+): number | null {
+  if (value === null || value === undefined || value === "") return null
+  const number = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(number) && number >= 0 ? number : null
+}
+
+export type SentryStats = Record<string, Array<[number, number]>>
+
+export function summedStats(
+  stats: SentryStats | null | undefined,
+  period: string
+): number | null {
+  const points = stats?.[period]
+  if (!points) return null
+
+  let total = 0
+  for (const [, count] of points) {
+    if (!Number.isFinite(count) || count < 0) return null
+    total += count
+    if (!Number.isFinite(total)) return null
+  }
+  return total
+}
+
+export function safeHttpUrl(value: string | null | undefined): string | null {
+  const text = value?.trim()
+  if (!text) return null
+
+  try {
+    const url = new URL(text)
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? url.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function escapeMarkdown(value: string): string {
+  return value.replace(/([\\`*_[\]{}()#+\-.!>|<>])/g, "\\$1")
+}
+
+function markdownValue(value: string): string {
+  return escapeMarkdown(unicodeSlice(value, MAX_PAGE_VALUE_CHARACTERS))
+}
+
+function plural(count: number, singular: string): string {
+  return `${count.toLocaleString("en-US")} ${singular}${count === 1 ? "" : "s"}`
+}
+
+export type TriageIssue = {
+  status: string | null
+  substatus: string | null
+  priority: string | null
+  level: string | null
+  isUnhandled: boolean | null
+  assignedTo: { name: string | null } | null
+  project: { name: string | null; slug: string | null } | null
+  platform: string | null
+  culprit: string | null
+  firstSeen: string | null
+  lastSeen: string | null
+  permalink: string | null
+  count: string | number | null
+  userCount: string | number | null
+  lifetime: {
+    count: string | number | null
+    userCount: string | number | null
+  } | null
+  stats: SentryStats | null
+}
+
+/** Build a bounded triage brief from group metadata, never raw event data. */
+export function issuePageContent(issue: TriageIssue): string {
+  const status = selectText(issue.status)
+  const detail = selectText(issue.substatus)
+  const priority = selectText(issue.priority)
+  const level = selectText(issue.level)
+  const assignee = propertyText(issue.assignedTo?.name)
+  const project = propertyText(issue.project?.name ?? issue.project?.slug)
+  const platform = propertyText(issue.platform)
+  const culprit = propertyText(issue.culprit)
+  const firstSeen = dateTime(issue.firstSeen)
+  const lastSeen = dateTime(issue.lastSeen)
+  const recentEvents = summedStats(issue.stats, "24h")
+  const windowEvents = nonnegativeNumber(issue.count)
+  const windowUsers = nonnegativeNumber(issue.userCount)
+  const lifetimeEvents = nonnegativeNumber(issue.lifetime?.count)
+  const lifetimeUsers = nonnegativeNumber(issue.lifetime?.userCount)
+  const url = safeHttpUrl(issue.permalink)
+
+  const signals = [
+    detail && ["New", "Regressed", "Escalating"].includes(detail)
+      ? detail
+      : null,
+    priority === "High" ? "High priority" : null,
+    level === "Fatal" ? "Fatal" : null,
+    issue.isUnhandled === true ? "Unhandled" : null,
+    !assignee && status === "Unresolved" ? "Unassigned" : null,
+  ].filter((value): value is string => Boolean(value))
+
+  const lines = [
+    `- **Status:** ${markdownValue(
+      [status, detail].filter(Boolean).join(" · ") || "Not provided"
+    )}`,
+    `- **Owner:** ${markdownValue(assignee || "Unassigned")}`,
+    recentEvents === null
+      ? null
+      : `- **Last 24 hours:** ${plural(recentEvents, "event")}`,
+    windowEvents === null && windowUsers === null
+      ? null
+      : `- **30-day impact:** ${[
+          windowEvents === null ? null : plural(windowEvents, "event"),
+          windowUsers === null ? null : plural(windowUsers, "user"),
+        ]
+          .filter(Boolean)
+          .join(" · ")}`,
+    lifetimeEvents === null && lifetimeUsers === null
+      ? null
+      : `- **Lifetime impact:** ${[
+          lifetimeEvents === null ? null : plural(lifetimeEvents, "event"),
+          lifetimeUsers === null ? null : plural(lifetimeUsers, "user"),
+        ]
+          .filter(Boolean)
+          .join(" · ")}`,
+    signals.length > 0
+      ? `- **Triage signals:** ${signals.map(markdownValue).join(" · ")}`
+      : null,
+    project || platform
+      ? `- **Location:** ${[project, platform]
+          .filter((value): value is string => Boolean(value))
+          .map(markdownValue)
+          .join(" · ")}`
+      : null,
+    culprit ? `- **Culprit:** ${markdownValue(culprit)}` : null,
+    firstSeen ? `- **First seen:** ${firstSeen}` : null,
+    lastSeen ? `- **Last seen:** ${lastSeen}` : null,
+  ].filter((line): line is string => Boolean(line))
+
+  const source = url
+    ? `\n\n[Open this issue in Sentry](${url
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29")})`
+    : ""
+  return `## Triage snapshot\n\n${lines.join("\n")}${source}`
+}

--- a/workers/sentry-sync/src/helpers.ts
+++ b/workers/sentry-sync/src/helpers.ts
@@ -1,7 +1,6 @@
 const MAX_TITLE_CHARACTERS = 2_000
 const MAX_PROPERTY_CHARACTERS = 2_000
 const MAX_SELECT_CHARACTERS = 100
-const MAX_PAGE_VALUE_CHARACTERS = 500
 
 function unicodeSlice(value: string, limit: number): string {
   const characters = Array.from(value)
@@ -9,8 +8,11 @@ function unicodeSlice(value: string, limit: number): string {
   return `${characters.slice(0, Math.max(0, limit - 1)).join("")}…`
 }
 
-export function titleText(value: string | null | undefined): string {
-  const text = value?.trim() || "Untitled Sentry issue"
+export function titleText(
+  value: string | null | undefined,
+  fallback: string
+): string {
+  const text = value?.trim() || fallback
   return unicodeSlice(text, MAX_TITLE_CHARACTERS)
 }
 
@@ -82,109 +84,4 @@ export function safeHttpUrl(value: string | null | undefined): string | null {
 
 export function escapeMarkdown(value: string): string {
   return value.replace(/([\\`*_[\]{}()#+\-.!>|<>])/g, "\\$1")
-}
-
-function markdownValue(value: string): string {
-  return escapeMarkdown(unicodeSlice(value, MAX_PAGE_VALUE_CHARACTERS))
-}
-
-function plural(count: number, singular: string): string {
-  return `${count.toLocaleString("en-US")} ${singular}${count === 1 ? "" : "s"}`
-}
-
-export type TriageIssue = {
-  status: string | null
-  substatus: string | null
-  priority: string | null
-  level: string | null
-  isUnhandled: boolean | null
-  assignedTo: { name: string | null } | null
-  project: { name: string | null; slug: string | null } | null
-  platform: string | null
-  culprit: string | null
-  firstSeen: string | null
-  lastSeen: string | null
-  permalink: string | null
-  count: string | number | null
-  userCount: string | number | null
-  lifetime: {
-    count: string | number | null
-    userCount: string | number | null
-  } | null
-  stats: SentryStats | null
-}
-
-/** Build a bounded triage brief from group metadata, never raw event data. */
-export function issuePageContent(issue: TriageIssue): string {
-  const status = selectText(issue.status)
-  const detail = selectText(issue.substatus)
-  const priority = selectText(issue.priority)
-  const level = selectText(issue.level)
-  const assignee = propertyText(issue.assignedTo?.name)
-  const project = propertyText(issue.project?.name ?? issue.project?.slug)
-  const platform = propertyText(issue.platform)
-  const culprit = propertyText(issue.culprit)
-  const firstSeen = dateTime(issue.firstSeen)
-  const lastSeen = dateTime(issue.lastSeen)
-  const recentEvents = summedStats(issue.stats, "24h")
-  const windowEvents = nonnegativeNumber(issue.count)
-  const windowUsers = nonnegativeNumber(issue.userCount)
-  const lifetimeEvents = nonnegativeNumber(issue.lifetime?.count)
-  const lifetimeUsers = nonnegativeNumber(issue.lifetime?.userCount)
-  const url = safeHttpUrl(issue.permalink)
-
-  const signals = [
-    detail && ["New", "Regressed", "Escalating"].includes(detail)
-      ? detail
-      : null,
-    priority === "High" ? "High priority" : null,
-    level === "Fatal" ? "Fatal" : null,
-    issue.isUnhandled === true ? "Unhandled" : null,
-    !assignee && status === "Unresolved" ? "Unassigned" : null,
-  ].filter((value): value is string => Boolean(value))
-
-  const lines = [
-    `- **Status:** ${markdownValue(
-      [status, detail].filter(Boolean).join(" · ") || "Not provided"
-    )}`,
-    `- **Owner:** ${markdownValue(assignee || "Unassigned")}`,
-    recentEvents === null
-      ? null
-      : `- **Last 24 hours:** ${plural(recentEvents, "event")}`,
-    windowEvents === null && windowUsers === null
-      ? null
-      : `- **30-day impact:** ${[
-          windowEvents === null ? null : plural(windowEvents, "event"),
-          windowUsers === null ? null : plural(windowUsers, "user"),
-        ]
-          .filter(Boolean)
-          .join(" · ")}`,
-    lifetimeEvents === null && lifetimeUsers === null
-      ? null
-      : `- **Lifetime impact:** ${[
-          lifetimeEvents === null ? null : plural(lifetimeEvents, "event"),
-          lifetimeUsers === null ? null : plural(lifetimeUsers, "user"),
-        ]
-          .filter(Boolean)
-          .join(" · ")}`,
-    signals.length > 0
-      ? `- **Triage signals:** ${signals.map(markdownValue).join(" · ")}`
-      : null,
-    project || platform
-      ? `- **Location:** ${[project, platform]
-          .filter((value): value is string => Boolean(value))
-          .map(markdownValue)
-          .join(" · ")}`
-      : null,
-    culprit ? `- **Culprit:** ${markdownValue(culprit)}` : null,
-    firstSeen ? `- **First seen:** ${firstSeen}` : null,
-    lastSeen ? `- **Last seen:** ${lastSeen}` : null,
-  ].filter((line): line is string => Boolean(line))
-
-  const source = url
-    ? `\n\n[Open this issue in Sentry](${url
-        .replace(/\(/g, "%28")
-        .replace(/\)/g, "%29")})`
-    : ""
-  return `## Triage snapshot\n\n${lines.join("\n")}${source}`
 }

--- a/workers/sentry-sync/src/index.ts
+++ b/workers/sentry-sync/src/index.ts
@@ -1,6 +1,5 @@
-// Entry point — maintains one rolling Sentry issue database for operational
-// triage and recent review. Every run is a complete, paginated reconciliation
-// of issue groups seen during the pinned prior 30 days.
+// Three default, complementary Sentry views: recent issue triage, project
+// reliability signals, and rollout health for the newest releases.
 
 import { Worker } from "@notionhq/workers"
 
@@ -10,18 +9,45 @@ import {
   issueSchema,
   issueToChange,
 } from "./issues.js"
-import { fetchIssuesPage, getIssueScope } from "./sentry.js"
+import {
+  INITIAL_TITLE as PROJECTS_TITLE,
+  PRIMARY_KEY as PROJECTS_PK,
+  aggregateProjectIssues,
+  aggregateProjectResource,
+  projectMatchesScope,
+  projectSchema,
+  projectToChange,
+  type ProjectAggregateMap,
+} from "./projects.js"
+import {
+  INITIAL_TITLE as RELEASES_TITLE,
+  PRIMARY_KEY as RELEASES_PK,
+  releaseHealthWindow,
+  releaseSchema,
+  releasesToChanges,
+} from "./releases.js"
+import {
+  SentryApiError,
+  fetchIssuesPage,
+  fetchProjectsPage,
+  fetchRecentReleases,
+  fetchReleaseHealth,
+  getSentryScope,
+  type SentryScope,
+} from "./sentry.js"
 import {
   issueWindow,
+  nextCursorTraversal,
   nextIssueState,
   type IssueSyncState,
+  type IssueWindow,
 } from "./sync-state.js"
 
 const worker = new Worker()
 
 // Sentry applies caller- and endpoint-specific frequency/concurrency limits,
-// rather than publishing one universal quota. Serialize all issue-list calls
-// through a conservative shared courtesy cap and still honor 429/reset headers.
+// rather than publishing one universal quota. Serialize all calls through a
+// conservative shared courtesy cap and still honor 429/reset headers.
 const pacer = worker.pacer("sentry", {
   allowedRequests: 60,
   intervalMs: 60_000,
@@ -44,7 +70,7 @@ worker.sync("issuesSync", {
     // Pin resource scope with the first page as well as the time window. If an
     // environment variable changes mid-run, the current snapshot finishes
     // against its original query and the new scope starts on the next cycle.
-    const scope = state?.scope ?? getIssueScope()
+    const scope = state?.scope ?? getSentryScope()
     const page = await fetchIssuesPage(
       beforeSentryRequest,
       {
@@ -60,6 +86,186 @@ worker.sync("issuesSync", {
       nextState: page.hasMore
         ? nextIssueState(state, window, scope, page.nextCursor)
         : undefined,
+    }
+  },
+})
+
+type ProjectIssueState = IssueSyncState & {
+  phase: "issues"
+  aggregates: ProjectAggregateMap
+}
+
+type ProjectRowsState = {
+  phase: "projects"
+  start: string
+  end: string
+  scope: SentryScope
+  aggregates: ProjectAggregateMap
+  unmatchedProjectIds: string[]
+  cursor?: string
+  seenCursors?: string[]
+}
+
+export type ProjectSyncState = ProjectIssueState | ProjectRowsState
+
+const projects = worker.database("projects", {
+  type: "managed",
+  initialTitle: PROJECTS_TITLE,
+  primaryKeyProperty: PROJECTS_PK,
+  schema: projectSchema,
+})
+
+worker.sync("projectsSync", {
+  database: projects,
+  mode: "replace",
+  schedule: "1d",
+  execute: async (previousState: ProjectSyncState | undefined) => {
+    let state = previousState
+    if (!state) {
+      const window = issueWindow(undefined)
+      state = {
+        phase: "issues",
+        ...window,
+        scope: getSentryScope(),
+        aggregates: {},
+      }
+    }
+
+    const window: IssueWindow = issueWindow(state)
+    if (state.phase === "issues") {
+      const page = await fetchIssuesPage(
+        beforeSentryRequest,
+        {
+          ...window,
+          cursor: state.cursor,
+          statsPeriod: "14d",
+        },
+        state.scope
+      )
+      const aggregates = aggregateProjectIssues(
+        state.aggregates,
+        page.resources,
+        window
+      )
+
+      if (page.hasMore) {
+        const next = nextIssueState(state, window, state.scope, page.nextCursor)
+        return {
+          changes: [],
+          hasMore: true,
+          nextState: {
+            phase: "issues" as const,
+            ...next,
+            aggregates,
+          },
+        }
+      }
+
+      return {
+        changes: [],
+        hasMore: true,
+        nextState: {
+          phase: "projects" as const,
+          ...window,
+          scope: state.scope,
+          aggregates,
+          unmatchedProjectIds: Object.keys(aggregates),
+        },
+      }
+    }
+
+    const page = await fetchProjectsPage(
+      beforeSentryRequest,
+      state.cursor,
+      state.scope
+    )
+    const resources = page.resources.filter((project) =>
+      projectMatchesScope(project, state.scope)
+    )
+    const returnedIds = new Set(resources.map((project) => project.id))
+    const unmatchedProjectIds = state.unmatchedProjectIds.filter(
+      (projectId) => !returnedIds.has(projectId)
+    )
+    const changes = resources.map((project) =>
+      projectToChange(
+        project,
+        state.aggregates[project.id],
+        window.end,
+        state.scope
+      )
+    )
+
+    if (page.hasMore) {
+      const traversal = nextCursorTraversal(
+        state.cursor,
+        state.seenCursors,
+        page.nextCursor,
+        "project"
+      )
+      return {
+        changes,
+        hasMore: true,
+        nextState: {
+          ...state,
+          ...traversal,
+          unmatchedProjectIds,
+        },
+      }
+    }
+
+    // An issue can outlive a deleted/inaccessible project record. Preserve its
+    // aggregate with current issue metadata rather than silently dropping risk.
+    const fallbackChanges = unmatchedProjectIds.map((projectId) =>
+      projectToChange(
+        aggregateProjectResource(state.aggregates[projectId]),
+        state.aggregates[projectId],
+        window.end,
+        state.scope
+      )
+    )
+    return { changes: [...changes, ...fallbackChanges], hasMore: false }
+  },
+})
+
+const releases = worker.database("releases", {
+  type: "managed",
+  initialTitle: RELEASES_TITLE,
+  primaryKeyProperty: RELEASES_PK,
+  schema: releaseSchema,
+})
+
+worker.sync("releasesSync", {
+  database: releases,
+  mode: "replace",
+  schedule: "15m",
+  execute: async () => {
+    const scope = getSentryScope()
+    const window = releaseHealthWindow()
+    const recentReleases = await fetchRecentReleases(beforeSentryRequest, scope)
+    if (recentReleases.length === 0) {
+      return { changes: [], hasMore: false }
+    }
+
+    let health
+    try {
+      health = await fetchReleaseHealth(
+        beforeSentryRequest,
+        window.start,
+        window.end,
+        scope
+      )
+    } catch (error) {
+      // Older self-hosted Sentry versions can expose release metadata without
+      // the sessions endpoint. Keep those rows useful; all other failures,
+      // including missing org:read, remain actionable.
+      if (!(error instanceof SentryApiError) || error.status !== 404)
+        throw error
+      health = { available: false, start: null, end: null, groups: [] }
+    }
+
+    return {
+      changes: releasesToChanges(recentReleases, health, scope),
+      hasMore: false,
     }
   },
 })

--- a/workers/sentry-sync/src/index.ts
+++ b/workers/sentry-sync/src/index.ts
@@ -36,6 +36,7 @@ import {
   type SentryScope,
 } from "./sentry.js"
 import {
+  boundedSyncState,
   issueWindow,
   nextCursorTraversal,
   nextIssueState,
@@ -84,7 +85,10 @@ worker.sync("issuesSync", {
       changes: page.resources.map(issueToChange),
       hasMore: page.hasMore,
       nextState: page.hasMore
-        ? nextIssueState(state, window, scope, page.nextCursor)
+        ? boundedSyncState(
+            nextIssueState(state, window, scope, page.nextCursor),
+            "issue pagination"
+          )
         : undefined,
     }
   },
@@ -153,24 +157,30 @@ worker.sync("projectsSync", {
         return {
           changes: [],
           hasMore: true,
-          nextState: {
-            phase: "issues" as const,
-            ...next,
-            aggregates,
-          },
+          nextState: boundedSyncState(
+            {
+              phase: "issues" as const,
+              ...next,
+              aggregates,
+            },
+            "project aggregation"
+          ),
         }
       }
 
       return {
         changes: [],
         hasMore: true,
-        nextState: {
-          phase: "projects" as const,
-          ...window,
-          scope: state.scope,
-          aggregates,
-          unmatchedProjectIds: Object.keys(aggregates),
-        },
+        nextState: boundedSyncState(
+          {
+            phase: "projects" as const,
+            ...window,
+            scope: state.scope,
+            aggregates,
+            unmatchedProjectIds: Object.keys(aggregates),
+          },
+          "project aggregation"
+        ),
       }
     }
 
@@ -205,11 +215,14 @@ worker.sync("projectsSync", {
       return {
         changes,
         hasMore: true,
-        nextState: {
-          ...state,
-          ...traversal,
-          unmatchedProjectIds,
-        },
+        nextState: boundedSyncState(
+          {
+            ...state,
+            ...traversal,
+            unmatchedProjectIds,
+          },
+          "project inventory"
+        ),
       }
     }
 

--- a/workers/sentry-sync/src/index.ts
+++ b/workers/sentry-sync/src/index.ts
@@ -1,0 +1,67 @@
+// Entry point — maintains one rolling Sentry issue database for operational
+// triage and recent review. Every run is a complete, paginated reconciliation
+// of issue groups seen during the pinned prior 30 days.
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  INITIAL_TITLE as ISSUES_TITLE,
+  PRIMARY_KEY as ISSUES_PK,
+  issueSchema,
+  issueToChange,
+} from "./issues.js"
+import { fetchIssuesPage, getIssueScope } from "./sentry.js"
+import {
+  issueWindow,
+  nextIssueState,
+  type IssueSyncState,
+} from "./sync-state.js"
+
+const worker = new Worker()
+
+// Sentry applies caller- and endpoint-specific frequency/concurrency limits,
+// rather than publishing one universal quota. Serialize all issue-list calls
+// through a conservative shared courtesy cap and still honor 429/reset headers.
+const pacer = worker.pacer("sentry", {
+  allowedRequests: 60,
+  intervalMs: 60_000,
+})
+const beforeSentryRequest = () => pacer.wait()
+
+const issues = worker.database("issues", {
+  type: "managed",
+  initialTitle: ISSUES_TITLE,
+  primaryKeyProperty: ISSUES_PK,
+  schema: issueSchema,
+})
+
+worker.sync("issuesSync", {
+  database: issues,
+  mode: "replace",
+  schedule: "15m",
+  execute: async (state: IssueSyncState | undefined) => {
+    const window = issueWindow(state)
+    // Pin resource scope with the first page as well as the time window. If an
+    // environment variable changes mid-run, the current snapshot finishes
+    // against its original query and the new scope starts on the next cycle.
+    const scope = state?.scope ?? getIssueScope()
+    const page = await fetchIssuesPage(
+      beforeSentryRequest,
+      {
+        ...window,
+        cursor: state?.cursor,
+      },
+      scope
+    )
+
+    return {
+      changes: page.resources.map(issueToChange),
+      hasMore: page.hasMore,
+      nextState: page.hasMore
+        ? nextIssueState(state, window, scope, page.nextCursor)
+        : undefined,
+    }
+  },
+})
+
+export default worker

--- a/workers/sentry-sync/src/index.ts
+++ b/workers/sentry-sync/src/index.ts
@@ -1,6 +1,8 @@
 // Three default, complementary Sentry views: recent issue triage, project
 // reliability signals, and rollout health for the newest releases.
 
+import { createHash } from "node:crypto"
+
 import { Worker } from "@notionhq/workers"
 
 import {
@@ -12,6 +14,7 @@ import {
 import {
   INITIAL_TITLE as PROJECTS_TITLE,
   PRIMARY_KEY as PROJECTS_PK,
+  ProjectAggregationLimitError,
   aggregateProjectIssues,
   aggregateProjectResource,
   projectMatchesScope,
@@ -27,19 +30,21 @@ import {
   releasesToChanges,
 } from "./releases.js"
 import {
-  SentryApiError,
   fetchIssuesPage,
   fetchProjectsPage,
   fetchRecentReleases,
   fetchReleaseHealth,
   getSentryScope,
+  type BeforeRequest,
   type SentryScope,
 } from "./sentry.js"
 import {
+  MAX_SAFE_SYNC_STATE_LENGTH,
   boundedSyncState,
   issueWindow,
   nextCursorTraversal,
   nextIssueState,
+  syncStateFits,
   type IssueSyncState,
   type IssueWindow,
 } from "./sync-state.js"
@@ -62,36 +67,42 @@ const issues = worker.database("issues", {
   schema: issueSchema,
 })
 
+export async function executeIssuesSync(
+  state: IssueSyncState | undefined,
+  beforeRequest: BeforeRequest
+) {
+  const window = issueWindow(state)
+  // Pin resource scope with the first page as well as the time window. If an
+  // environment variable changes mid-run, the current snapshot finishes
+  // against its original query and the new scope starts on the next cycle.
+  const scope = state?.scope ?? getSentryScope()
+  const page = await fetchIssuesPage(
+    beforeRequest,
+    {
+      ...window,
+      cursor: state?.cursor,
+    },
+    scope
+  )
+
+  return {
+    changes: page.resources.map(issueToChange),
+    hasMore: page.hasMore,
+    nextState: page.hasMore
+      ? boundedSyncState(
+          nextIssueState(state, window, scope, page.nextCursor),
+          "issue pagination"
+        )
+      : undefined,
+  }
+}
+
 worker.sync("issuesSync", {
   database: issues,
   mode: "replace",
   schedule: "15m",
-  execute: async (state: IssueSyncState | undefined) => {
-    const window = issueWindow(state)
-    // Pin resource scope with the first page as well as the time window. If an
-    // environment variable changes mid-run, the current snapshot finishes
-    // against its original query and the new scope starts on the next cycle.
-    const scope = state?.scope ?? getSentryScope()
-    const page = await fetchIssuesPage(
-      beforeSentryRequest,
-      {
-        ...window,
-        cursor: state?.cursor,
-      },
-      scope
-    )
-
-    return {
-      changes: page.resources.map(issueToChange),
-      hasMore: page.hasMore,
-      nextState: page.hasMore
-        ? boundedSyncState(
-            nextIssueState(state, window, scope, page.nextCursor),
-            "issue pagination"
-          )
-        : undefined,
-    }
-  },
+  execute: (state: IssueSyncState | undefined) =>
+    executeIssuesSync(state, beforeSentryRequest),
 })
 
 type ProjectIssueState = IssueSyncState & {
@@ -105,12 +116,53 @@ type ProjectRowsState = {
   end: string
   scope: SentryScope
   aggregates: ProjectAggregateMap
-  unmatchedProjectIds: string[]
+  emittedAggregateIds?: string[]
+  /** Accepted only while migrating continuations created before pruning. */
+  unmatchedProjectIds?: string[]
   cursor?: string
   seenCursors?: string[]
 }
 
-export type ProjectSyncState = ProjectIssueState | ProjectRowsState
+type ProjectScopeRequiredState = {
+  phase: "scope-required"
+  blockedScopeIdentity: string
+  reason: "project-count" | "state-size"
+}
+
+export type ProjectSyncState =
+  | ProjectIssueState
+  | ProjectRowsState
+  | ProjectScopeRequiredState
+
+// Reserve enough space for a bounded cursor history once project rows begin.
+// Aggregates shrink during that phase, so a state accepted here cannot later
+// cross the runtime limit merely by advancing inventory pagination.
+const PROJECT_INVENTORY_CURSOR_HEADROOM = 40 * 1024
+const MAX_PROJECT_AGGREGATION_STATE_LENGTH =
+  MAX_SAFE_SYNC_STATE_LENGTH - PROJECT_INVENTORY_CURSOR_HEADROOM
+
+function projectScopeIdentity(scope: SentryScope): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        ...scope,
+        projects: [...scope.projects].sort(),
+        environments: [...scope.environments].sort(),
+      })
+    )
+    .digest("hex")
+}
+
+function scopeRequiredState(
+  scope: SentryScope,
+  reason: ProjectScopeRequiredState["reason"]
+): ProjectScopeRequiredState {
+  return {
+    phase: "scope-required",
+    blockedScopeIdentity: projectScopeIdentity(scope),
+    reason,
+  }
+}
 
 const projects = worker.database("projects", {
   type: "managed",
@@ -119,125 +171,185 @@ const projects = worker.database("projects", {
   schema: projectSchema,
 })
 
-worker.sync("projectsSync", {
-  database: projects,
-  mode: "replace",
-  schedule: "1d",
-  execute: async (previousState: ProjectSyncState | undefined) => {
-    let state = previousState
-    if (!state) {
-      const window = issueWindow(undefined)
-      state = {
-        phase: "issues",
-        ...window,
-        scope: getSentryScope(),
-        aggregates: {},
-      }
-    }
-
-    const window: IssueWindow = issueWindow(state)
-    if (state.phase === "issues") {
-      const page = await fetchIssuesPage(
-        beforeSentryRequest,
-        {
-          ...window,
-          cursor: state.cursor,
-          statsPeriod: "14d",
-        },
-        state.scope
+export async function executeProjectsSync(
+  previousState: ProjectSyncState | undefined,
+  beforeRequest: BeforeRequest
+) {
+  let state = previousState
+  if (state?.phase === "scope-required") {
+    const scope = getSentryScope()
+    if (projectScopeIdentity(scope) === state.blockedScopeIdentity) {
+      const reason =
+        state.reason === "project-count"
+          ? "more than 500 active projects"
+          : "too much continuation data"
+      throw new Error(
+        `Sentry project aggregation paused before writing rows because it collected ${reason}. Narrow SENTRY_PROJECTS or SENTRY_ENVIRONMENTS, then retry; the refresh will restart automatically after the configured scope changes.`
       )
-      const aggregates = aggregateProjectIssues(
+    }
+    const window = issueWindow(undefined)
+    state = {
+      phase: "issues",
+      ...window,
+      scope,
+      aggregates: {},
+    }
+  }
+  if (!state) {
+    const window = issueWindow(undefined)
+    state = {
+      phase: "issues",
+      ...window,
+      scope: getSentryScope(),
+      aggregates: {},
+    }
+  }
+
+  const window: IssueWindow = issueWindow(state)
+  if (state.phase === "issues") {
+    const page = await fetchIssuesPage(
+      beforeRequest,
+      {
+        ...window,
+        cursor: state.cursor,
+        statsPeriod: "14d",
+      },
+      state.scope
+    )
+    let aggregates: ProjectAggregateMap
+    try {
+      aggregates = aggregateProjectIssues(
         state.aggregates,
         page.resources,
         window
       )
-
-      if (page.hasMore) {
-        const next = nextIssueState(state, window, state.scope, page.nextCursor)
-        return {
-          changes: [],
-          hasMore: true,
-          nextState: boundedSyncState(
-            {
-              phase: "issues" as const,
-              ...next,
-              aggregates,
-            },
-            "project aggregation"
-          ),
-        }
-      }
-
+    } catch (error) {
+      if (!(error instanceof ProjectAggregationLimitError)) throw error
       return {
         changes: [],
         hasMore: true,
-        nextState: boundedSyncState(
-          {
-            phase: "projects" as const,
-            ...window,
-            scope: state.scope,
-            aggregates,
-            unmatchedProjectIds: Object.keys(aggregates),
-          },
-          "project aggregation"
-        ),
+        nextState: scopeRequiredState(state.scope, "project-count"),
       }
     }
-
-    const page = await fetchProjectsPage(
-      beforeSentryRequest,
-      state.cursor,
-      state.scope
-    )
-    const resources = page.resources.filter((project) =>
-      projectMatchesScope(project, state.scope)
-    )
-    const returnedIds = new Set(resources.map((project) => project.id))
-    const unmatchedProjectIds = state.unmatchedProjectIds.filter(
-      (projectId) => !returnedIds.has(projectId)
-    )
-    const changes = resources.map((project) =>
-      projectToChange(
-        project,
-        state.aggregates[project.id],
-        window.end,
-        state.scope
-      )
-    )
 
     if (page.hasMore) {
-      const traversal = nextCursorTraversal(
-        state.cursor,
-        state.seenCursors,
-        page.nextCursor,
-        "project"
-      )
+      const next = nextIssueState(state, window, state.scope, page.nextCursor)
+      const nextState: ProjectIssueState = {
+        phase: "issues",
+        ...next,
+        aggregates,
+      }
+      if (!syncStateFits(nextState, MAX_PROJECT_AGGREGATION_STATE_LENGTH)) {
+        return {
+          changes: [],
+          hasMore: true,
+          nextState: scopeRequiredState(state.scope, "state-size"),
+        }
+      }
       return {
-        changes,
+        changes: [],
         hasMore: true,
-        nextState: boundedSyncState(
-          {
-            ...state,
-            ...traversal,
-            unmatchedProjectIds,
-          },
-          "project inventory"
-        ),
+        nextState,
       }
     }
 
-    // An issue can outlive a deleted/inaccessible project record. Preserve its
-    // aggregate with current issue metadata rather than silently dropping risk.
-    const fallbackChanges = unmatchedProjectIds.map((projectId) =>
-      projectToChange(
-        aggregateProjectResource(state.aggregates[projectId]),
-        state.aggregates[projectId],
-        window.end,
-        state.scope
-      )
+    const nextState: ProjectRowsState = {
+      phase: "projects",
+      ...window,
+      scope: state.scope,
+      aggregates,
+    }
+    if (!syncStateFits(nextState, MAX_PROJECT_AGGREGATION_STATE_LENGTH)) {
+      return {
+        changes: [],
+        hasMore: true,
+        nextState: scopeRequiredState(state.scope, "state-size"),
+      }
+    }
+    return {
+      changes: [],
+      hasMore: true,
+      nextState,
+    }
+  }
+
+  const page = await fetchProjectsPage(beforeRequest, state.cursor, state.scope)
+  const resources = page.resources.filter((project) =>
+    projectMatchesScope(project, state.scope)
+  )
+  const remainingAggregates = { ...state.aggregates }
+  const legacyUnmatchedIds = state.unmatchedProjectIds
+    ? new Set(state.unmatchedProjectIds)
+    : undefined
+  const emittedAggregateIds = new Set(
+    state.emittedAggregateIds ??
+      (legacyUnmatchedIds
+        ? Object.keys(state.aggregates).filter(
+            (projectId) => !legacyUnmatchedIds.has(projectId)
+          )
+        : [])
+  )
+  for (const projectId of emittedAggregateIds) {
+    delete remainingAggregates[projectId]
+  }
+  const changes = []
+  for (const project of resources) {
+    const aggregate = remainingAggregates[project.id]
+    // Project inventory can move while cursor pagination is in flight. If a
+    // project carrying an aggregate repeats on a later page, keep the first
+    // enriched row rather than overwriting it with zeroes after pruning.
+    if (!aggregate && emittedAggregateIds.has(project.id)) continue
+    changes.push(projectToChange(project, aggregate, window.end, state.scope))
+    if (aggregate) {
+      delete remainingAggregates[project.id]
+      emittedAggregateIds.add(project.id)
+    }
+  }
+
+  if (page.hasMore) {
+    const traversal = nextCursorTraversal(
+      state.cursor,
+      state.seenCursors,
+      page.nextCursor,
+      "project"
     )
-    return { changes: [...changes, ...fallbackChanges], hasMore: false }
-  },
+    return {
+      changes,
+      hasMore: true,
+      nextState: boundedSyncState(
+        {
+          phase: "projects" as const,
+          start: state.start,
+          end: state.end,
+          scope: state.scope,
+          aggregates: remainingAggregates,
+          emittedAggregateIds: [...emittedAggregateIds],
+          ...traversal,
+        },
+        "project inventory"
+      ),
+    }
+  }
+
+  // An issue can outlive a deleted/inaccessible project record. Preserve its
+  // aggregate with current issue metadata rather than silently dropping risk.
+  const fallbackChanges = Object.keys(remainingAggregates).map((projectId) =>
+    projectToChange(
+      aggregateProjectResource(remainingAggregates[projectId]),
+      remainingAggregates[projectId],
+      window.end,
+      state.scope
+    )
+  )
+  return { changes: [...changes, ...fallbackChanges], hasMore: false }
+}
+
+worker.sync("projectsSync", {
+  database: projects,
+  mode: "replace",
+  schedule: "1d",
+  execute: (state: ProjectSyncState | undefined) =>
+    executeProjectsSync(state, beforeSentryRequest),
 })
 
 const releases = worker.database("releases", {
@@ -247,40 +359,32 @@ const releases = worker.database("releases", {
   schema: releaseSchema,
 })
 
+export async function executeReleasesSync(beforeRequest: BeforeRequest) {
+  const scope = getSentryScope()
+  const window = releaseHealthWindow()
+  const recentReleases = await fetchRecentReleases(beforeRequest, scope)
+  if (recentReleases.length === 0) {
+    return { changes: [], hasMore: false }
+  }
+
+  const health = await fetchReleaseHealth(
+    beforeRequest,
+    window.start,
+    window.end,
+    scope
+  )
+
+  return {
+    changes: releasesToChanges(recentReleases, health, scope),
+    hasMore: false,
+  }
+}
+
 worker.sync("releasesSync", {
   database: releases,
   mode: "replace",
   schedule: "15m",
-  execute: async () => {
-    const scope = getSentryScope()
-    const window = releaseHealthWindow()
-    const recentReleases = await fetchRecentReleases(beforeSentryRequest, scope)
-    if (recentReleases.length === 0) {
-      return { changes: [], hasMore: false }
-    }
-
-    let health
-    try {
-      health = await fetchReleaseHealth(
-        beforeSentryRequest,
-        window.start,
-        window.end,
-        scope
-      )
-    } catch (error) {
-      // A sessions 404 can mean that Release Health is unavailable on this
-      // route or installation. Preserve useful metadata-only rows; the README
-      // lists other 404 causes to check when health was expected.
-      if (!(error instanceof SentryApiError) || error.status !== 404)
-        throw error
-      health = { available: false, start: null, end: null, groups: [] }
-    }
-
-    return {
-      changes: releasesToChanges(recentReleases, health, scope),
-      hasMore: false,
-    }
-  },
+  execute: () => executeReleasesSync(beforeSentryRequest),
 })
 
 export default worker

--- a/workers/sentry-sync/src/index.ts
+++ b/workers/sentry-sync/src/index.ts
@@ -268,9 +268,9 @@ worker.sync("releasesSync", {
         scope
       )
     } catch (error) {
-      // Older self-hosted Sentry versions can expose release metadata without
-      // the sessions endpoint. Keep those rows useful; all other failures,
-      // including missing org:read, remain actionable.
+      // A sessions 404 can mean that Release Health is unavailable on this
+      // route or installation. Preserve useful metadata-only rows; the README
+      // lists other 404 causes to check when health was expected.
       if (!(error instanceof SentryApiError) || error.status !== 404)
         throw error
       health = { available: false, start: null, end: null, groups: [] }

--- a/workers/sentry-sync/src/issues.ts
+++ b/workers/sentry-sync/src/issues.ts
@@ -1,0 +1,158 @@
+// Sentry issue groups — a rolling operational view for triage and review.
+// Keep schema and transform property order aligned.
+
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  dateTime,
+  issuePageContent,
+  nonnegativeNumber,
+  propertyText,
+  safeHttpUrl,
+  selectText,
+  summedStats,
+  titleText,
+} from "./helpers.js"
+import type { SentryIssue } from "./sentry.js"
+
+export const INITIAL_TITLE = "Sentry Issues — Last 30 Days"
+export const PRIMARY_KEY = "Sentry Issue ID"
+
+export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("bug"),
+  properties: {
+    Issue: Schema.title(),
+
+    Status: Schema.select([
+      { name: "Unresolved" },
+      { name: "Resolved" },
+      { name: "Ignored" },
+      { name: "Pending Deletion" },
+      { name: "Pending Merge" },
+      { name: "Reprocessing" },
+    ]),
+
+    Assignee: Schema.richText(),
+
+    "Issue Link": Schema.url(),
+
+    "Last Seen": Schema.date(),
+
+    Priority: Schema.select([
+      { name: "High" },
+      { name: "Medium" },
+      { name: "Low" },
+    ]),
+
+    // Sentry's native lifecycle detail: new, ongoing, regressed, escalating,
+    // or an archive condition. Unknown future values remain visible.
+    "Status Detail": Schema.select([]),
+
+    Level: Schema.select([
+      { name: "Fatal" },
+      { name: "Error" },
+      { name: "Warning" },
+      { name: "Info" },
+      { name: "Debug" },
+    ]),
+
+    Unhandled: Schema.checkbox(),
+
+    "Events (24h)": Schema.number(),
+
+    "Events (30d)": Schema.number(),
+
+    "Users (30d)": Schema.number(),
+
+    "Lifetime Events": Schema.number(),
+
+    "Lifetime Users": Schema.number(),
+
+    Project: Schema.select([]),
+
+    Category: Schema.select([]),
+
+    "Issue Type": Schema.select([]),
+
+    Platform: Schema.select([]),
+
+    Culprit: Schema.richText(),
+
+    "First Seen": Schema.date(),
+
+    "Issue Key": Schema.richText(),
+
+    "Sentry Issue ID": Schema.richText(),
+  },
+}
+
+export function issueToChange(issue: SentryIssue) {
+  const status = selectText(issue.status)
+  const assignee = propertyText(issue.assignedTo?.name)
+  const url = safeHttpUrl(issue.permalink)
+  const lastSeen = dateTime(issue.lastSeen)
+  const priority = selectText(issue.priority)
+  const statusDetail = selectText(issue.substatus)
+  const level = selectText(issue.level)
+  const recentEvents = summedStats(issue.stats, "24h")
+  const windowEvents = nonnegativeNumber(issue.count)
+  const windowUsers = nonnegativeNumber(issue.userCount)
+  const lifetimeEvents = nonnegativeNumber(issue.lifetime?.count)
+  const lifetimeUsers = nonnegativeNumber(issue.lifetime?.userCount)
+  const project = selectText(issue.project?.name ?? issue.project?.slug)
+  const category = selectText(issue.issueCategory)
+  const issueType = selectText(issue.issueType)
+  const platform = selectText(issue.platform ?? issue.project?.platform)
+  const culprit = propertyText(issue.culprit)
+  const firstSeen = dateTime(issue.firstSeen)
+  const issueKey = propertyText(issue.shortId)
+
+  return {
+    type: "upsert" as const,
+    key: issue.id,
+    // Sentry does not expose a reliable general issue-mutation timestamp.
+    // lastSeen tracks event activity, not status/priority/assignee changes, so
+    // this replacement sync intentionally omits upstreamUpdatedAt.
+    pageContentMarkdown: issuePageContent(issue),
+    properties: {
+      Issue: Builder.title(titleText(issue.title)),
+      ...(status ? { Status: Builder.select(status) } : {}),
+      ...(assignee ? { Assignee: Builder.richText(assignee) } : {}),
+      ...(url ? { "Issue Link": Builder.url(url) } : {}),
+      ...(lastSeen ? { "Last Seen": Builder.dateTime(lastSeen) } : {}),
+      ...(priority ? { Priority: Builder.select(priority) } : {}),
+      ...(statusDetail
+        ? { "Status Detail": Builder.select(statusDetail) }
+        : {}),
+      ...(level ? { Level: Builder.select(level) } : {}),
+      ...(issue.isUnhandled === null
+        ? {}
+        : { Unhandled: Builder.checkbox(issue.isUnhandled) }),
+      ...(recentEvents === null
+        ? {}
+        : { "Events (24h)": Builder.number(recentEvents) }),
+      ...(windowEvents === null
+        ? {}
+        : { "Events (30d)": Builder.number(windowEvents) }),
+      ...(windowUsers === null
+        ? {}
+        : { "Users (30d)": Builder.number(windowUsers) }),
+      ...(lifetimeEvents === null
+        ? {}
+        : { "Lifetime Events": Builder.number(lifetimeEvents) }),
+      ...(lifetimeUsers === null
+        ? {}
+        : { "Lifetime Users": Builder.number(lifetimeUsers) }),
+      ...(project ? { Project: Builder.select(project) } : {}),
+      ...(category ? { Category: Builder.select(category) } : {}),
+      ...(issueType ? { "Issue Type": Builder.select(issueType) } : {}),
+      ...(platform ? { Platform: Builder.select(platform) } : {}),
+      ...(culprit ? { Culprit: Builder.richText(culprit) } : {}),
+      ...(firstSeen ? { "First Seen": Builder.dateTime(firstSeen) } : {}),
+      ...(issueKey ? { "Issue Key": Builder.richText(issueKey) } : {}),
+      "Sentry Issue ID": Builder.richText(issue.id),
+    },
+  }
+}

--- a/workers/sentry-sync/src/issues.ts
+++ b/workers/sentry-sync/src/issues.ts
@@ -2,7 +2,7 @@
 // Keep schema and transform property order aligned.
 
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import * as Schema from "@notionhq/workers/schema"
 
 import {
@@ -20,7 +20,7 @@ import type { SentryIssue } from "./sentry.js"
 export const INITIAL_TITLE = "Sentry Issues"
 export const PRIMARY_KEY = "Sentry Issue ID"
 
-export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const issueSchema = {
   databaseIcon: notionIcon("bug"),
   properties: {
     Issue: Schema.title(),
@@ -86,9 +86,14 @@ export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Sentry Issue ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
-export function issueToChange(issue: SentryIssue) {
+type IssueChange = SyncChangeUpsert<
+  typeof PRIMARY_KEY,
+  typeof issueSchema.properties
+> & { pageContentMarkdown: string }
+
+export function issueToChange(issue: SentryIssue): IssueChange {
   const status = selectText(issue.status)
   const assignee = propertyText(issue.assignedTo?.name)
   const url = safeHttpUrl(issue.permalink)
@@ -118,40 +123,29 @@ export function issueToChange(issue: SentryIssue) {
     pageContentMarkdown: issuePageContent(issue),
     properties: {
       Issue: Builder.title(titleText(issue.title)),
-      ...(status ? { Status: Builder.select(status) } : {}),
-      ...(assignee ? { Assignee: Builder.richText(assignee) } : {}),
-      ...(url ? { "Issue Link": Builder.url(url) } : {}),
-      ...(lastSeen ? { "Last Seen": Builder.dateTime(lastSeen) } : {}),
-      ...(priority ? { Priority: Builder.select(priority) } : {}),
-      ...(statusDetail
-        ? { "Status Detail": Builder.select(statusDetail) }
-        : {}),
-      ...(level ? { Level: Builder.select(level) } : {}),
-      ...(issue.isUnhandled === null
-        ? {}
-        : { Unhandled: Builder.checkbox(issue.isUnhandled) }),
-      ...(recentEvents === null
-        ? {}
-        : { "Events (24h)": Builder.number(recentEvents) }),
-      ...(windowEvents === null
-        ? {}
-        : { "Events (30d)": Builder.number(windowEvents) }),
-      ...(windowUsers === null
-        ? {}
-        : { "Users (30d)": Builder.number(windowUsers) }),
-      ...(lifetimeEvents === null
-        ? {}
-        : { "Lifetime Events": Builder.number(lifetimeEvents) }),
-      ...(lifetimeUsers === null
-        ? {}
-        : { "Lifetime Users": Builder.number(lifetimeUsers) }),
-      ...(project ? { Project: Builder.select(project) } : {}),
-      ...(category ? { Category: Builder.select(category) } : {}),
-      ...(issueType ? { "Issue Type": Builder.select(issueType) } : {}),
-      ...(platform ? { Platform: Builder.select(platform) } : {}),
-      ...(culprit ? { Culprit: Builder.richText(culprit) } : {}),
-      ...(firstSeen ? { "First Seen": Builder.dateTime(firstSeen) } : {}),
-      ...(issueKey ? { "Issue Key": Builder.richText(issueKey) } : {}),
+      Status: status ? Builder.select(status) : [],
+      Assignee: assignee ? Builder.richText(assignee) : [],
+      "Issue Link": url ? Builder.url(url) : [],
+      "Last Seen": lastSeen ? Builder.dateTime(lastSeen) : [],
+      Priority: priority ? Builder.select(priority) : [],
+      "Status Detail": statusDetail ? Builder.select(statusDetail) : [],
+      Level: level ? Builder.select(level) : [],
+      Unhandled:
+        issue.isUnhandled === null ? [] : Builder.checkbox(issue.isUnhandled),
+      "Events (24h)": recentEvents === null ? [] : Builder.number(recentEvents),
+      "Events (30d)": windowEvents === null ? [] : Builder.number(windowEvents),
+      "Users (30d)": windowUsers === null ? [] : Builder.number(windowUsers),
+      "Lifetime Events":
+        lifetimeEvents === null ? [] : Builder.number(lifetimeEvents),
+      "Lifetime Users":
+        lifetimeUsers === null ? [] : Builder.number(lifetimeUsers),
+      Project: project ? Builder.select(project) : [],
+      Category: category ? Builder.select(category) : [],
+      "Issue Type": issueType ? Builder.select(issueType) : [],
+      Platform: platform ? Builder.select(platform) : [],
+      Culprit: culprit ? Builder.richText(culprit) : [],
+      "First Seen": firstSeen ? Builder.dateTime(firstSeen) : [],
+      "Issue Key": issueKey ? Builder.richText(issueKey) : [],
       "Sentry Issue ID": Builder.richText(issue.id),
     },
   }

--- a/workers/sentry-sync/src/issues.ts
+++ b/workers/sentry-sync/src/issues.ts
@@ -17,7 +17,7 @@ import {
 } from "./helpers.js"
 import type { SentryIssue } from "./sentry.js"
 
-export const INITIAL_TITLE = "Sentry Issues — Last 30 Days"
+export const INITIAL_TITLE = "Sentry Issues"
 export const PRIMARY_KEY = "Sentry Issue ID"
 
 export const issueSchema: Schema.Schema<typeof PRIMARY_KEY> = {

--- a/workers/sentry-sync/src/issues.ts
+++ b/workers/sentry-sync/src/issues.ts
@@ -7,13 +7,14 @@ import * as Schema from "@notionhq/workers/schema"
 
 import {
   dateTime,
-  issuePageContent,
+  escapeMarkdown,
   nonnegativeNumber,
   propertyText,
   safeHttpUrl,
   selectText,
   summedStats,
   titleText,
+  type SentryStats,
 } from "./helpers.js"
 import type { SentryIssue } from "./sentry.js"
 
@@ -93,6 +94,118 @@ type IssueChange = SyncChangeUpsert<
   typeof issueSchema.properties
 > & { pageContentMarkdown: string }
 
+const MAX_PAGE_VALUE_CHARACTERS = 500
+
+type TriageIssue = {
+  status: string | null
+  substatus: string | null
+  priority: string | null
+  level: string | null
+  isUnhandled: boolean | null
+  assignedTo: { name: string | null } | null
+  project: { name: string | null; slug: string | null } | null
+  platform: string | null
+  culprit: string | null
+  firstSeen: string | null
+  lastSeen: string | null
+  permalink: string | null
+  count: string | number | null
+  userCount: string | number | null
+  lifetime: {
+    count: string | number | null
+    userCount: string | number | null
+  } | null
+  stats: SentryStats | null
+}
+
+function markdownValue(value: string): string {
+  const characters = Array.from(value)
+  const bounded =
+    characters.length <= MAX_PAGE_VALUE_CHARACTERS
+      ? value
+      : `${characters.slice(0, MAX_PAGE_VALUE_CHARACTERS - 1).join("")}…`
+  return escapeMarkdown(bounded)
+}
+
+function plural(count: number, singular: string): string {
+  return `${count.toLocaleString("en-US")} ${singular}${count === 1 ? "" : "s"}`
+}
+
+/** Build a bounded triage brief from group metadata, never raw event data. */
+export function issuePageContent(issue: TriageIssue): string {
+  const status = selectText(issue.status)
+  const detail = selectText(issue.substatus)
+  const priority = selectText(issue.priority)
+  const level = selectText(issue.level)
+  const assignee = propertyText(issue.assignedTo?.name)
+  const project = propertyText(issue.project?.name ?? issue.project?.slug)
+  const platform = propertyText(issue.platform)
+  const culprit = propertyText(issue.culprit)
+  const firstSeen = dateTime(issue.firstSeen)
+  const lastSeen = dateTime(issue.lastSeen)
+  const recentEvents = summedStats(issue.stats, "24h")
+  const windowEvents = nonnegativeNumber(issue.count)
+  const windowUsers = nonnegativeNumber(issue.userCount)
+  const lifetimeEvents = nonnegativeNumber(issue.lifetime?.count)
+  const lifetimeUsers = nonnegativeNumber(issue.lifetime?.userCount)
+  const url = safeHttpUrl(issue.permalink)
+
+  const signals = [
+    detail && ["New", "Regressed", "Escalating"].includes(detail)
+      ? detail
+      : null,
+    priority === "High" ? "High priority" : null,
+    level === "Fatal" ? "Fatal" : null,
+    issue.isUnhandled === true ? "Unhandled" : null,
+    !assignee && status === "Unresolved" ? "Unassigned" : null,
+  ].filter((value): value is string => Boolean(value))
+
+  const lines = [
+    `- **Status:** ${markdownValue(
+      [status, detail].filter(Boolean).join(" · ") || "Not provided"
+    )}`,
+    `- **Owner:** ${markdownValue(assignee || "Unassigned")}`,
+    recentEvents === null
+      ? null
+      : `- **Last 24 hours:** ${plural(recentEvents, "event")}`,
+    windowEvents === null && windowUsers === null
+      ? null
+      : `- **30-day impact:** ${[
+          windowEvents === null ? null : plural(windowEvents, "event"),
+          windowUsers === null ? null : plural(windowUsers, "user"),
+        ]
+          .filter(Boolean)
+          .join(" · ")}`,
+    lifetimeEvents === null && lifetimeUsers === null
+      ? null
+      : `- **Lifetime impact:** ${[
+          lifetimeEvents === null ? null : plural(lifetimeEvents, "event"),
+          lifetimeUsers === null ? null : plural(lifetimeUsers, "user"),
+        ]
+          .filter(Boolean)
+          .join(" · ")}`,
+    signals.length > 0
+      ? `- **Triage signals:** ${signals.map(markdownValue).join(" · ")}`
+      : null,
+    project || platform
+      ? `- **Location:** ${[project, platform]
+          .filter((value): value is string => Boolean(value))
+          .map(markdownValue)
+          .join(" · ")}`
+      : null,
+    culprit ? `- **Culprit:** ${markdownValue(culprit)}` : null,
+    firstSeen ? `- **First seen:** ${firstSeen}` : null,
+    lastSeen ? `- **Last seen:** ${lastSeen}` : null,
+  ].filter((line): line is string => Boolean(line))
+
+  const source = url
+    ? `\n\n[Open this issue in Sentry](${url
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29")})`
+    : ""
+  return `## Triage snapshot\n\n${lines.join("\n")}${source}`
+}
+
 export function issueToChange(issue: SentryIssue): IssueChange {
   const status = selectText(issue.status)
   const assignee = propertyText(issue.assignedTo?.name)
@@ -122,7 +235,7 @@ export function issueToChange(issue: SentryIssue): IssueChange {
     // this replacement sync intentionally omits upstreamUpdatedAt.
     pageContentMarkdown: issuePageContent(issue),
     properties: {
-      Issue: Builder.title(titleText(issue.title)),
+      Issue: Builder.title(titleText(issue.title, "Untitled Sentry issue")),
       Status: status ? Builder.select(status) : [],
       Assignee: assignee ? Builder.richText(assignee) : [],
       "Issue Link": url ? Builder.url(url) : [],

--- a/workers/sentry-sync/src/projects.ts
+++ b/workers/sentry-sync/src/projects.ts
@@ -22,6 +22,15 @@ export const PRIMARY_KEY = "Sentry Project ID"
 export const MAX_AGGREGATED_PROJECTS = 500
 const MAX_MULTI_SELECT_VALUES = 100
 
+export class ProjectAggregationLimitError extends Error {
+  constructor() {
+    super(
+      `Sentry project aggregation exceeded ${MAX_AGGREGATED_PROJECTS} active projects`
+    )
+    this.name = "ProjectAggregationLimitError"
+  }
+}
+
 export type MostActiveIssue = {
   id: string
   title: string
@@ -110,19 +119,6 @@ function issueEventBuckets(
   return { previous, current }
 }
 
-function sameIdentity(
-  current: string | null,
-  next: string | null,
-  field: string,
-  projectId: string
-): void {
-  if (current && next && current !== next) {
-    throw new Error(
-      `Sentry project ${projectId} returned conflicting ${field} values during one refresh`
-    )
-  }
-}
-
 function maxDate(
   current: string | null,
   candidate: string | null
@@ -168,27 +164,11 @@ export function aggregateProjectIssues(
     }
 
     const existing = aggregates[projectId]
-    if (existing) {
-      sameIdentity(
-        existing.projectName,
-        issue.project?.name ?? null,
-        "names",
-        projectId
-      )
-      sameIdentity(
-        existing.projectSlug,
-        issue.project?.slug ?? null,
-        "slugs",
-        projectId
-      )
-    }
     if (
       !existing &&
       Object.keys(aggregates).length >= MAX_AGGREGATED_PROJECTS
     ) {
-      throw new Error(
-        `Sentry project aggregation exceeded ${MAX_AGGREGATED_PROJECTS} active projects; narrow SENTRY_PROJECTS to keep sync state bounded.`
-      )
+      throw new ProjectAggregationLimitError()
     }
 
     const aggregate: ProjectIssueAggregate = existing ?? {
@@ -213,6 +193,9 @@ export function aggregateProjectIssues(
       lastSeen: null,
     }
 
+    // Names and slugs can change between issue pages. The immutable ID owns
+    // aggregation identity; issue metadata is only a fallback when the
+    // canonical project inventory record is deleted or inaccessible.
     aggregate.projectName ??= issue.project?.name ?? null
     aggregate.projectSlug ??= issue.project?.slug ?? null
     aggregate.platform ??= issue.platform ?? issue.project?.platform ?? null

--- a/workers/sentry-sync/src/projects.ts
+++ b/workers/sentry-sync/src/projects.ts
@@ -1,0 +1,434 @@
+// Project inventory enriched with issue-derived reliability signals. User
+// counts are intentionally absent because one person can span many groups.
+
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  dateTime,
+  escapeMarkdown,
+  nonnegativeNumber,
+  propertyText,
+  safeHttpUrl,
+  selectText,
+  titleText,
+} from "./helpers.js"
+import type { SentryIssue, SentryProject, SentryScope } from "./sentry.js"
+import type { IssueWindow } from "./sync-state.js"
+
+export const INITIAL_TITLE = "Sentry Projects"
+export const PRIMARY_KEY = "Sentry Project ID"
+export const MAX_AGGREGATED_PROJECTS = 500
+const MAX_MULTI_SELECT_VALUES = 100
+
+export type MostActiveIssue = {
+  id: string
+  title: string
+  events: number
+  url: string | null
+}
+
+export type ProjectIssueAggregate = {
+  projectId: string
+  projectName: string | null
+  projectSlug: string | null
+  platform: string | null
+  issueGroups: number
+  unresolvedIssues: number
+  highPriorityUnresolved: number
+  newUnresolved: number
+  regressedUnresolved: number
+  escalatingUnresolved: number
+  unhandledUnresolved: number
+  unassignedUnresolved: number
+  previous7dEvents: number
+  events7d: number
+  events30d: number
+  statsComplete: boolean
+  countsComplete: boolean
+  mostActiveIssue: MostActiveIssue | null
+  lastSeen: string | null
+}
+
+export type ProjectAggregateMap = Record<string, ProjectIssueAggregate>
+
+export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("chart-line"),
+  properties: {
+    Project: Schema.title(),
+    "Unresolved Issues (30d)": Schema.number(),
+    "Events (7d)": Schema.number(),
+    "Most Active Issue (7d)": Schema.richText(),
+    "Issue Link": Schema.url(),
+    "Last Seen": Schema.date(),
+    "Previous 7d Events": Schema.number(),
+    "Event Change vs Prior 7d": Schema.number(),
+    "Issue Groups (30d)": Schema.number(),
+    "Events (30d)": Schema.number(),
+    "High-Priority Unresolved (30d)": Schema.number(),
+    "New Unresolved (30d)": Schema.number(),
+    "Regressed Unresolved (30d)": Schema.number(),
+    "Escalating Unresolved (30d)": Schema.number(),
+    "Unhandled Unresolved (30d)": Schema.number(),
+    "Unassigned Unresolved (30d)": Schema.number(),
+    "Project Link": Schema.url(),
+    Platform: Schema.select([]),
+    Teams: Schema.multiSelect([]),
+    "Has Sessions": Schema.checkbox(),
+    "First Event": Schema.date(),
+    "Environment Scope": Schema.richText(),
+    "As Of": Schema.date(),
+    "Project Slug": Schema.richText(),
+    "Sentry Project ID": Schema.richText(),
+  },
+}
+
+function issueEventBuckets(
+  issue: SentryIssue,
+  window: IssueWindow
+): { previous: number; current: number } | null {
+  const points = issue.stats?.["14d"]
+  if (!points) return null
+
+  const end = Date.parse(window.end)
+  const split = end - 7 * 86_400_000
+  const start = end - 14 * 86_400_000
+  let previous = 0
+  let current = 0
+  for (const [rawTimestamp, count] of points) {
+    const timestamp =
+      rawTimestamp < 1_000_000_000_000 ? rawTimestamp * 1_000 : rawTimestamp
+    if (timestamp >= start && timestamp < split) previous += count
+    if (timestamp >= split && timestamp <= end) current += count
+  }
+  return { previous, current }
+}
+
+function sameIdentity(
+  current: string | null,
+  next: string | null,
+  field: string,
+  projectId: string
+): void {
+  if (current && next && current !== next) {
+    throw new Error(
+      `Sentry project ${projectId} returned conflicting ${field} values during one refresh`
+    )
+  }
+}
+
+function maxDate(
+  current: string | null,
+  candidate: string | null
+): string | null {
+  const valid = dateTime(candidate)
+  if (!valid) return current
+  return !current || Date.parse(valid) > Date.parse(current) ? valid : current
+}
+
+function preferMostActive(
+  current: MostActiveIssue | null,
+  issue: SentryIssue,
+  events: number
+): MostActiveIssue {
+  const rawUrl = safeHttpUrl(issue.permalink)
+  const candidate = {
+    id: issue.id,
+    title: propertyText(issue.title) ?? "Untitled issue",
+    events,
+    url: rawUrl && Array.from(rawUrl).length <= 2_000 ? rawUrl : null,
+  }
+  if (!current) return candidate
+  if (candidate.events !== current.events) {
+    return candidate.events > current.events ? candidate : current
+  }
+  return candidate.id.localeCompare(current.id) < 0 ? candidate : current
+}
+
+/** Fold one issue page into a compact, serializable project map. */
+export function aggregateProjectIssues(
+  prior: ProjectAggregateMap,
+  issues: SentryIssue[],
+  window: IssueWindow
+): ProjectAggregateMap {
+  const aggregates: ProjectAggregateMap = structuredClone(prior)
+
+  for (const issue of issues) {
+    const projectId = issue.project?.id?.trim()
+    if (!projectId) {
+      throw new Error(
+        `Sentry issue ${issue.id} is missing an immutable project ID required by the projects sync`
+      )
+    }
+
+    const existing = aggregates[projectId]
+    if (existing) {
+      sameIdentity(
+        existing.projectName,
+        issue.project?.name ?? null,
+        "names",
+        projectId
+      )
+      sameIdentity(
+        existing.projectSlug,
+        issue.project?.slug ?? null,
+        "slugs",
+        projectId
+      )
+    }
+    if (
+      !existing &&
+      Object.keys(aggregates).length >= MAX_AGGREGATED_PROJECTS
+    ) {
+      throw new Error(
+        `Sentry project aggregation exceeded ${MAX_AGGREGATED_PROJECTS} active projects; narrow SENTRY_PROJECTS to keep sync state bounded.`
+      )
+    }
+
+    const aggregate: ProjectIssueAggregate = existing ?? {
+      projectId,
+      projectName: issue.project?.name ?? null,
+      projectSlug: issue.project?.slug ?? null,
+      platform: issue.platform ?? issue.project?.platform ?? null,
+      issueGroups: 0,
+      unresolvedIssues: 0,
+      highPriorityUnresolved: 0,
+      newUnresolved: 0,
+      regressedUnresolved: 0,
+      escalatingUnresolved: 0,
+      unhandledUnresolved: 0,
+      unassignedUnresolved: 0,
+      previous7dEvents: 0,
+      events7d: 0,
+      events30d: 0,
+      statsComplete: true,
+      countsComplete: true,
+      mostActiveIssue: null,
+      lastSeen: null,
+    }
+
+    aggregate.projectName ??= issue.project?.name ?? null
+    aggregate.projectSlug ??= issue.project?.slug ?? null
+    aggregate.platform ??= issue.platform ?? issue.project?.platform ?? null
+    aggregate.issueGroups += 1
+    aggregate.lastSeen = maxDate(aggregate.lastSeen, issue.lastSeen)
+
+    const status = issue.status?.trim().toLowerCase()
+    const substatus = issue.substatus?.trim().toLowerCase()
+    const unresolved = status === "unresolved"
+    if (unresolved) {
+      aggregate.unresolvedIssues += 1
+      if (issue.priority?.trim().toLowerCase() === "high") {
+        aggregate.highPriorityUnresolved += 1
+      }
+      if (substatus === "new") aggregate.newUnresolved += 1
+      if (substatus === "regressed") aggregate.regressedUnresolved += 1
+      if (substatus === "escalating") aggregate.escalatingUnresolved += 1
+      if (issue.isUnhandled === true) aggregate.unhandledUnresolved += 1
+      if (!issue.assignedTo?.name?.trim()) aggregate.unassignedUnresolved += 1
+    }
+
+    const count = nonnegativeNumber(issue.count)
+    if (count === null) aggregate.countsComplete = false
+    else aggregate.events30d += count
+
+    const buckets = issueEventBuckets(issue, window)
+    if (!buckets) {
+      aggregate.statsComplete = false
+    } else {
+      aggregate.previous7dEvents += buckets.previous
+      aggregate.events7d += buckets.current
+      aggregate.mostActiveIssue = preferMostActive(
+        aggregate.mostActiveIssue,
+        issue,
+        buckets.current
+      )
+    }
+
+    aggregates[projectId] = aggregate
+  }
+
+  return aggregates
+}
+
+export function projectMatchesScope(
+  project: Pick<SentryProject, "id" | "slug">,
+  scope: SentryScope
+): boolean {
+  return (
+    scope.projects.length === 0 ||
+    scope.projects.includes(project.id) ||
+    scope.projects.includes(project.slug)
+  )
+}
+
+function projectIssueUrl(scope: SentryScope, projectId: string): string {
+  const url = new URL(scope.baseUrl)
+  const prefix = url.pathname.replace(/\/+$/, "")
+  url.pathname = `${prefix}/organizations/${encodeURIComponent(
+    scope.organization
+  )}/issues/`
+  url.searchParams.set("project", projectId)
+  for (const environment of scope.environments) {
+    url.searchParams.append("environment", environment)
+  }
+  return url.toString()
+}
+
+export function aggregateProjectResource(
+  aggregate: ProjectIssueAggregate
+): SentryProject {
+  return {
+    id: aggregate.projectId,
+    name:
+      aggregate.projectName?.trim() ||
+      aggregate.projectSlug?.trim() ||
+      `Project ${aggregate.projectId}`,
+    slug: aggregate.projectSlug?.trim() || aggregate.projectId,
+    platform: aggregate.platform,
+    platforms: aggregate.platform ? [aggregate.platform] : [],
+    teams: [],
+    dateCreated: null,
+    firstEvent: null,
+    hasSessions: null,
+  }
+}
+
+function projectPageContent(
+  project: SentryProject,
+  aggregate: ProjectIssueAggregate | undefined,
+  asOf: string,
+  scope: SentryScope
+): string {
+  const unresolved = aggregate?.unresolvedIssues ?? 0
+  const lines = [
+    `- **Unresolved issue groups seen in 30 days:** ${unresolved.toLocaleString(
+      "en-US"
+    )}`,
+    aggregate?.statsComplete === false
+      ? "- **7-day event trend:** Incomplete in the source response"
+      : `- **7-day event trend:** ${(aggregate?.events7d ?? 0).toLocaleString(
+          "en-US"
+        )} current · ${(aggregate?.previous7dEvents ?? 0).toLocaleString(
+          "en-US"
+        )} previous`,
+    `- **Ownership gaps:** ${(
+      aggregate?.unassignedUnresolved ?? 0
+    ).toLocaleString("en-US")} unresolved and unassigned`,
+    `- **Lifecycle signals:** ${(aggregate?.newUnresolved ?? 0).toLocaleString(
+      "en-US"
+    )} new · ${(aggregate?.regressedUnresolved ?? 0).toLocaleString(
+      "en-US"
+    )} regressed · ${(aggregate?.escalatingUnresolved ?? 0).toLocaleString(
+      "en-US"
+    )} escalating`,
+    `- **Environment scope:** ${escapeMarkdown(
+      propertyText(scope.environments.join(", ") || "All environments") ??
+        "All environments"
+    )}`,
+    `- **Snapshot:** ${asOf}`,
+  ]
+  const top =
+    aggregate?.statsComplete === true ? aggregate.mostActiveIssue : null
+  const topLine = top
+    ? `\n\nMost active issue in the current seven-day window: **${escapeMarkdown(
+        propertyText(top.title) ?? "Untitled issue"
+      )}** (${top.events.toLocaleString("en-US")} events).`
+    : ""
+  const link = projectIssueUrl(scope, project.id)
+  return `## Reliability snapshot\n\n${lines.join("\n")}${topLine}\n\n[Review this project's issues in Sentry](${link})`
+}
+
+export function projectToChange(
+  project: SentryProject,
+  aggregate: ProjectIssueAggregate | undefined,
+  asOf: string,
+  scope: SentryScope
+) {
+  const mostActive =
+    aggregate?.statsComplete === true ? aggregate.mostActiveIssue : null
+  const platform = selectText(
+    project.platform || project.platforms[0] || aggregate?.platform
+  )
+  const teams = project.teams
+    .map((team) => selectText(team.name))
+    .filter((value): value is string => Boolean(value))
+  if (teams.length > MAX_MULTI_SELECT_VALUES) {
+    throw new Error(
+      `Sentry project ${project.id} has more than ${MAX_MULTI_SELECT_VALUES} teams and cannot fit in one complete Notion property.`
+    )
+  }
+  const lastSeen = dateTime(aggregate?.lastSeen)
+  const firstEvent = dateTime(project.firstEvent)
+  const projectLink = safeHttpUrl(projectIssueUrl(scope, project.id))
+  const issueLink = safeHttpUrl(mostActive?.url)
+
+  return {
+    type: "upsert" as const,
+    key: project.id,
+    pageContentMarkdown: projectPageContent(project, aggregate, asOf, scope),
+    properties: {
+      Project: Builder.title(titleText(project.name)),
+      "Unresolved Issues (30d)": Builder.number(
+        aggregate?.unresolvedIssues ?? 0
+      ),
+      ...(aggregate?.statsComplete === false
+        ? {}
+        : { "Events (7d)": Builder.number(aggregate?.events7d ?? 0) }),
+      ...(mostActive
+        ? {
+            "Most Active Issue (7d)": Builder.richText(
+              propertyText(mostActive.title) ?? "Untitled issue"
+            ),
+          }
+        : {}),
+      ...(issueLink ? { "Issue Link": Builder.url(issueLink) } : {}),
+      ...(lastSeen ? { "Last Seen": Builder.dateTime(lastSeen) } : {}),
+      ...(aggregate?.statsComplete === false
+        ? {}
+        : {
+            "Previous 7d Events": Builder.number(
+              aggregate?.previous7dEvents ?? 0
+            ),
+            "Event Change vs Prior 7d": Builder.number(
+              (aggregate?.events7d ?? 0) - (aggregate?.previous7dEvents ?? 0)
+            ),
+          }),
+      "Issue Groups (30d)": Builder.number(aggregate?.issueGroups ?? 0),
+      ...(aggregate?.countsComplete === false
+        ? {}
+        : { "Events (30d)": Builder.number(aggregate?.events30d ?? 0) }),
+      "High-Priority Unresolved (30d)": Builder.number(
+        aggregate?.highPriorityUnresolved ?? 0
+      ),
+      "New Unresolved (30d)": Builder.number(aggregate?.newUnresolved ?? 0),
+      "Regressed Unresolved (30d)": Builder.number(
+        aggregate?.regressedUnresolved ?? 0
+      ),
+      "Escalating Unresolved (30d)": Builder.number(
+        aggregate?.escalatingUnresolved ?? 0
+      ),
+      "Unhandled Unresolved (30d)": Builder.number(
+        aggregate?.unhandledUnresolved ?? 0
+      ),
+      "Unassigned Unresolved (30d)": Builder.number(
+        aggregate?.unassignedUnresolved ?? 0
+      ),
+      ...(projectLink ? { "Project Link": Builder.url(projectLink) } : {}),
+      ...(platform ? { Platform: Builder.select(platform) } : {}),
+      ...(teams.length > 0 ? { Teams: Builder.multiSelect(...teams) } : {}),
+      ...(project.hasSessions === null
+        ? {}
+        : { "Has Sessions": Builder.checkbox(project.hasSessions) }),
+      ...(firstEvent ? { "First Event": Builder.dateTime(firstEvent) } : {}),
+      "Environment Scope": Builder.richText(
+        propertyText(scope.environments.join(", ") || "All environments") ??
+          "All environments"
+      ),
+      "As Of": Builder.dateTime(asOf),
+      "Project Slug": Builder.richText(project.slug),
+      "Sentry Project ID": Builder.richText(project.id),
+    },
+  }
+}

--- a/workers/sentry-sync/src/projects.ts
+++ b/workers/sentry-sync/src/projects.ts
@@ -2,7 +2,7 @@
 // counts are intentionally absent because one person can span many groups.
 
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import * as Schema from "@notionhq/workers/schema"
 
 import {
@@ -53,7 +53,7 @@ export type ProjectIssueAggregate = {
 
 export type ProjectAggregateMap = Record<string, ProjectIssueAggregate>
 
-export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const projectSchema = {
   databaseIcon: notionIcon("chart-line"),
   properties: {
     Project: Schema.title(),
@@ -82,7 +82,12 @@ export const projectSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     "Project Slug": Schema.richText(),
     "Sentry Project ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+type ProjectChange = SyncChangeUpsert<
+  typeof PRIMARY_KEY,
+  typeof projectSchema.properties
+> & { pageContentMarkdown: string }
 
 function issueEventBuckets(
   issue: SentryIssue,
@@ -345,7 +350,7 @@ export function projectToChange(
   aggregate: ProjectIssueAggregate | undefined,
   asOf: string,
   scope: SentryScope
-) {
+): ProjectChange {
   const mostActive =
     aggregate?.statsComplete === true ? aggregate.mostActiveIssue : null
   const platform = selectText(
@@ -373,32 +378,30 @@ export function projectToChange(
       "Unresolved Issues (30d)": Builder.number(
         aggregate?.unresolvedIssues ?? 0
       ),
-      ...(aggregate?.statsComplete === false
-        ? {}
-        : { "Events (7d)": Builder.number(aggregate?.events7d ?? 0) }),
-      ...(mostActive
-        ? {
-            "Most Active Issue (7d)": Builder.richText(
-              propertyText(mostActive.title) ?? "Untitled issue"
-            ),
-          }
-        : {}),
-      ...(issueLink ? { "Issue Link": Builder.url(issueLink) } : {}),
-      ...(lastSeen ? { "Last Seen": Builder.dateTime(lastSeen) } : {}),
-      ...(aggregate?.statsComplete === false
-        ? {}
-        : {
-            "Previous 7d Events": Builder.number(
-              aggregate?.previous7dEvents ?? 0
-            ),
-            "Event Change vs Prior 7d": Builder.number(
+      "Events (7d)":
+        aggregate?.statsComplete === false
+          ? []
+          : Builder.number(aggregate?.events7d ?? 0),
+      "Most Active Issue (7d)": mostActive
+        ? Builder.richText(propertyText(mostActive.title) ?? "Untitled issue")
+        : [],
+      "Issue Link": issueLink ? Builder.url(issueLink) : [],
+      "Last Seen": lastSeen ? Builder.dateTime(lastSeen) : [],
+      "Previous 7d Events":
+        aggregate?.statsComplete === false
+          ? []
+          : Builder.number(aggregate?.previous7dEvents ?? 0),
+      "Event Change vs Prior 7d":
+        aggregate?.statsComplete === false
+          ? []
+          : Builder.number(
               (aggregate?.events7d ?? 0) - (aggregate?.previous7dEvents ?? 0)
             ),
-          }),
       "Issue Groups (30d)": Builder.number(aggregate?.issueGroups ?? 0),
-      ...(aggregate?.countsComplete === false
-        ? {}
-        : { "Events (30d)": Builder.number(aggregate?.events30d ?? 0) }),
+      "Events (30d)":
+        aggregate?.countsComplete === false
+          ? []
+          : Builder.number(aggregate?.events30d ?? 0),
       "High-Priority Unresolved (30d)": Builder.number(
         aggregate?.highPriorityUnresolved ?? 0
       ),
@@ -415,13 +418,14 @@ export function projectToChange(
       "Unassigned Unresolved (30d)": Builder.number(
         aggregate?.unassignedUnresolved ?? 0
       ),
-      ...(projectLink ? { "Project Link": Builder.url(projectLink) } : {}),
-      ...(platform ? { Platform: Builder.select(platform) } : {}),
-      ...(teams.length > 0 ? { Teams: Builder.multiSelect(...teams) } : {}),
-      ...(project.hasSessions === null
-        ? {}
-        : { "Has Sessions": Builder.checkbox(project.hasSessions) }),
-      ...(firstEvent ? { "First Event": Builder.dateTime(firstEvent) } : {}),
+      "Project Link": projectLink ? Builder.url(projectLink) : [],
+      Platform: platform ? Builder.select(platform) : [],
+      Teams: Builder.multiSelect(...teams),
+      "Has Sessions":
+        project.hasSessions === null
+          ? []
+          : Builder.checkbox(project.hasSessions),
+      "First Event": firstEvent ? Builder.dateTime(firstEvent) : [],
       "Environment Scope": Builder.richText(
         propertyText(scope.environments.join(", ") || "All environments") ??
           "All environments"

--- a/workers/sentry-sync/src/projects.ts
+++ b/workers/sentry-sync/src/projects.ts
@@ -374,7 +374,9 @@ export function projectToChange(
     key: project.id,
     pageContentMarkdown: projectPageContent(project, aggregate, asOf, scope),
     properties: {
-      Project: Builder.title(titleText(project.name)),
+      Project: Builder.title(
+        titleText(project.name, "Untitled Sentry project")
+      ),
       "Unresolved Issues (30d)": Builder.number(
         aggregate?.unresolvedIssues ?? 0
       ),

--- a/workers/sentry-sync/src/releases.ts
+++ b/workers/sentry-sync/src/releases.ts
@@ -1,0 +1,282 @@
+// The newest organization releases enriched with one aggregate Release Health
+// query. Rows match Sentry's release entity; there are no per-release calls.
+
+import * as Builder from "@notionhq/workers/builder"
+import { notionIcon } from "@notionhq/workers"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  dateTime,
+  escapeMarkdown,
+  propertyText,
+  safeHttpUrl,
+  selectText,
+  titleText,
+} from "./helpers.js"
+import type {
+  SentryRelease,
+  SentryReleaseHealth,
+  SentryReleaseHealthSnapshot,
+  SentryScope,
+} from "./sentry.js"
+
+export const INITIAL_TITLE = "Sentry Releases"
+export const PRIMARY_KEY = "Sentry Release ID"
+export const RELEASE_HEALTH_DAYS = 7
+const MAX_MULTI_SELECT_VALUES = 100
+
+export function releaseHealthWindow(now = Date.now()): {
+  start: string
+  end: string
+} {
+  if (!Number.isFinite(now) || now < 0) {
+    throw new Error(
+      "Cannot create a Sentry release window from an invalid time"
+    )
+  }
+  return {
+    start: new Date(
+      Math.max(0, now - RELEASE_HEALTH_DAYS * 86_400_000)
+    ).toISOString(),
+    end: new Date(now).toISOString(),
+  }
+}
+
+export const releaseSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+  databaseIcon: notionIcon("shield"),
+  properties: {
+    Release: Schema.title(),
+    Projects: Schema.multiSelect([]),
+    "Crash-Free Users": Schema.number("percent"),
+    "Crash-Free Sessions": Schema.number("percent"),
+    "New Issues": Schema.number(),
+    Status: Schema.select([]),
+    "Sessions (7d)": Schema.number(),
+    "Users (7d)": Schema.number(),
+    "Sentry Link": Schema.url(),
+    "Released At": Schema.date(),
+    "Created At": Schema.date(),
+    "Health Data (7d)": Schema.checkbox(),
+    "Release URL": Schema.url(),
+    "First Event": Schema.date(),
+    "Last Event": Schema.date(),
+    Deploys: Schema.number(),
+    Commits: Schema.number(),
+    Platforms: Schema.multiSelect([]),
+    Version: Schema.richText(),
+    Reference: Schema.richText(),
+    "Window Start": Schema.date(),
+    "Window End": Schema.date(),
+    "Health Project Scope": Schema.richText(),
+    "Environment Scope": Schema.richText(),
+    "Sentry Release ID": Schema.richText(),
+  },
+}
+
+export function healthByRelease(
+  snapshot: SentryReleaseHealthSnapshot
+): Map<string, SentryReleaseHealth> {
+  const result = new Map<string, SentryReleaseHealth>()
+  for (const group of snapshot.groups) {
+    if (result.has(group.release)) {
+      throw new Error(
+        `Sentry release health returned duplicate release group ${group.release}`
+      )
+    }
+    result.set(group.release, group)
+  }
+  return result
+}
+
+function sentryPercent(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new Error(
+      `Sentry returned an invalid crash-free percentage: ${value}`
+    )
+  }
+  // The sessions API reports percentage points (for example, 99.9), while a
+  // Notion percent property stores the corresponding fraction.
+  return value / 100
+}
+
+export function sentryReleaseUrl(scope: SentryScope, version: string): string {
+  const url = new URL(scope.baseUrl)
+  const prefix = url.pathname.replace(/\/+$/, "")
+  url.pathname = `${prefix}/organizations/${encodeURIComponent(
+    scope.organization
+  )}/releases/${encodeURIComponent(version)}/`
+  return url.toString()
+}
+
+function releasePageContent(
+  release: SentryRelease,
+  health: SentryReleaseHealth | undefined,
+  snapshot: SentryReleaseHealthSnapshot,
+  scope: SentryScope
+): string {
+  const projects = release.projects
+    .map((project) => project.name || project.slug)
+    .join(", ")
+  const lines = [
+    `- **Projects:** ${escapeMarkdown(
+      propertyText(projects) ?? "Not provided"
+    )}`,
+    `- **Release:** ${escapeMarkdown(
+      propertyText(release.version) ?? "Unknown"
+    )}`,
+    health?.crashFreeUsers === null || health?.crashFreeUsers === undefined
+      ? "- **Crash-free users:** Not available"
+      : `- **Crash-free users:** ${health.crashFreeUsers.toLocaleString(
+          "en-US",
+          { maximumFractionDigits: 3 }
+        )}%`,
+    health?.sessions === null || health?.sessions === undefined
+      ? "- **Seven-day exposure:** Not available"
+      : `- **Seven-day exposure:** ${health.sessions.toLocaleString(
+          "en-US"
+        )} sessions${
+          health.users === null
+            ? ""
+            : ` · ${health.users.toLocaleString("en-US")} users`
+        }`,
+    snapshot.available
+      ? `- **Health window:** ${snapshot.start} to ${snapshot.end}`
+      : "- **Health window:** Not available on this Sentry installation",
+    `- **Health project scope:** ${escapeMarkdown(
+      propertyText(scope.projects.join(", ") || "All accessible projects") ??
+        "All accessible projects"
+    )}`,
+    `- **Environment scope:** ${escapeMarkdown(
+      propertyText(scope.environments.join(", ") || "All environments") ??
+        "All environments"
+    )}`,
+  ]
+  const sourceUrl = sentryReleaseUrl(scope, release.version)
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
+  return `## Rollout snapshot\n\n${lines.join(
+    "\n"
+  )}\n\n[Open this release in Sentry](${sourceUrl})`
+}
+
+export function releasesToChanges(
+  releases: SentryRelease[],
+  snapshot: SentryReleaseHealthSnapshot,
+  scope: SentryScope
+) {
+  const health = healthByRelease(snapshot)
+  return releases.map((release) => {
+    const releaseHealth = health.get(release.version)
+    const projects = [
+      ...new Set(
+        release.projects
+          .map((project) => selectText(project.name || project.slug))
+          .filter((value): value is string => Boolean(value))
+      ),
+    ]
+    const platforms = [
+      ...new Set(
+        release.projects
+          .flatMap((project) => [project.platform, ...project.platforms])
+          .map(selectText)
+          .filter((value): value is string => Boolean(value))
+      ),
+    ]
+    if (projects.length > MAX_MULTI_SELECT_VALUES) {
+      throw new Error(
+        `Sentry release ${release.id} spans more than ${MAX_MULTI_SELECT_VALUES} projects; customize the Projects field to summarize associations while keeping the row complete.`
+      )
+    }
+    if (platforms.length > MAX_MULTI_SELECT_VALUES) {
+      throw new Error(
+        `Sentry release ${release.id} has more than ${MAX_MULTI_SELECT_VALUES} platforms; narrow SENTRY_PROJECTS to keep the Notion row complete.`
+      )
+    }
+    const crashFreeUsers = sentryPercent(releaseHealth?.crashFreeUsers)
+    const crashFreeSessions = sentryPercent(releaseHealth?.crashFreeSessions)
+    const status = selectText(release.status)
+    const sentryUrl = safeHttpUrl(sentryReleaseUrl(scope, release.version))
+    const externalUrl = safeHttpUrl(release.url)
+    const releasedAt = dateTime(release.dateReleased)
+    const createdAt = dateTime(release.dateCreated)
+    const firstEvent = dateTime(release.firstEvent)
+    const lastEvent = dateTime(release.lastEvent)
+    const reference = propertyText(release.ref)
+    const hasHealthData = snapshot.available ? Boolean(releaseHealth) : null
+
+    return {
+      type: "upsert" as const,
+      key: release.id,
+      pageContentMarkdown: releasePageContent(
+        release,
+        releaseHealth,
+        snapshot,
+        scope
+      ),
+      properties: {
+        Release: Builder.title(
+          titleText(release.shortVersion ?? release.version)
+        ),
+        ...(projects.length > 0
+          ? { Projects: Builder.multiSelect(...projects) }
+          : {}),
+        ...(crashFreeUsers === null
+          ? {}
+          : { "Crash-Free Users": Builder.number(crashFreeUsers) }),
+        ...(crashFreeSessions === null
+          ? {}
+          : { "Crash-Free Sessions": Builder.number(crashFreeSessions) }),
+        ...(release.newGroups === null
+          ? {}
+          : { "New Issues": Builder.number(release.newGroups) }),
+        ...(status ? { Status: Builder.select(status) } : {}),
+        ...(releaseHealth?.sessions === null ||
+        releaseHealth?.sessions === undefined
+          ? {}
+          : { "Sessions (7d)": Builder.number(releaseHealth.sessions) }),
+        ...(releaseHealth?.users === null || releaseHealth?.users === undefined
+          ? {}
+          : { "Users (7d)": Builder.number(releaseHealth.users) }),
+        ...(sentryUrl ? { "Sentry Link": Builder.url(sentryUrl) } : {}),
+        ...(releasedAt ? { "Released At": Builder.dateTime(releasedAt) } : {}),
+        ...(createdAt ? { "Created At": Builder.dateTime(createdAt) } : {}),
+        ...(hasHealthData === null
+          ? {}
+          : { "Health Data (7d)": Builder.checkbox(hasHealthData) }),
+        ...(externalUrl ? { "Release URL": Builder.url(externalUrl) } : {}),
+        ...(firstEvent ? { "First Event": Builder.dateTime(firstEvent) } : {}),
+        ...(lastEvent ? { "Last Event": Builder.dateTime(lastEvent) } : {}),
+        ...(release.deployCount === null
+          ? {}
+          : { Deploys: Builder.number(release.deployCount) }),
+        ...(release.commitCount === null
+          ? {}
+          : { Commits: Builder.number(release.commitCount) }),
+        ...(platforms.length > 0
+          ? { Platforms: Builder.multiSelect(...platforms) }
+          : {}),
+        Version: Builder.richText(
+          propertyText(release.version) ?? "Unknown release"
+        ),
+        ...(reference ? { Reference: Builder.richText(reference) } : {}),
+        ...(snapshot.start
+          ? { "Window Start": Builder.dateTime(snapshot.start) }
+          : {}),
+        ...(snapshot.end
+          ? { "Window End": Builder.dateTime(snapshot.end) }
+          : {}),
+        "Health Project Scope": Builder.richText(
+          propertyText(
+            scope.projects.join(", ") || "All accessible projects"
+          ) ?? "All accessible projects"
+        ),
+        "Environment Scope": Builder.richText(
+          propertyText(scope.environments.join(", ") || "All environments") ??
+            "All environments"
+        ),
+        "Sentry Release ID": Builder.richText(release.id),
+      },
+    }
+  })
+}

--- a/workers/sentry-sync/src/releases.ts
+++ b/workers/sentry-sync/src/releases.ts
@@ -221,7 +221,10 @@ export function releasesToChanges(
       ),
       properties: {
         Release: Builder.title(
-          titleText(release.shortVersion ?? release.version)
+          titleText(
+            release.shortVersion ?? release.version,
+            "Untitled Sentry release"
+          )
         ),
         Projects: Builder.multiSelect(...projects),
         "Crash-Free Users":

--- a/workers/sentry-sync/src/releases.ts
+++ b/workers/sentry-sync/src/releases.ts
@@ -145,9 +145,7 @@ function releasePageContent(
             ? ""
             : ` · ${health.users.toLocaleString("en-US")} users`
         }`,
-    snapshot.available
-      ? `- **Health window:** ${snapshot.start} to ${snapshot.end}`
-      : "- **Health window:** Not available on this Sentry installation",
+    `- **Health window:** ${snapshot.start} to ${snapshot.end}`,
     `- **Health project scope:** ${escapeMarkdown(
       propertyText(scope.projects.join(", ") || "All accessible projects") ??
         "All accessible projects"
@@ -208,7 +206,7 @@ export function releasesToChanges(
     const firstEvent = dateTime(release.firstEvent)
     const lastEvent = dateTime(release.lastEvent)
     const reference = propertyText(release.ref)
-    const hasHealthData = snapshot.available ? Boolean(releaseHealth) : null
+    const hasHealthData = Boolean(releaseHealth)
 
     return {
       type: "upsert" as const,
@@ -246,8 +244,7 @@ export function releasesToChanges(
         "Sentry Link": sentryUrl ? Builder.url(sentryUrl) : [],
         "Released At": releasedAt ? Builder.dateTime(releasedAt) : [],
         "Created At": createdAt ? Builder.dateTime(createdAt) : [],
-        "Health Data (7d)":
-          hasHealthData === null ? [] : Builder.checkbox(hasHealthData),
+        "Health Data (7d)": Builder.checkbox(hasHealthData),
         "Release URL": externalUrl ? Builder.url(externalUrl) : [],
         "First Event": firstEvent ? Builder.dateTime(firstEvent) : [],
         "Last Event": lastEvent ? Builder.dateTime(lastEvent) : [],
@@ -264,8 +261,8 @@ export function releasesToChanges(
           propertyText(release.version) ?? "Unknown release"
         ),
         Reference: reference ? Builder.richText(reference) : [],
-        "Window Start": snapshot.start ? Builder.dateTime(snapshot.start) : [],
-        "Window End": snapshot.end ? Builder.dateTime(snapshot.end) : [],
+        "Window Start": Builder.dateTime(snapshot.start),
+        "Window End": Builder.dateTime(snapshot.end),
         "Health Project Scope": Builder.richText(
           propertyText(
             scope.projects.join(", ") || "All accessible projects"

--- a/workers/sentry-sync/src/releases.ts
+++ b/workers/sentry-sync/src/releases.ts
@@ -2,7 +2,7 @@
 // query. Rows match Sentry's release entity; there are no per-release calls.
 
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import * as Schema from "@notionhq/workers/schema"
 
 import {
@@ -42,7 +42,7 @@ export function releaseHealthWindow(now = Date.now()): {
   }
 }
 
-export const releaseSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const releaseSchema = {
   databaseIcon: notionIcon("shield"),
   properties: {
     Release: Schema.title(),
@@ -71,7 +71,12 @@ export const releaseSchema: Schema.Schema<typeof PRIMARY_KEY> = {
     "Environment Scope": Schema.richText(),
     "Sentry Release ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+type ReleaseChange = SyncChangeUpsert<
+  typeof PRIMARY_KEY,
+  typeof releaseSchema.properties
+> & { pageContentMarkdown: string }
 
 export function healthByRelease(
   snapshot: SentryReleaseHealthSnapshot
@@ -164,7 +169,7 @@ export function releasesToChanges(
   releases: SentryRelease[],
   snapshot: SentryReleaseHealthSnapshot,
   scope: SentryScope
-) {
+): ReleaseChange[] {
   const health = healthByRelease(snapshot)
   return releases.map((release) => {
     const releaseHealth = health.get(release.version)
@@ -218,54 +223,46 @@ export function releasesToChanges(
         Release: Builder.title(
           titleText(release.shortVersion ?? release.version)
         ),
-        ...(projects.length > 0
-          ? { Projects: Builder.multiSelect(...projects) }
-          : {}),
-        ...(crashFreeUsers === null
-          ? {}
-          : { "Crash-Free Users": Builder.number(crashFreeUsers) }),
-        ...(crashFreeSessions === null
-          ? {}
-          : { "Crash-Free Sessions": Builder.number(crashFreeSessions) }),
-        ...(release.newGroups === null
-          ? {}
-          : { "New Issues": Builder.number(release.newGroups) }),
-        ...(status ? { Status: Builder.select(status) } : {}),
-        ...(releaseHealth?.sessions === null ||
-        releaseHealth?.sessions === undefined
-          ? {}
-          : { "Sessions (7d)": Builder.number(releaseHealth.sessions) }),
-        ...(releaseHealth?.users === null || releaseHealth?.users === undefined
-          ? {}
-          : { "Users (7d)": Builder.number(releaseHealth.users) }),
-        ...(sentryUrl ? { "Sentry Link": Builder.url(sentryUrl) } : {}),
-        ...(releasedAt ? { "Released At": Builder.dateTime(releasedAt) } : {}),
-        ...(createdAt ? { "Created At": Builder.dateTime(createdAt) } : {}),
-        ...(hasHealthData === null
-          ? {}
-          : { "Health Data (7d)": Builder.checkbox(hasHealthData) }),
-        ...(externalUrl ? { "Release URL": Builder.url(externalUrl) } : {}),
-        ...(firstEvent ? { "First Event": Builder.dateTime(firstEvent) } : {}),
-        ...(lastEvent ? { "Last Event": Builder.dateTime(lastEvent) } : {}),
-        ...(release.deployCount === null
-          ? {}
-          : { Deploys: Builder.number(release.deployCount) }),
-        ...(release.commitCount === null
-          ? {}
-          : { Commits: Builder.number(release.commitCount) }),
-        ...(platforms.length > 0
-          ? { Platforms: Builder.multiSelect(...platforms) }
-          : {}),
+        Projects: Builder.multiSelect(...projects),
+        "Crash-Free Users":
+          crashFreeUsers === null ? [] : Builder.number(crashFreeUsers),
+        "Crash-Free Sessions":
+          crashFreeSessions === null ? [] : Builder.number(crashFreeSessions),
+        "New Issues":
+          release.newGroups === null ? [] : Builder.number(release.newGroups),
+        Status: status ? Builder.select(status) : [],
+        "Sessions (7d)":
+          releaseHealth?.sessions === null ||
+          releaseHealth?.sessions === undefined
+            ? []
+            : Builder.number(releaseHealth.sessions),
+        "Users (7d)":
+          releaseHealth?.users === null || releaseHealth?.users === undefined
+            ? []
+            : Builder.number(releaseHealth.users),
+        "Sentry Link": sentryUrl ? Builder.url(sentryUrl) : [],
+        "Released At": releasedAt ? Builder.dateTime(releasedAt) : [],
+        "Created At": createdAt ? Builder.dateTime(createdAt) : [],
+        "Health Data (7d)":
+          hasHealthData === null ? [] : Builder.checkbox(hasHealthData),
+        "Release URL": externalUrl ? Builder.url(externalUrl) : [],
+        "First Event": firstEvent ? Builder.dateTime(firstEvent) : [],
+        "Last Event": lastEvent ? Builder.dateTime(lastEvent) : [],
+        Deploys:
+          release.deployCount === null
+            ? []
+            : Builder.number(release.deployCount),
+        Commits:
+          release.commitCount === null
+            ? []
+            : Builder.number(release.commitCount),
+        Platforms: Builder.multiSelect(...platforms),
         Version: Builder.richText(
           propertyText(release.version) ?? "Unknown release"
         ),
-        ...(reference ? { Reference: Builder.richText(reference) } : {}),
-        ...(snapshot.start
-          ? { "Window Start": Builder.dateTime(snapshot.start) }
-          : {}),
-        ...(snapshot.end
-          ? { "Window End": Builder.dateTime(snapshot.end) }
-          : {}),
+        Reference: reference ? Builder.richText(reference) : [],
+        "Window Start": snapshot.start ? Builder.dateTime(snapshot.start) : [],
+        "Window End": snapshot.end ? Builder.dateTime(snapshot.end) : [],
         "Health Project Scope": Builder.richText(
           propertyText(
             scope.projects.join(", ") || "All accessible projects"

--- a/workers/sentry-sync/src/sentry.ts
+++ b/workers/sentry-sync/src/sentry.ts
@@ -1,5 +1,5 @@
-// Minimal Sentry REST client for organization issue groups. It intentionally
-// never requests event payloads, stack traces, breadcrumbs, tags, or user PII.
+// Minimal Sentry REST client for issue groups, projects, recent releases, and
+// aggregate session health. It never requests raw events or user PII.
 
 import { createHash } from "node:crypto"
 
@@ -9,10 +9,25 @@ import type { SentryStats } from "./helpers.js"
 
 const DEFAULT_BASE_URL = "https://sentry.io"
 const PAGE_SIZE = 100
+const RECENT_RELEASE_LIMIT = 100
+// 250 groups × four fields × (seven daily buckets + totals) stays below
+// Sentry's documented 10,000-data-point ceiling even if series are computed
+// before includeSeries=0 is applied.
+const RELEASE_HEALTH_GROUP_LIMIT = 250
 const REQUEST_TIMEOUT_MS = 30_000
 const ERROR_EXCERPT_CHARACTERS = 500
 
 export type BeforeRequest = () => Promise<void>
+
+export class SentryApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message)
+    this.name = "SentryApiError"
+  }
+}
 
 export type SentryIssue = {
   id: string
@@ -50,9 +65,10 @@ export type FetchIssuesOptions = {
   start: string
   end: string
   cursor?: string
+  statsPeriod?: "24h" | "14d"
 }
 
-export type SentryIssueScope = {
+export type SentryScope = {
   baseUrl: string
   organization: string
   projects: string[]
@@ -60,10 +76,72 @@ export type SentryIssueScope = {
   credentialFingerprint: string
 }
 
+export type SentryIssueScope = SentryScope
+
 export type SentryPage = {
   resources: SentryIssue[]
   hasMore: boolean
   nextCursor: string | undefined
+}
+
+export type SentryProject = {
+  id: string
+  name: string
+  slug: string
+  platform: string | null
+  platforms: string[]
+  teams: Array<{ id: string; name: string; slug: string }>
+  dateCreated: string | null
+  firstEvent: string | null
+  hasSessions: boolean | null
+}
+
+export type SentryProjectPage = {
+  resources: SentryProject[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}
+
+export type SentryReleaseProject = {
+  id: string | null
+  name: string
+  slug: string
+  newGroups: number | null
+  platform: string | null
+  platforms: string[]
+  hasHealthData: boolean | null
+}
+
+export type SentryRelease = {
+  id: string
+  version: string
+  shortVersion: string | null
+  status: string | null
+  ref: string | null
+  url: string | null
+  dateReleased: string | null
+  dateCreated: string | null
+  newGroups: number | null
+  commitCount: number | null
+  deployCount: number | null
+  firstEvent: string | null
+  lastEvent: string | null
+  projects: SentryReleaseProject[]
+}
+
+export type SentryReleaseHealth = {
+  release: string
+  sessions: number | null
+  users: number | null
+  crashFreeSessions: number | null
+  crashFreeUsers: number | null
+}
+
+export type SentryReleaseHealthSnapshot = {
+  available: boolean
+  start: string | null
+  end: string | null
+  groups: SentryReleaseHealth[]
 }
 
 function requireEnv(name: string): string {
@@ -117,7 +195,7 @@ function sentryBaseUrl(
   return url
 }
 
-export function getIssueScope(): SentryIssueScope {
+export function getSentryScope(): SentryScope {
   const token = requireEnv("SENTRY_AUTH_TOKEN")
   return {
     baseUrl: sentryBaseUrl().toString(),
@@ -128,6 +206,9 @@ export function getIssueScope(): SentryIssueScope {
   }
 }
 
+// Retain the issue-specific name for forks importing the original example.
+export const getIssueScope = getSentryScope
+
 function tokenFingerprint(token: string): string {
   return createHash("sha256").update(token).digest("hex")
 }
@@ -137,14 +218,14 @@ function validateScopeValues(values: unknown, name: string): string[] {
     !Array.isArray(values) ||
     values.some((value) => typeof value !== "string" || !value.trim())
   ) {
-    throw new Error(`Sentry issue sync state has invalid ${name}`)
+    throw new Error(`Sentry sync state has invalid ${name}`)
   }
   return values.map((value) => value.trim())
 }
 
 export function buildIssuesUrl(
   options: FetchIssuesOptions,
-  scope = getIssueScope()
+  scope = getSentryScope()
 ): URL {
   const organization = organizationSlug(scope.organization)
   const projects = validateScopeValues(scope.projects, "project filters")
@@ -165,7 +246,7 @@ export function buildIssuesUrl(
   base.searchParams.set("start", options.start)
   base.searchParams.set("end", options.end)
   base.searchParams.set("sort", "new")
-  base.searchParams.set("groupStatsPeriod", "24h")
+  base.searchParams.set("groupStatsPeriod", options.statsPeriod ?? "24h")
   base.searchParams.set("limit", String(PAGE_SIZE))
 
   for (const project of projects) {
@@ -177,6 +258,88 @@ export function buildIssuesUrl(
   if (options.cursor) base.searchParams.set("cursor", options.cursor)
 
   return base
+}
+
+function organizationResourceUrl(
+  scope: SentryScope,
+  resource: "projects" | "releases" | "sessions"
+): URL {
+  const organization = organizationSlug(scope.organization)
+  const base = sentryBaseUrl(scope.baseUrl)
+  const prefix = base.pathname.replace(/\/+$/, "")
+  base.pathname = `${prefix}/api/0/organizations/${encodeURIComponent(
+    organization
+  )}/${resource}/`
+  return base
+}
+
+export function buildProjectsUrl(
+  cursor: string | undefined,
+  scope = getSentryScope()
+): URL {
+  const url = organizationResourceUrl(scope, "projects")
+  url.searchParams.set("per_page", String(PAGE_SIZE))
+  if (cursor) url.searchParams.set("cursor", cursor)
+  return url
+}
+
+/** The newest 100 releases are a deliberate product boundary, not truncation. */
+export function buildReleasesUrl(scope = getSentryScope()): URL {
+  const url = organizationResourceUrl(scope, "releases")
+  url.searchParams.set("per_page", String(RECENT_RELEASE_LIMIT))
+  // Sentry otherwise defaults this endpoint to open releases. The explicit
+  // empty filter keeps recently archived releases in rollout history too.
+  url.searchParams.set("status", "")
+  for (const project of validateScopeValues(
+    scope.projects,
+    "project filters"
+  )) {
+    url.searchParams.append("project", project)
+  }
+  for (const environment of validateScopeValues(
+    scope.environments,
+    "environment filters"
+  )) {
+    url.searchParams.append("environment", environment)
+  }
+  return url
+}
+
+export function buildReleaseHealthUrl(
+  start: string,
+  end: string,
+  scope = getSentryScope()
+): URL {
+  const url = organizationResourceUrl(scope, "sessions")
+  url.searchParams.set("start", start)
+  url.searchParams.set("end", end)
+  url.searchParams.set("interval", "1d")
+  for (const field of [
+    "sum(session)",
+    "count_unique(user)",
+    "crash_free_rate(session)",
+    "crash_free_rate(user)",
+  ]) {
+    url.searchParams.append("field", field)
+  }
+  url.searchParams.append("groupBy", "release")
+  url.searchParams.set("orderBy", "-sum(session)")
+  url.searchParams.set("includeTotals", "1")
+  url.searchParams.set("includeSeries", "0")
+  url.searchParams.set("per_page", String(RELEASE_HEALTH_GROUP_LIMIT))
+  for (const project of validateScopeValues(
+    scope.projects,
+    "project filters"
+  )) {
+    url.searchParams.append("project", project)
+  }
+  for (const environment of validateScopeValues(
+    scope.environments,
+    "environment filters"
+  )) {
+    url.searchParams.append("environment", environment)
+  }
+  return url
 }
 
 export function parseRetryAfterSeconds(
@@ -258,10 +421,11 @@ function linkAttributes(value: string): Map<string, string> {
 /** Parse Sentry's RFC-style Link header; page length is never authoritative. */
 export function nextCursorFromLink(
   linkHeader: string | null,
-  expectedRequestUrl: URL
+  expectedRequestUrl: URL,
+  resource = "issue"
 ): string | undefined {
   if (!linkHeader?.trim()) {
-    throw new Error("Sentry issue pagination is missing its Link header")
+    throw new Error(`Sentry ${resource} pagination is missing its Link header`)
   }
 
   const nextEntries = splitLinkHeader(linkHeader).filter((entry) => {
@@ -269,39 +433,43 @@ export function nextCursorFromLink(
     return (attributes.get("rel") ?? "").split(/\s+/).includes("next")
   })
   if (nextEntries.length !== 1) {
-    throw new Error("Sentry issue pagination must contain one next Link entry")
+    throw new Error(
+      `Sentry ${resource} pagination must contain one next Link entry`
+    )
   }
 
   const entry = nextEntries[0]
   const attributes = linkAttributes(entry)
   const results = attributes.get("results")
   if (results !== "true" && results !== "false") {
-    throw new Error("Sentry issue pagination has an invalid results flag")
+    throw new Error(`Sentry ${resource} pagination has an invalid results flag`)
   }
   if (results === "false") return undefined
 
   const targetMatch = entry.match(/^\s*<([^>]+)>/)
   if (!targetMatch) {
-    throw new Error("Sentry issue pagination has an invalid next URL")
+    throw new Error(`Sentry ${resource} pagination has an invalid next URL`)
   }
 
   let target: URL
   try {
     target = new URL(targetMatch[1], expectedRequestUrl)
   } catch {
-    throw new Error("Sentry issue pagination has an invalid next URL")
+    throw new Error(`Sentry ${resource} pagination has an invalid next URL`)
   }
   if (
     target.origin !== expectedRequestUrl.origin ||
     target.pathname !== expectedRequestUrl.pathname
   ) {
-    throw new Error("Sentry issue pagination returned an untrusted next URL")
+    throw new Error(
+      `Sentry ${resource} pagination returned an untrusted next URL`
+    )
   }
 
   const cursors = target.searchParams.getAll("cursor")
   const cursor = cursors.length === 1 ? cursors[0].trim() : ""
   if (!cursor) {
-    throw new Error("Sentry issue pagination is missing its next cursor")
+    throw new Error(`Sentry ${resource} pagination is missing its next cursor`)
   }
   return cursor
 }
@@ -360,37 +528,42 @@ function nullableRecord(
 
 function selectedStats(
   record: Record<string, unknown>,
-  index: number
+  index: number,
+  period: "24h" | "14d"
 ): SentryStats | null {
   const stats = nullableRecord(record, "stats", index)
-  if (!stats || stats["24h"] === null || stats["24h"] === undefined) {
+  if (!stats || stats[period] === null || stats[period] === undefined) {
     return null
   }
-  if (!Array.isArray(stats["24h"])) {
-    throw new Error(`Sentry issue ${index} has invalid 24h stats`)
+  if (!Array.isArray(stats[period])) {
+    throw new Error(`Sentry issue ${index} has invalid ${period} stats`)
   }
 
-  const points: Array<[number, number]> = stats["24h"].map(
+  const points: Array<[number, number]> = stats[period].map(
     (point, pointIndex) => {
       if (!Array.isArray(point) || point.length < 2) {
         throw new Error(
-          `Sentry issue ${index} has an invalid 24h stats point ${pointIndex}`
+          `Sentry issue ${index} has an invalid ${period} stats point ${pointIndex}`
         )
       }
       const timestamp = Number(point[0])
       const count = Number(point[1])
       if (!Number.isFinite(timestamp) || !Number.isFinite(count) || count < 0) {
         throw new Error(
-          `Sentry issue ${index} has an invalid 24h stats point ${pointIndex}`
+          `Sentry issue ${index} has an invalid ${period} stats point ${pointIndex}`
         )
       }
       return [timestamp, count]
     }
   )
-  return { "24h": points }
+  return { [period]: points }
 }
 
-function parseIssue(value: unknown, index: number): SentryIssue {
+function parseIssue(
+  value: unknown,
+  index: number,
+  statsPeriod: "24h" | "14d"
+): SentryIssue {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`Sentry issue ${index} is not an object`)
   }
@@ -442,7 +615,7 @@ function parseIssue(value: unknown, index: number): SentryIssue {
       : null,
     firstSeen: nullableString(record, "firstSeen", index),
     lastSeen: nullableString(record, "lastSeen", index),
-    stats: selectedStats(record, index),
+    stats: selectedStats(record, index, statsPeriod),
   }
 }
 
@@ -451,18 +624,18 @@ function errorExcerpt(text: string): string {
   return Array.from(compact).slice(0, ERROR_EXCERPT_CHARACTERS).join("")
 }
 
-export async function fetchIssuesPage(
+async function fetchSentryJson(
   beforeRequest: BeforeRequest,
-  options: FetchIssuesOptions,
-  scope = getIssueScope()
-): Promise<SentryPage> {
+  url: URL,
+  scope: SentryScope,
+  activity: string
+): Promise<{ body: unknown; headers: Headers }> {
   const token = requireEnv("SENTRY_AUTH_TOKEN")
   if (tokenFingerprint(token) !== scope.credentialFingerprint) {
     throw new Error(
-      "SENTRY_AUTH_TOKEN changed during Sentry issue pagination; restart the full refresh with one credential."
+      `SENTRY_AUTH_TOKEN changed during Sentry ${activity}; restart the full refresh with one credential.`
     )
   }
-  const url = buildIssuesUrl(options, scope)
 
   await beforeRequest()
   let response: Response
@@ -495,14 +668,14 @@ export async function fetchIssuesPage(
   }
   if (!response.ok) {
     const detail = errorExcerpt(text)
-    throw new Error(
+    throw new SentryApiError(
+      response.status,
       `Sentry API error (${response.status})${detail ? `: ${detail}` : ""}`
     )
   }
 
-  let body: unknown
   try {
-    body = JSON.parse(text)
+    return { body: JSON.parse(text), headers: response.headers }
   } catch {
     throw new Error(
       `Sentry API returned invalid JSON (${response.status}): ${errorExcerpt(
@@ -510,14 +683,370 @@ export async function fetchIssuesPage(
       )}`
     )
   }
+}
+
+function resourceRecord(
+  value: unknown,
+  label: string
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function resourceString(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+  required = false
+): string | null {
+  const value = record[key]
+  if (value === null || value === undefined) {
+    if (required) throw new Error(`${label} is missing ${key}`)
+    return null
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${label} has an invalid ${key}`)
+  }
+  if (required && !value.trim()) throw new Error(`${label} is missing ${key}`)
+  return value
+}
+
+function resourceId(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): string {
+  const value = record[key]
+  const text =
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value))
+      ? String(value).trim()
+      : ""
+  if (!text) throw new Error(`${label} is missing its immutable ${key}`)
+  return text
+}
+
+function optionalResourceId(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): string | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  const text =
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value))
+      ? String(value).trim()
+      : ""
+  if (!text) throw new Error(`${label} has an invalid ${key}`)
+  return text
+}
+
+function resourceNumber(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): number | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} has an invalid ${key}`)
+  }
+  return value
+}
+
+function resourceBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): boolean | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} has an invalid ${key}`)
+  }
+  return value
+}
+
+function resourceArray(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): unknown[] {
+  const value = record[key]
+  if (value === null || value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`${label} has an invalid ${key}`)
+  return value
+}
+
+function requiredResourceArray(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): unknown[] {
+  if (!Object.prototype.hasOwnProperty.call(record, key)) {
+    throw new Error(`${label} is missing ${key}`)
+  }
+  const value = record[key]
+  if (!Array.isArray(value)) throw new Error(`${label} has an invalid ${key}`)
+  return value
+}
+
+function resourceStrings(
+  record: Record<string, unknown>,
+  key: string,
+  label: string
+): string[] {
+  return resourceArray(record, key, label).map((value, index) => {
+    if (typeof value !== "string") {
+      throw new Error(`${label} has an invalid ${key} value ${index}`)
+    }
+    return value
+  })
+}
+
+function parseProject(value: unknown, index: number): SentryProject {
+  const label = `Sentry project ${index}`
+  const record = resourceRecord(value, label)
+  const teams = resourceArray(record, "teams", label).map((team, teamIndex) => {
+    const teamLabel = `${label} team ${teamIndex}`
+    const teamRecord = resourceRecord(team, teamLabel)
+    return {
+      id: resourceId(teamRecord, "id", teamLabel),
+      name: resourceString(teamRecord, "name", teamLabel, true) as string,
+      slug: resourceString(teamRecord, "slug", teamLabel, true) as string,
+    }
+  })
+
+  return {
+    id: resourceId(record, "id", label),
+    name: resourceString(record, "name", label, true) as string,
+    slug: resourceString(record, "slug", label, true) as string,
+    platform: resourceString(record, "platform", label),
+    platforms: resourceStrings(record, "platforms", label),
+    teams,
+    dateCreated: resourceString(record, "dateCreated", label),
+    firstEvent: resourceString(record, "firstEvent", label),
+    hasSessions: resourceBoolean(record, "hasSessions", label),
+  }
+}
+
+function parseReleaseProject(
+  value: unknown,
+  releaseIndex: number,
+  projectIndex: number
+): SentryReleaseProject {
+  const label = `Sentry release ${releaseIndex} project ${projectIndex}`
+  const record = resourceRecord(value, label)
+  return {
+    id: optionalResourceId(record, "id", label),
+    name: resourceString(record, "name", label, true) as string,
+    slug: resourceString(record, "slug", label, true) as string,
+    newGroups: resourceNumber(record, "newGroups", label),
+    platform: resourceString(record, "platform", label),
+    platforms: resourceStrings(record, "platforms", label),
+    hasHealthData: resourceBoolean(record, "hasHealthData", label),
+  }
+}
+
+function parseRelease(value: unknown, index: number): SentryRelease {
+  const label = `Sentry release ${index}`
+  const record = resourceRecord(value, label)
+  const projects = requiredResourceArray(record, "projects", label).map(
+    (project, projectIndex) => parseReleaseProject(project, index, projectIndex)
+  )
+  if (
+    new Set(projects.map((project) => project.slug)).size !== projects.length
+  ) {
+    throw new Error(`${label} contains duplicate project slugs`)
+  }
+  return {
+    id: resourceId(record, "id", label),
+    version: resourceString(record, "version", label, true) as string,
+    shortVersion: resourceString(record, "shortVersion", label),
+    status: resourceString(record, "status", label),
+    ref: resourceString(record, "ref", label),
+    url: resourceString(record, "url", label),
+    dateReleased: resourceString(record, "dateReleased", label),
+    dateCreated: resourceString(record, "dateCreated", label),
+    newGroups: resourceNumber(record, "newGroups", label),
+    commitCount: resourceNumber(record, "commitCount", label),
+    deployCount: resourceNumber(record, "deployCount", label),
+    firstEvent: resourceString(record, "firstEvent", label),
+    lastEvent: resourceString(record, "lastEvent", label),
+    projects,
+  }
+}
+
+function releaseHealthNumber(
+  totals: Record<string, unknown>,
+  key: string,
+  label: string
+): number | null {
+  const value = totals[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} has an invalid ${key}`)
+  }
+  return value
+}
+
+function parseReleaseHealthGroup(
+  value: unknown,
+  index: number
+): SentryReleaseHealth {
+  const label = `Sentry release health group ${index}`
+  const record = resourceRecord(value, label)
+  const by = resourceRecord(record.by, `${label} by`)
+  const totals = resourceRecord(record.totals, `${label} totals`)
+  const release = resourceString(by, "release", label, true) as string
+  return {
+    release,
+    sessions: releaseHealthNumber(totals, "sum(session)", label),
+    users: releaseHealthNumber(totals, "count_unique(user)", label),
+    crashFreeSessions: releaseHealthNumber(
+      totals,
+      "crash_free_rate(session)",
+      label
+    ),
+    crashFreeUsers: releaseHealthNumber(totals, "crash_free_rate(user)", label),
+  }
+}
+
+export async function fetchIssuesPage(
+  beforeRequest: BeforeRequest,
+  options: FetchIssuesOptions,
+  scope = getSentryScope()
+): Promise<SentryPage> {
+  const url = buildIssuesUrl(options, scope)
+  const { body, headers } = await fetchSentryJson(
+    beforeRequest,
+    url,
+    scope,
+    "issue pagination"
+  )
   if (!Array.isArray(body)) {
     throw new Error("Sentry issue response must be a JSON array")
   }
 
-  const nextCursor = nextCursorFromLink(response.headers.get("link"), url)
+  const nextCursor = nextCursorFromLink(headers.get("link"), url)
+  const statsPeriod = options.statsPeriod ?? "24h"
   return {
-    resources: body.map(parseIssue),
+    resources: body.map((issue, index) =>
+      parseIssue(issue, index, statsPeriod)
+    ),
     hasMore: nextCursor !== undefined,
     nextCursor,
+  }
+}
+
+export async function fetchProjectsPage(
+  beforeRequest: BeforeRequest,
+  cursor: string | undefined,
+  scope = getSentryScope()
+): Promise<SentryProjectPage> {
+  const url = buildProjectsUrl(cursor, scope)
+  const { body, headers } = await fetchSentryJson(
+    beforeRequest,
+    url,
+    scope,
+    "project pagination"
+  )
+  if (!Array.isArray(body)) {
+    throw new Error("Sentry project response must be a JSON array")
+  }
+  const nextCursor = nextCursorFromLink(headers.get("link"), url, "project")
+  return {
+    resources: body.map(parseProject),
+    hasMore: nextCursor !== undefined,
+    nextCursor,
+  }
+}
+
+export async function fetchRecentReleases(
+  beforeRequest: BeforeRequest,
+  scope = getSentryScope()
+): Promise<SentryRelease[]> {
+  const url = buildReleasesUrl(scope)
+  const { body } = await fetchSentryJson(
+    beforeRequest,
+    url,
+    scope,
+    "recent release loading"
+  )
+  if (!Array.isArray(body)) {
+    throw new Error("Sentry release response must be a JSON array")
+  }
+  if (body.length > RECENT_RELEASE_LIMIT) {
+    throw new Error(
+      `Sentry returned more than the requested ${RECENT_RELEASE_LIMIT} recent releases`
+    )
+  }
+  const releases = body.map(parseRelease)
+  if (new Set(releases.map((release) => release.id)).size !== releases.length) {
+    throw new Error("Sentry release response contains duplicate release IDs")
+  }
+  return releases
+}
+
+export async function fetchReleaseHealth(
+  beforeRequest: BeforeRequest,
+  start: string,
+  end: string,
+  scope = getSentryScope()
+): Promise<SentryReleaseHealthSnapshot> {
+  const url = buildReleaseHealthUrl(start, end, scope)
+  const { body, headers } = await fetchSentryJson(
+    beforeRequest,
+    url,
+    scope,
+    "release health loading"
+  )
+  const record = resourceRecord(body, "Sentry release health response")
+  const groups = requiredResourceArray(
+    record,
+    "groups",
+    "Sentry release health response"
+  )
+  if (groups.length >= RELEASE_HEALTH_GROUP_LIMIT) {
+    throw new Error(
+      `Sentry release health reached the ${RELEASE_HEALTH_GROUP_LIMIT}-group safety limit; narrow SENTRY_PROJECTS or SENTRY_ENVIRONMENTS to avoid an incomplete refresh.`
+    )
+  }
+  const link = headers.get("link")
+  if (link) {
+    const nextCursor = nextCursorFromLink(link, url, "release health")
+    if (nextCursor) {
+      throw new Error(
+        "Sentry release health returned another page; narrow SENTRY_PROJECTS or SENTRY_ENVIRONMENTS so the aggregate refresh is complete."
+      )
+    }
+  }
+  const responseStart = resourceString(
+    record,
+    "start",
+    "Sentry release health response",
+    true
+  ) as string
+  const responseEnd = resourceString(
+    record,
+    "end",
+    "Sentry release health response",
+    true
+  ) as string
+  if (
+    !Number.isFinite(Date.parse(responseStart)) ||
+    !Number.isFinite(Date.parse(responseEnd)) ||
+    Date.parse(responseStart) >= Date.parse(responseEnd)
+  ) {
+    throw new Error("Sentry release health response has an invalid time window")
+  }
+  return {
+    available: true,
+    start: responseStart,
+    end: responseEnd,
+    groups: groups.map(parseReleaseHealthGroup),
   }
 }

--- a/workers/sentry-sync/src/sentry.ts
+++ b/workers/sentry-sync/src/sentry.ts
@@ -1,5 +1,6 @@
-// Minimal Sentry REST client for issue groups, projects, recent releases, and
-// aggregate session health. It never requests raw events or user PII.
+// Sentry REST client for issue groups, projects, recent releases, and aggregate
+// session health. It does not request raw events; parsers select only the fields
+// used by the Notion databases and do not persist unselected personal data.
 
 import { createHash } from "node:crypto"
 
@@ -16,6 +17,8 @@ const RECENT_RELEASE_LIMIT = 100
 const RELEASE_HEALTH_GROUP_LIMIT = 250
 const REQUEST_TIMEOUT_MS = 30_000
 const ERROR_EXCERPT_CHARACTERS = 500
+
+// API contracts
 
 export type BeforeRequest = () => Promise<void>
 
@@ -76,9 +79,7 @@ export type SentryScope = {
   credentialFingerprint: string
 }
 
-export type SentryIssueScope = SentryScope
-
-export type SentryPage = {
+export type SentryIssuePage = {
   resources: SentryIssue[]
   hasMore: boolean
   nextCursor: string | undefined
@@ -144,6 +145,8 @@ export type SentryReleaseHealthSnapshot = {
   groups: SentryReleaseHealth[]
 }
 
+// Configuration and request construction
+
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim()
   if (!value) throw new Error(`${name} is not set.`)
@@ -205,9 +208,6 @@ export function getSentryScope(): SentryScope {
     credentialFingerprint: tokenFingerprint(token),
   }
 }
-
-// Retain the issue-specific name for forks importing the original example.
-export const getIssueScope = getSentryScope
 
 function tokenFingerprint(token: string): string {
   return createHash("sha256").update(token).digest("hex")
@@ -342,6 +342,8 @@ export function buildReleaseHealthUrl(
   return url
 }
 
+// Rate limits and pagination
+
 export function parseRetryAfterSeconds(
   value: string | null,
   now = Date.now()
@@ -473,6 +475,8 @@ export function nextCursorFromLink(
   }
   return cursor
 }
+
+// Issue response parsing
 
 function nullableString(
   record: Record<string, unknown>,
@@ -619,6 +623,8 @@ function parseIssue(
   }
 }
 
+// Authenticated transport
+
 function errorExcerpt(text: string): string {
   const compact = text.replace(/\s+/g, " ").trim()
   return Array.from(compact).slice(0, ERROR_EXCERPT_CHARACTERS).join("")
@@ -684,6 +690,8 @@ async function fetchSentryJson(
     )
   }
 }
+
+// Project and release response parsing
 
 function resourceRecord(
   value: unknown,
@@ -915,11 +923,13 @@ function parseReleaseHealthGroup(
   }
 }
 
+// Resource fetchers
+
 export async function fetchIssuesPage(
   beforeRequest: BeforeRequest,
   options: FetchIssuesOptions,
   scope = getSentryScope()
-): Promise<SentryPage> {
+): Promise<SentryIssuePage> {
   const url = buildIssuesUrl(options, scope)
   const { body, headers } = await fetchSentryJson(
     beforeRequest,

--- a/workers/sentry-sync/src/sentry.ts
+++ b/workers/sentry-sync/src/sentry.ts
@@ -2,8 +2,6 @@
 // session health. It does not request raw events; parsers select only the fields
 // used by the Notion databases and do not persist unselected personal data.
 
-import { createHash } from "node:crypto"
-
 import { RateLimitError } from "@notionhq/workers"
 
 import type { SentryStats } from "./helpers.js"
@@ -76,7 +74,6 @@ export type SentryScope = {
   organization: string
   projects: string[]
   environments: string[]
-  credentialFingerprint: string
 }
 
 export type SentryIssuePage = {
@@ -139,9 +136,8 @@ export type SentryReleaseHealth = {
 }
 
 export type SentryReleaseHealthSnapshot = {
-  available: boolean
-  start: string | null
-  end: string | null
+  start: string
+  end: string
   groups: SentryReleaseHealth[]
 }
 
@@ -199,18 +195,13 @@ function sentryBaseUrl(
 }
 
 export function getSentryScope(): SentryScope {
-  const token = requireEnv("SENTRY_AUTH_TOKEN")
+  requireEnv("SENTRY_AUTH_TOKEN")
   return {
     baseUrl: sentryBaseUrl().toString(),
     organization: organizationSlug(requireEnv("SENTRY_ORG_SLUG")),
     projects: commaSeparatedEnv("SENTRY_PROJECTS"),
     environments: commaSeparatedEnv("SENTRY_ENVIRONMENTS"),
-    credentialFingerprint: tokenFingerprint(token),
   }
-}
-
-function tokenFingerprint(token: string): string {
-  return createHash("sha256").update(token).digest("hex")
 }
 
 function validateScopeValues(values: unknown, name: string): string[] {
@@ -287,9 +278,6 @@ export function buildProjectsUrl(
 export function buildReleasesUrl(scope = getSentryScope()): URL {
   const url = organizationResourceUrl(scope, "releases")
   url.searchParams.set("per_page", String(RECENT_RELEASE_LIMIT))
-  // Sentry otherwise defaults this endpoint to open releases. The explicit
-  // empty filter keeps recently archived releases in rollout history too.
-  url.searchParams.set("status", "")
   for (const project of validateScopeValues(
     scope.projects,
     "project filters"
@@ -637,11 +625,6 @@ async function fetchSentryJson(
   activity: string
 ): Promise<{ body: unknown; headers: Headers }> {
   const token = requireEnv("SENTRY_AUTH_TOKEN")
-  if (tokenFingerprint(token) !== scope.credentialFingerprint) {
-    throw new Error(
-      `SENTRY_AUTH_TOKEN changed during Sentry ${activity}; restart the full refresh with one credential.`
-    )
-  }
 
   await beforeRequest()
   let response: Response
@@ -657,10 +640,10 @@ async function fetchSentryJson(
     })
   } catch (error) {
     if (error instanceof Error && error.name === "TimeoutError") {
-      throw new Error("Sentry API request timed out after 30 seconds")
+      throw new Error(`Sentry ${activity} timed out after 30 seconds`)
     }
     throw new Error(
-      `Sentry API request failed: ${
+      `Sentry ${activity} request failed: ${
         error instanceof Error ? error.message : "unknown network error"
       }`
     )
@@ -676,7 +659,9 @@ async function fetchSentryJson(
     const detail = errorExcerpt(text)
     throw new SentryApiError(
       response.status,
-      `Sentry API error (${response.status})${detail ? `: ${detail}` : ""}`
+      `Sentry API error (${response.status}) during ${activity}${
+        detail ? `: ${detail}` : ""
+      }`
     )
   }
 
@@ -684,9 +669,7 @@ async function fetchSentryJson(
     return { body: JSON.parse(text), headers: response.headers }
   } catch {
     throw new Error(
-      `Sentry API returned invalid JSON (${response.status}): ${errorExcerpt(
-        text
-      )}`
+      `Sentry ${activity} returned invalid JSON (${response.status}): ${errorExcerpt(text)}`
     )
   }
 }
@@ -1054,7 +1037,6 @@ export async function fetchReleaseHealth(
     throw new Error("Sentry release health response has an invalid time window")
   }
   return {
-    available: true,
     start: responseStart,
     end: responseEnd,
     groups: groups.map(parseReleaseHealthGroup),

--- a/workers/sentry-sync/src/sentry.ts
+++ b/workers/sentry-sync/src/sentry.ts
@@ -1,0 +1,523 @@
+// Minimal Sentry REST client for organization issue groups. It intentionally
+// never requests event payloads, stack traces, breadcrumbs, tags, or user PII.
+
+import { createHash } from "node:crypto"
+
+import { RateLimitError } from "@notionhq/workers"
+
+import type { SentryStats } from "./helpers.js"
+
+const DEFAULT_BASE_URL = "https://sentry.io"
+const PAGE_SIZE = 100
+const REQUEST_TIMEOUT_MS = 30_000
+const ERROR_EXCERPT_CHARACTERS = 500
+
+export type BeforeRequest = () => Promise<void>
+
+export type SentryIssue = {
+  id: string
+  shortId: string | null
+  title: string
+  culprit: string | null
+  permalink: string | null
+  status: string | null
+  substatus: string | null
+  priority: string | null
+  level: string | null
+  isUnhandled: boolean | null
+  assignedTo: { name: string | null } | null
+  project: {
+    id: string | null
+    name: string | null
+    slug: string | null
+    platform: string | null
+  } | null
+  platform: string | null
+  issueCategory: string | null
+  issueType: string | null
+  count: string | number | null
+  userCount: string | number | null
+  lifetime: {
+    count: string | number | null
+    userCount: string | number | null
+  } | null
+  firstSeen: string | null
+  lastSeen: string | null
+  stats: SentryStats | null
+}
+
+export type FetchIssuesOptions = {
+  start: string
+  end: string
+  cursor?: string
+}
+
+export type SentryIssueScope = {
+  baseUrl: string
+  organization: string
+  projects: string[]
+  environments: string[]
+  credentialFingerprint: string
+}
+
+export type SentryPage = {
+  resources: SentryIssue[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is not set.`)
+  return value
+}
+
+function commaSeparatedEnv(name: string): string[] {
+  const values = process.env[name]?.split(",") ?? []
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))]
+}
+
+function organizationSlug(value: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value)) {
+    throw new Error(
+      "SENTRY_ORG_SLUG must contain only letters, numbers, hyphens, or underscores."
+    )
+  }
+  return value
+}
+
+function sentryBaseUrl(
+  raw = process.env.SENTRY_BASE_URL?.trim() || DEFAULT_BASE_URL
+): URL {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error("SENTRY_BASE_URL must be a valid absolute URL.")
+  }
+
+  const loopbackHosts = new Set(["localhost", "127.0.0.1", "[::1]", "::1"])
+  const isLoopbackHttp =
+    url.protocol === "http:" && loopbackHosts.has(url.hostname.toLowerCase())
+  if (url.protocol !== "https:" && !isLoopbackHttp) {
+    throw new Error(
+      "SENTRY_BASE_URL must use HTTPS (HTTP is allowed only for a loopback development server)."
+    )
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      "SENTRY_BASE_URL cannot contain credentials, query parameters, or a fragment."
+    )
+  }
+  if (url.pathname.replace(/\/+$/, "").endsWith("/api/0")) {
+    throw new Error("SENTRY_BASE_URL must be the server root, without /api/0.")
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, "")
+  return url
+}
+
+export function getIssueScope(): SentryIssueScope {
+  const token = requireEnv("SENTRY_AUTH_TOKEN")
+  return {
+    baseUrl: sentryBaseUrl().toString(),
+    organization: organizationSlug(requireEnv("SENTRY_ORG_SLUG")),
+    projects: commaSeparatedEnv("SENTRY_PROJECTS"),
+    environments: commaSeparatedEnv("SENTRY_ENVIRONMENTS"),
+    credentialFingerprint: tokenFingerprint(token),
+  }
+}
+
+function tokenFingerprint(token: string): string {
+  return createHash("sha256").update(token).digest("hex")
+}
+
+function validateScopeValues(values: unknown, name: string): string[] {
+  if (
+    !Array.isArray(values) ||
+    values.some((value) => typeof value !== "string" || !value.trim())
+  ) {
+    throw new Error(`Sentry issue sync state has invalid ${name}`)
+  }
+  return values.map((value) => value.trim())
+}
+
+export function buildIssuesUrl(
+  options: FetchIssuesOptions,
+  scope = getIssueScope()
+): URL {
+  const organization = organizationSlug(scope.organization)
+  const projects = validateScopeValues(scope.projects, "project filters")
+  const environments = validateScopeValues(
+    scope.environments,
+    "environment filters"
+  )
+  const base = sentryBaseUrl(scope.baseUrl)
+  const prefix = base.pathname.replace(/\/+$/, "")
+  base.pathname = `${prefix}/api/0/organizations/${encodeURIComponent(
+    organization
+  )}/issues/`
+
+  // Sentry defaults this endpoint to unresolved issues. An explicit empty
+  // query is required for the rolling database to include resolved/ignored
+  // issues as well as active ones.
+  base.searchParams.set("query", "")
+  base.searchParams.set("start", options.start)
+  base.searchParams.set("end", options.end)
+  base.searchParams.set("sort", "new")
+  base.searchParams.set("groupStatsPeriod", "24h")
+  base.searchParams.set("limit", String(PAGE_SIZE))
+
+  for (const project of projects) {
+    base.searchParams.append("project", project)
+  }
+  for (const environment of environments) {
+    base.searchParams.append("environment", environment)
+  }
+  if (options.cursor) base.searchParams.set("cursor", options.cursor)
+
+  return base
+}
+
+export function parseRetryAfterSeconds(
+  value: string | null,
+  now = Date.now()
+): number | undefined {
+  if (!value?.trim()) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds)
+
+  const retryAt = Date.parse(value)
+  if (!Number.isFinite(retryAt)) return undefined
+  return Math.max(0, Math.ceil((retryAt - now) / 1_000))
+}
+
+/** Calculate the longest usable delay from Sentry's rate-limit headers. */
+export function rateLimitRetryAfterSeconds(
+  headers: Headers,
+  now = Date.now()
+): number | undefined {
+  const delays: number[] = []
+  const retryAfter = parseRetryAfterSeconds(headers.get("retry-after"), now)
+  if (retryAfter !== undefined) delays.push(retryAfter)
+
+  const remainingHeader = headers.get("x-sentry-rate-limit-remaining")
+  const resetHeader = headers.get("x-sentry-rate-limit-reset")
+  const remaining = remainingHeader === null ? NaN : Number(remainingHeader)
+  const reset = resetHeader === null ? NaN : Number(resetHeader)
+  if (Number.isFinite(remaining) && remaining <= 0 && Number.isFinite(reset)) {
+    const resetMs = reset > 10_000_000_000 ? reset : reset * 1_000
+    delays.push(Math.max(0, Math.ceil((resetMs - now) / 1_000)))
+  }
+
+  return delays.length > 0 ? Math.max(...delays) : undefined
+}
+
+function splitLinkHeader(header: string): string[] {
+  const entries: string[] = []
+  let start = 0
+  let inAngle = false
+  let inQuote = false
+  let escaped = false
+
+  for (let index = 0; index < header.length; index += 1) {
+    const character = header[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (inQuote && character === "\\") {
+      escaped = true
+      continue
+    }
+    if (character === '"' && !inAngle) inQuote = !inQuote
+    if (!inQuote && character === "<") inAngle = true
+    if (!inQuote && character === ">") inAngle = false
+    if (character === "," && !inAngle && !inQuote) {
+      entries.push(header.slice(start, index).trim())
+      start = index + 1
+    }
+  }
+  entries.push(header.slice(start).trim())
+  return entries.filter(Boolean)
+}
+
+function linkAttributes(value: string): Map<string, string> {
+  const attributes = new Map<string, string>()
+  const pattern = /;\s*([^\s=;]+)\s*=\s*(?:"((?:\\.|[^"])*)"|([^\s;,]+))/g
+  for (const match of value.matchAll(pattern)) {
+    attributes.set(
+      match[1].toLowerCase(),
+      (match[2] ?? match[3] ?? "").replace(/\\"/g, '"')
+    )
+  }
+  return attributes
+}
+
+/** Parse Sentry's RFC-style Link header; page length is never authoritative. */
+export function nextCursorFromLink(
+  linkHeader: string | null,
+  expectedRequestUrl: URL
+): string | undefined {
+  if (!linkHeader?.trim()) {
+    throw new Error("Sentry issue pagination is missing its Link header")
+  }
+
+  const nextEntries = splitLinkHeader(linkHeader).filter((entry) => {
+    const attributes = linkAttributes(entry)
+    return (attributes.get("rel") ?? "").split(/\s+/).includes("next")
+  })
+  if (nextEntries.length !== 1) {
+    throw new Error("Sentry issue pagination must contain one next Link entry")
+  }
+
+  const entry = nextEntries[0]
+  const attributes = linkAttributes(entry)
+  const results = attributes.get("results")
+  if (results !== "true" && results !== "false") {
+    throw new Error("Sentry issue pagination has an invalid results flag")
+  }
+  if (results === "false") return undefined
+
+  const targetMatch = entry.match(/^\s*<([^>]+)>/)
+  if (!targetMatch) {
+    throw new Error("Sentry issue pagination has an invalid next URL")
+  }
+
+  let target: URL
+  try {
+    target = new URL(targetMatch[1], expectedRequestUrl)
+  } catch {
+    throw new Error("Sentry issue pagination has an invalid next URL")
+  }
+  if (
+    target.origin !== expectedRequestUrl.origin ||
+    target.pathname !== expectedRequestUrl.pathname
+  ) {
+    throw new Error("Sentry issue pagination returned an untrusted next URL")
+  }
+
+  const cursors = target.searchParams.getAll("cursor")
+  const cursor = cursors.length === 1 ? cursors[0].trim() : ""
+  if (!cursor) {
+    throw new Error("Sentry issue pagination is missing its next cursor")
+  }
+  return cursor
+}
+
+function nullableString(
+  record: Record<string, unknown>,
+  key: string,
+  index: number
+): string | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "string") {
+    throw new Error(`Sentry issue ${index} has an invalid ${key}`)
+  }
+  return value
+}
+
+function nullableCount(
+  record: Record<string, unknown>,
+  key: string,
+  index: number
+): string | number | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw new Error(`Sentry issue ${index} has an invalid ${key}`)
+  }
+  return value
+}
+
+function nullableBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  index: number
+): boolean | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "boolean") {
+    throw new Error(`Sentry issue ${index} has an invalid ${key}`)
+  }
+  return value
+}
+
+function nullableRecord(
+  record: Record<string, unknown>,
+  key: string,
+  index: number
+): Record<string, unknown> | null {
+  const value = record[key]
+  if (value === null || value === undefined) return null
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Sentry issue ${index} has an invalid ${key}`)
+  }
+  return value as Record<string, unknown>
+}
+
+function selectedStats(
+  record: Record<string, unknown>,
+  index: number
+): SentryStats | null {
+  const stats = nullableRecord(record, "stats", index)
+  if (!stats || stats["24h"] === null || stats["24h"] === undefined) {
+    return null
+  }
+  if (!Array.isArray(stats["24h"])) {
+    throw new Error(`Sentry issue ${index} has invalid 24h stats`)
+  }
+
+  const points: Array<[number, number]> = stats["24h"].map(
+    (point, pointIndex) => {
+      if (!Array.isArray(point) || point.length < 2) {
+        throw new Error(
+          `Sentry issue ${index} has an invalid 24h stats point ${pointIndex}`
+        )
+      }
+      const timestamp = Number(point[0])
+      const count = Number(point[1])
+      if (!Number.isFinite(timestamp) || !Number.isFinite(count) || count < 0) {
+        throw new Error(
+          `Sentry issue ${index} has an invalid 24h stats point ${pointIndex}`
+        )
+      }
+      return [timestamp, count]
+    }
+  )
+  return { "24h": points }
+}
+
+function parseIssue(value: unknown, index: number): SentryIssue {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Sentry issue ${index} is not an object`)
+  }
+  const record = value as Record<string, unknown>
+  const id = nullableString(record, "id", index)?.trim()
+  const title = nullableString(record, "title", index)
+  if (!id) throw new Error(`Sentry issue ${index} is missing its immutable id`)
+  if (title === null)
+    throw new Error(`Sentry issue ${index} is missing its title`)
+
+  const assignedTo = nullableRecord(record, "assignedTo", index)
+  const project = nullableRecord(record, "project", index)
+  const lifetime = nullableRecord(record, "lifetime", index)
+
+  return {
+    id,
+    title,
+    shortId: nullableString(record, "shortId", index),
+    culprit: nullableString(record, "culprit", index),
+    permalink: nullableString(record, "permalink", index),
+    status: nullableString(record, "status", index),
+    substatus: nullableString(record, "substatus", index),
+    priority: nullableString(record, "priority", index),
+    level: nullableString(record, "level", index),
+    isUnhandled: nullableBoolean(record, "isUnhandled", index),
+    assignedTo: assignedTo
+      ? { name: nullableString(assignedTo, "name", index) }
+      : null,
+    project: project
+      ? {
+          id: nullableString(project, "id", index),
+          name: nullableString(project, "name", index),
+          slug: nullableString(project, "slug", index),
+          platform: nullableString(project, "platform", index),
+        }
+      : null,
+    platform:
+      nullableString(record, "platform", index) ??
+      (project ? nullableString(project, "platform", index) : null),
+    issueCategory: nullableString(record, "issueCategory", index),
+    issueType: nullableString(record, "issueType", index),
+    count: nullableCount(record, "count", index),
+    userCount: nullableCount(record, "userCount", index),
+    lifetime: lifetime
+      ? {
+          count: nullableCount(lifetime, "count", index),
+          userCount: nullableCount(lifetime, "userCount", index),
+        }
+      : null,
+    firstSeen: nullableString(record, "firstSeen", index),
+    lastSeen: nullableString(record, "lastSeen", index),
+    stats: selectedStats(record, index),
+  }
+}
+
+function errorExcerpt(text: string): string {
+  const compact = text.replace(/\s+/g, " ").trim()
+  return Array.from(compact).slice(0, ERROR_EXCERPT_CHARACTERS).join("")
+}
+
+export async function fetchIssuesPage(
+  beforeRequest: BeforeRequest,
+  options: FetchIssuesOptions,
+  scope = getIssueScope()
+): Promise<SentryPage> {
+  const token = requireEnv("SENTRY_AUTH_TOKEN")
+  if (tokenFingerprint(token) !== scope.credentialFingerprint) {
+    throw new Error(
+      "SENTRY_AUTH_TOKEN changed during Sentry issue pagination; restart the full refresh with one credential."
+    )
+  }
+  const url = buildIssuesUrl(options, scope)
+
+  await beforeRequest()
+  let response: Response
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": "notion-cookbook-sentry-sync",
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new Error("Sentry API request timed out after 30 seconds")
+    }
+    throw new Error(
+      `Sentry API request failed: ${
+        error instanceof Error ? error.message : "unknown network error"
+      }`
+    )
+  }
+
+  const text = await response.text()
+  if (response.status === 429) {
+    throw new RateLimitError({
+      retryAfter: rateLimitRetryAfterSeconds(response.headers),
+    })
+  }
+  if (!response.ok) {
+    const detail = errorExcerpt(text)
+    throw new Error(
+      `Sentry API error (${response.status})${detail ? `: ${detail}` : ""}`
+    )
+  }
+
+  let body: unknown
+  try {
+    body = JSON.parse(text)
+  } catch {
+    throw new Error(
+      `Sentry API returned invalid JSON (${response.status}): ${errorExcerpt(
+        text
+      )}`
+    )
+  }
+  if (!Array.isArray(body)) {
+    throw new Error("Sentry issue response must be a JSON array")
+  }
+
+  const nextCursor = nextCursorFromLink(response.headers.get("link"), url)
+  return {
+    resources: body.map(parseIssue),
+    hasMore: nextCursor !== undefined,
+    nextCursor,
+  }
+}

--- a/workers/sentry-sync/src/sync-state.ts
+++ b/workers/sentry-sync/src/sync-state.ts
@@ -1,0 +1,80 @@
+// Pure, serializable state helpers for the rolling replacement scan.
+
+import type { SentryIssueScope } from "./sentry.js"
+
+export const ISSUE_WINDOW_DAYS = 30
+const DAY_MS = 24 * 60 * 60 * 1_000
+
+export type IssueSyncState = {
+  start: string
+  end: string
+  scope: SentryIssueScope
+  cursor?: string
+  seenCursors?: string[]
+}
+
+export type IssueWindow = {
+  start: string
+  end: string
+}
+
+function validTimestamp(value: string | undefined): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value))
+}
+
+/** Pin the rolling window until every page in the full refresh has finished. */
+export function issueWindow(
+  state: IssueSyncState | undefined,
+  now = Date.now()
+): IssueWindow {
+  if (state) {
+    if (!validTimestamp(state.start) || !validTimestamp(state.end)) {
+      throw new Error("Sentry issue sync state has an invalid time window")
+    }
+    if (Date.parse(state.start) >= Date.parse(state.end)) {
+      throw new Error("Sentry issue sync state must start before it ends")
+    }
+    return { start: state.start, end: state.end }
+  }
+
+  if (!Number.isFinite(now) || now < 0) {
+    throw new Error("Cannot create a Sentry issue window from an invalid time")
+  }
+
+  return {
+    start: new Date(
+      Math.max(0, now - ISSUE_WINDOW_DAYS * DAY_MS)
+    ).toISOString(),
+    end: new Date(now).toISOString(),
+  }
+}
+
+/**
+ * Persist every cursor in the current traversal so A → B → A fails closed
+ * instead of leaving a replacement run alive forever.
+ */
+export function nextIssueState(
+  state: IssueSyncState | undefined,
+  window: IssueWindow,
+  scope: SentryIssueScope,
+  nextCursor: string | undefined
+): IssueSyncState {
+  const cursor = nextCursor?.trim()
+  if (!cursor) {
+    throw new Error("Sentry issue pagination is missing its next cursor")
+  }
+
+  const seenCursors = new Set(state?.seenCursors ?? [])
+  if (state?.cursor) seenCursors.add(state.cursor)
+  if (seenCursors.has(cursor)) {
+    throw new Error("Sentry issue pagination repeated a cursor")
+  }
+  seenCursors.add(cursor)
+
+  return {
+    ...window,
+    scope,
+    cursor,
+    seenCursors: [...seenCursors],
+  }
+}

--- a/workers/sentry-sync/src/sync-state.ts
+++ b/workers/sentry-sync/src/sync-state.ts
@@ -1,6 +1,6 @@
 // Pure, serializable state helpers for the rolling replacement scan.
 
-import type { SentryIssueScope } from "./sentry.js"
+import type { SentryScope } from "./sentry.js"
 
 export const ISSUE_WINDOW_DAYS = 30
 // Workers rejects nextState above 256 KiB. Keep explicit headroom so future
@@ -11,7 +11,7 @@ const DAY_MS = 24 * 60 * 60 * 1_000
 export type IssueSyncState = {
   start: string
   end: string
-  scope: SentryIssueScope
+  scope: SentryScope
   cursor?: string
   seenCursors?: string[]
 }
@@ -72,7 +72,7 @@ export function issueWindow(
 export function nextIssueState(
   state: IssueSyncState | undefined,
   window: IssueWindow,
-  scope: SentryIssueScope,
+  scope: SentryScope,
   nextCursor: string | undefined
 ): IssueSyncState {
   const traversal = nextCursorTraversal(

--- a/workers/sentry-sync/src/sync-state.ts
+++ b/workers/sentry-sync/src/sync-state.ts
@@ -59,22 +59,36 @@ export function nextIssueState(
   scope: SentryIssueScope,
   nextCursor: string | undefined
 ): IssueSyncState {
-  const cursor = nextCursor?.trim()
-  if (!cursor) {
-    throw new Error("Sentry issue pagination is missing its next cursor")
-  }
-
-  const seenCursors = new Set(state?.seenCursors ?? [])
-  if (state?.cursor) seenCursors.add(state.cursor)
-  if (seenCursors.has(cursor)) {
-    throw new Error("Sentry issue pagination repeated a cursor")
-  }
-  seenCursors.add(cursor)
+  const traversal = nextCursorTraversal(
+    state?.cursor,
+    state?.seenCursors,
+    nextCursor,
+    "issue"
+  )
 
   return {
     ...window,
     scope,
-    cursor,
-    seenCursors: [...seenCursors],
+    ...traversal,
   }
+}
+
+export function nextCursorTraversal(
+  currentCursor: string | undefined,
+  priorCursors: string[] | undefined,
+  nextCursor: string | undefined,
+  resource: string
+): { cursor: string; seenCursors: string[] } {
+  const cursor = nextCursor?.trim()
+  if (!cursor) {
+    throw new Error(`Sentry ${resource} pagination is missing its next cursor`)
+  }
+
+  const seenCursors = new Set(priorCursors ?? [])
+  if (currentCursor) seenCursors.add(currentCursor)
+  if (seenCursors.has(cursor)) {
+    throw new Error(`Sentry ${resource} pagination repeated a cursor`)
+  }
+  seenCursors.add(cursor)
+  return { cursor, seenCursors: [...seenCursors] }
 }

--- a/workers/sentry-sync/src/sync-state.ts
+++ b/workers/sentry-sync/src/sync-state.ts
@@ -1,12 +1,16 @@
 // Pure, serializable state helpers for the rolling replacement scan.
 
+import { createHash } from "node:crypto"
+
 import type { SentryScope } from "./sentry.js"
 
 export const ISSUE_WINDOW_DAYS = 30
 // Workers rejects nextState above 256 KiB. Keep explicit headroom so future
 // state fields cannot turn a useful scope error into a runtime rejection.
 export const MAX_SAFE_SYNC_STATE_LENGTH = 240 * 1024
+export const MAX_RECENT_CURSOR_FINGERPRINTS = 32
 const DAY_MS = 24 * 60 * 60 * 1_000
+const textEncoder = new TextEncoder()
 
 export type IssueSyncState = {
   start: string
@@ -21,14 +25,26 @@ export type IssueWindow = {
   end: string
 }
 
-/** Fail with scope guidance before Workers rejects an oversized continuation. */
+/** Apply a conservative UTF-8 byte budget below the runtime's string limit. */
+export function syncStateSize(state: unknown): number {
+  return textEncoder.encode(JSON.stringify(state)).byteLength
+}
+
+export function syncStateFits(
+  state: unknown,
+  limit = MAX_SAFE_SYNC_STATE_LENGTH
+): boolean {
+  return syncStateSize(state) <= limit
+}
+
+/** Fail before Workers rejects an oversized continuation. */
 export function boundedSyncState<T>(state: T, resource: string): T {
-  const serializedLength = JSON.stringify(state).length
+  const serializedLength = syncStateSize(state)
   if (serializedLength > MAX_SAFE_SYNC_STATE_LENGTH) {
     throw new Error(
       `Sentry ${resource} continuation state exceeded the 240 KiB safety budget (${Math.ceil(
         serializedLength / 1024
-      )} KiB); narrow SENTRY_PROJECTS so the refresh can continue safely.`
+      )} KiB); the current refresh cannot continue safely.`
     )
   }
   return state
@@ -65,10 +81,7 @@ export function issueWindow(
   }
 }
 
-/**
- * Persist every cursor in the current traversal so A → B → A fails closed
- * instead of leaving a replacement run alive forever.
- */
+/** Keep recent cursor fingerprints so common loops fail without growing state. */
 export function nextIssueState(
   state: IssueSyncState | undefined,
   window: IssueWindow,
@@ -100,11 +113,31 @@ export function nextCursorTraversal(
     throw new Error(`Sentry ${resource} pagination is missing its next cursor`)
   }
 
-  const seenCursors = new Set(priorCursors ?? [])
-  if (currentCursor) seenCursors.add(currentCursor)
-  if (seenCursors.has(cursor)) {
+  // Persist compact fingerprints instead of provider-controlled cursor text.
+  // A bounded recent history catches common cursor cycles without introducing
+  // an artificial maximum page count or unbounded continuation state.
+  const fingerprint = (value: string): string =>
+    /^h:[A-Za-z0-9_-]{22}$/.test(value)
+      ? value
+      : `h:${createHash("sha256").update(value).digest("base64url").slice(0, 22)}`
+  let recentCursors = (priorCursors ?? [])
+    .map(fingerprint)
+    .slice(-MAX_RECENT_CURSOR_FINGERPRINTS)
+  if (currentCursor) {
+    const currentFingerprint = fingerprint(currentCursor)
+    if (!recentCursors.includes(currentFingerprint)) {
+      recentCursors.push(currentFingerprint)
+      recentCursors = recentCursors.slice(-MAX_RECENT_CURSOR_FINGERPRINTS)
+    }
+  }
+  const nextFingerprint = fingerprint(cursor)
+  if (recentCursors.includes(nextFingerprint)) {
     throw new Error(`Sentry ${resource} pagination repeated a cursor`)
   }
-  seenCursors.add(cursor)
-  return { cursor, seenCursors: [...seenCursors] }
+  return {
+    cursor,
+    seenCursors: [...recentCursors, nextFingerprint].slice(
+      -MAX_RECENT_CURSOR_FINGERPRINTS
+    ),
+  }
 }

--- a/workers/sentry-sync/src/sync-state.ts
+++ b/workers/sentry-sync/src/sync-state.ts
@@ -3,6 +3,9 @@
 import type { SentryIssueScope } from "./sentry.js"
 
 export const ISSUE_WINDOW_DAYS = 30
+// Workers rejects nextState above 256 KiB. Keep explicit headroom so future
+// state fields cannot turn a useful scope error into a runtime rejection.
+export const MAX_SAFE_SYNC_STATE_LENGTH = 240 * 1024
 const DAY_MS = 24 * 60 * 60 * 1_000
 
 export type IssueSyncState = {
@@ -16,6 +19,19 @@ export type IssueSyncState = {
 export type IssueWindow = {
   start: string
   end: string
+}
+
+/** Fail with scope guidance before Workers rejects an oversized continuation. */
+export function boundedSyncState<T>(state: T, resource: string): T {
+  const serializedLength = JSON.stringify(state).length
+  if (serializedLength > MAX_SAFE_SYNC_STATE_LENGTH) {
+    throw new Error(
+      `Sentry ${resource} continuation state exceeded the 240 KiB safety budget (${Math.ceil(
+        serializedLength / 1024
+      )} KiB); narrow SENTRY_PROJECTS so the refresh can continue safely.`
+    )
+  }
+  return state
 }
 
 function validTimestamp(value: string | undefined): value is string {

--- a/workers/sentry-sync/test.ts
+++ b/workers/sentry-sync/test.ts
@@ -51,6 +51,8 @@ import {
 } from "./src/sentry.js"
 import {
   ISSUE_WINDOW_DAYS,
+  MAX_SAFE_SYNC_STATE_LENGTH,
+  boundedSyncState,
   issueWindow,
   nextCursorTraversal,
   nextIssueState,
@@ -437,17 +439,43 @@ test("issue transform keeps stable identity and actionable impact fields", () =>
   assert.match(change.pageContentMarkdown, /Open this issue in Sentry/)
 })
 
-test("issue transform omits absent optional fields without inventing false values", () => {
-  const change = issueToChange(minimalIssue)
+test("issue transform clears values that disappear without inventing false values", () => {
+  const populated = issueToChange(fullIssue).properties as Record<
+    string,
+    unknown
+  >
+  const change = issueToChange({ ...minimalIssue, id: fullIssue.id })
   const properties = change.properties as Record<string, unknown>
-
-  assert.deepEqual(Object.keys(properties), ["Issue", "Sentry Issue ID"])
-  assert.equal(properties.Unhandled, undefined)
-  assert.equal(properties["Events (24h)"], undefined)
-  assert.equal(properties["Events (30d)"], undefined)
-  assert.equal(properties["Users (30d)"], undefined)
-  assert.equal(properties["Lifetime Events"], undefined)
-  assert.equal(properties["Lifetime Users"], undefined)
+  const clearableProperties = [
+    "Status",
+    "Assignee",
+    "Issue Link",
+    "Last Seen",
+    "Priority",
+    "Status Detail",
+    "Level",
+    "Unhandled",
+    "Events (24h)",
+    "Events (30d)",
+    "Users (30d)",
+    "Lifetime Events",
+    "Lifetime Users",
+    "Project",
+    "Category",
+    "Issue Type",
+    "Platform",
+    "Culprit",
+    "First Seen",
+    "Issue Key",
+  ]
+  for (const property of clearableProperties) {
+    assert.notDeepEqual(populated[property], [], `${property} starts populated`)
+    assert.deepEqual(
+      properties[property],
+      [],
+      `${property} is explicitly cleared`
+    )
+  }
   assert.match(change.pageContentMarkdown, /Status:\*\* Not provided/)
 })
 
@@ -548,7 +576,7 @@ test("project aggregation answers service-risk questions without double-counting
   assert.match(change.pageContentMarkdown, /Ownership gaps/)
 })
 
-test("project event buckets use exact seven-day boundaries and omit incomplete totals", () => {
+test("project event buckets use exact boundaries and clear incomplete totals", () => {
   const window = {
     start: "2026-06-02T15:00:00.000Z",
     end: "2026-07-02T15:00:00.000Z",
@@ -574,6 +602,12 @@ test("project event buckets use exact seven-day boundaries and omit incomplete t
   )["99"]
   assert.equal(complete.previous7dEvents, 2)
   assert.equal(complete.events7d, 8)
+  const completeProperties = projectToChange(
+    fullProject,
+    complete,
+    window.end,
+    defaultScope
+  ).properties as Record<string, unknown>
 
   const incomplete = aggregateProjectIssues(
     {},
@@ -587,11 +621,25 @@ test("project event buckets use exact seven-day boundaries and omit incomplete t
     defaultScope
   )
   const properties = change.properties as Record<string, unknown>
-  assert.equal(properties["Events (7d)"], undefined)
-  assert.equal(properties["Previous 7d Events"], undefined)
-  assert.equal(properties["Event Change"], undefined)
-  assert.equal(properties["Events (30d)"], undefined)
-  assert.equal(properties["Most Active Issue (7d)"], undefined)
+  for (const property of [
+    "Events (7d)",
+    "Previous 7d Events",
+    "Event Change vs Prior 7d",
+    "Events (30d)",
+    "Most Active Issue (7d)",
+    "Issue Link",
+  ]) {
+    assert.notDeepEqual(
+      completeProperties[property],
+      [],
+      `${property} starts populated`
+    )
+    assert.deepEqual(
+      properties[property],
+      [],
+      `${property} is explicitly cleared`
+    )
+  }
 })
 
 test("project aggregation fails closed without immutable or consistent identity", () => {
@@ -657,6 +705,11 @@ test("release transform combines metadata and aggregate health with stable ident
 })
 
 test("release rows remain useful when health is absent and preserve explicit zeroes", () => {
+  const populatedProperties = releasesToChanges(
+    [fullRelease],
+    fullReleaseHealth,
+    defaultScope
+  )[0].properties as Record<string, unknown>
   const noHealth = releasesToChanges(
     [
       {
@@ -677,8 +730,23 @@ test("release rows remain useful when health is absent and preserve explicit zer
   const noHealthProperties = noHealth.properties as Record<string, unknown>
   assertPropertyContains(noHealthProperties["Health Data (7d)"], "No")
   assertPropertyContains(noHealthProperties["New Issues"], "0")
-  assert.equal(noHealthProperties["Crash-Free Sessions"], undefined)
-  assert.equal(noHealthProperties["Sessions (7d)"], undefined)
+  for (const property of [
+    "Crash-Free Users",
+    "Crash-Free Sessions",
+    "Sessions (7d)",
+    "Users (7d)",
+  ]) {
+    assert.notDeepEqual(
+      populatedProperties[property],
+      [],
+      `${property} starts populated`
+    )
+    assert.deepEqual(
+      noHealthProperties[property],
+      [],
+      `${property} is explicitly cleared`
+    )
+  }
 
   const zeroHealth = releasesToChanges(
     [fullRelease],
@@ -810,6 +878,21 @@ test("issue window is exactly 30 days and remains pinned between pages", () => {
     seenCursors: ["cursor-a"],
   }
   assert.deepEqual(issueWindow(state, now + 7 * 86_400_000), window)
+})
+
+test("continuation state keeps headroom below the Workers runtime limit", () => {
+  assert.ok(MAX_SAFE_SYNC_STATE_LENGTH < 256 * 1024)
+  assert.deepEqual(boundedSyncState({ cursor: "small" }, "test"), {
+    cursor: "small",
+  })
+  assert.throws(
+    () =>
+      boundedSyncState(
+        { data: "x".repeat(MAX_SAFE_SYNC_STATE_LENGTH) },
+        "test"
+      ),
+    /240 KiB safety budget.*narrow SENTRY_PROJECTS/
+  )
 })
 
 test("release health window is exactly seven days", () => {
@@ -1629,6 +1712,45 @@ test("projects Worker validates a resumed snapshot before making requests", asyn
   assert.equal(fetched, false)
 })
 
+test("projects Worker rejects oversized continuation state before the runtime", async () => {
+  configureEnvironment()
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  Date.now = () => now
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    const issues = Array.from({ length: 100 }, (_, index) =>
+      rawIssue({
+        id: `issue-${index}`,
+        title: `Issue ${index} ${"x".repeat(1_990)}`,
+        permalink: `https://acme.sentry.io/issues/${index}/${"y".repeat(
+          1_850
+        )}`,
+        project: {
+          id: `project-${index}`,
+          name: `Project ${index}`,
+          slug: `project-${index}`,
+          platform: "node",
+        },
+        stats: {
+          "14d": [[Date.parse("2026-07-01T15:00:00.000Z") / 1_000, 1]],
+        },
+      })
+    )
+    return new Response(JSON.stringify(issues), {
+      status: 200,
+      headers: { Link: nextLink(url, "oversized-page-2") },
+    })
+  }) as typeof fetch
+
+  await assert.rejects(
+    worker.run("projectsSync", sentryPacerContext<ProjectSyncState>(), {
+      concreteOutput: true,
+    }),
+    /project aggregation continuation state exceeded.*narrow SENTRY_PROJECTS/
+  )
+})
+
 test("releases Worker uses one bounded list and one aggregate health request", async () => {
   configureEnvironment()
   process.env.SENTRY_PROJECTS = "checkout-api"
@@ -1705,7 +1827,7 @@ test("releases Worker preserves metadata when an older server lacks sessions", a
   assert.equal(result.hasMore, false)
   assert.equal(result.changes.length, 1)
   assert.equal(result.changes[0].targetDatabaseKey, "releases")
-  assert.equal(result.changes[0].properties?.["Health Data (7d)"], undefined)
-  assert.equal(result.changes[0].properties?.["Window Start"], undefined)
-  assert.equal(result.changes[0].properties?.["Window End"], undefined)
+  assert.deepEqual(result.changes[0].properties?.["Health Data (7d)"], [])
+  assert.deepEqual(result.changes[0].properties?.["Window Start"], [])
+  assert.deepEqual(result.changes[0].properties?.["Window End"], [])
 })

--- a/workers/sentry-sync/test.ts
+++ b/workers/sentry-sync/test.ts
@@ -15,8 +15,12 @@ import {
   summedStats,
   titleText,
 } from "./src/helpers.js"
-import worker from "./src/index.js"
-import type { ProjectSyncState } from "./src/index.js"
+import worker, {
+  executeIssuesSync,
+  executeProjectsSync,
+  executeReleasesSync,
+  type ProjectSyncState,
+} from "./src/index.js"
 import { issuePageContent, issueToChange } from "./src/issues.js"
 import {
   aggregateProjectIssues,
@@ -50,11 +54,13 @@ import {
 } from "./src/sentry.js"
 import {
   ISSUE_WINDOW_DAYS,
+  MAX_RECENT_CURSOR_FINGERPRINTS,
   MAX_SAFE_SYNC_STATE_LENGTH,
   boundedSyncState,
   issueWindow,
   nextCursorTraversal,
   nextIssueState,
+  syncStateSize,
   type IssueSyncState,
 } from "./src/sync-state.js"
 
@@ -140,7 +146,6 @@ const defaultScope: SentryScope = {
   organization: "acme",
   projects: [],
   environments: [],
-  credentialFingerprint: "test-only-fingerprint",
 }
 
 const fullProject: SentryProject = {
@@ -153,6 +158,31 @@ const fullProject: SentryProject = {
   dateCreated: "2025-01-01T00:00:00.000Z",
   firstEvent: "2025-01-02T00:00:00.000Z",
   hasSessions: true,
+}
+
+function projectAggregate(projectId: string): ProjectIssueAggregate {
+  return aggregateProjectIssues(
+    {},
+    [
+      {
+        ...fullIssue,
+        id: `issue-${projectId}`,
+        project: {
+          ...fullIssue.project!,
+          id: projectId,
+          name: `Project ${projectId}`,
+          slug: `project-${projectId}`,
+        },
+        stats: {
+          "14d": [[Date.parse("2026-07-01T15:00:00.000Z") / 1_000, 1]],
+        },
+      },
+    ],
+    {
+      start: "2026-06-02T15:00:00.000Z",
+      end: "2026-07-02T15:00:00.000Z",
+    }
+  )[projectId]
 }
 
 const fullRelease: SentryRelease = {
@@ -183,7 +213,6 @@ const fullRelease: SentryRelease = {
 }
 
 const fullReleaseHealth: SentryReleaseHealthSnapshot = {
-  available: true,
   start: "2026-06-25T00:00:00.000Z",
   end: "2026-07-02T00:00:00.000Z",
   groups: [
@@ -641,7 +670,7 @@ test("project event buckets use exact boundaries and clear incomplete totals", (
   }
 })
 
-test("project aggregation fails closed without immutable or consistent identity", () => {
+test("project aggregation requires immutable IDs and tolerates project renames", () => {
   const window = {
     start: "2026-06-02T15:00:00.000Z",
     end: "2026-07-02T15:00:00.000Z",
@@ -655,22 +684,39 @@ test("project aggregation fails closed without immutable or consistent identity"
       ),
     /immutable project ID/
   )
-  assert.throws(
-    () =>
-      aggregateProjectIssues(
-        {},
-        [
-          fullIssue,
-          {
-            ...fullIssue,
-            id: "different-issue",
-            project: { ...fullIssue.project!, slug: "different-slug" },
-          },
-        ],
-        window
-      ),
-    /conflicting slugs/
+  const firstPage = aggregateProjectIssues({}, [fullIssue], window)
+  const renamedProject = {
+    ...fullProject,
+    name: "Checkout Platform",
+    slug: "checkout-platform",
+  }
+  const secondPage = aggregateProjectIssues(
+    firstPage,
+    [
+      {
+        ...fullIssue,
+        id: "different-issue",
+        project: {
+          ...fullIssue.project!,
+          name: renamedProject.name,
+          slug: renamedProject.slug,
+        },
+      },
+    ],
+    window
   )
+  assert.deepEqual(Object.keys(secondPage), ["99"])
+  assert.equal(secondPage["99"].issueGroups, 2)
+
+  const change = projectToChange(
+    renamedProject,
+    secondPage["99"],
+    window.end,
+    defaultScope
+  )
+  assert.equal(change.key, "99")
+  assertPropertyContains(change.properties.Project, "Checkout Platform")
+  assertPropertyContains(change.properties["Project Slug"], "checkout-platform")
 })
 
 test("release transform combines metadata and aggregate health with stable identity", () => {
@@ -695,6 +741,10 @@ test("release transform combines metadata and aggregate health with stable ident
   assertPropertyContains(properties["Crash-Free Users"], "0.995")
   assertPropertyContains(properties["Sessions (7d)"], "12000")
   assertPropertyContains(properties["New Issues"], "3")
+  assert.match(
+    change.pageContentMarkdown,
+    /2026-06-25T00:00:00.000Z to 2026-07-02T00:00:00.000Z/
+  )
   assertPropertyContains(
     properties["Health Project Scope"],
     "All accessible projects"
@@ -920,7 +970,7 @@ test("continuation state keeps headroom below the Workers runtime limit", () => 
         { data: "x".repeat(MAX_SAFE_SYNC_STATE_LENGTH) },
         "test"
       ),
-    /240 KiB safety budget.*narrow SENTRY_PROJECTS/
+    /240 KiB safety budget.*cannot continue safely/
   )
 })
 
@@ -943,7 +993,9 @@ test("cursor state catches immediate and longer pagination loops", () => {
   const second = nextIssueState(first, window, defaultScope, "cursor-b")
 
   assert.equal(first.cursor, "cursor-a")
-  assert.deepEqual(second.seenCursors, ["cursor-a", "cursor-b"])
+  assert.equal(second.seenCursors?.length, 2)
+  assert.ok(second.seenCursors?.every((cursor) => cursor.startsWith("h:")))
+  assert.equal(second.seenCursors?.includes("cursor-a"), false)
   assert.throws(
     () => nextIssueState(first, window, defaultScope, "cursor-a"),
     /repeated/
@@ -966,6 +1018,23 @@ test("cursor state catches immediate and longer pagination loops", () => {
       ),
     /project pagination repeated/
   )
+})
+
+test("cursor history stays compact without imposing a page limit", () => {
+  let cursor: string | undefined
+  let seenCursors: string[] | undefined
+  for (let index = 0; index < 2_000; index += 1) {
+    const traversal = nextCursorTraversal(
+      cursor,
+      seenCursors,
+      `cursor-${index}`,
+      "test"
+    )
+    cursor = traversal.cursor
+    seenCursors = traversal.seenCursors
+  }
+  assert.equal(seenCursors?.length, MAX_RECENT_CURSOR_FINGERPRINTS)
+  assert.ok(syncStateSize({ cursor, seenCursors }) < 2 * 1024)
 })
 
 test("request URL explicitly includes all statuses and repeatable filters", () => {
@@ -1014,8 +1083,7 @@ test("project and release URLs are bounded and carry the configured scope", () =
   const releases = buildReleasesUrl()
   assert.equal(releases.pathname, "/api/0/organizations/acme/releases/")
   assert.equal(releases.searchParams.get("per_page"), "100")
-  assert.equal(releases.searchParams.has("status"), true)
-  assert.equal(releases.searchParams.get("status"), "")
+  assert.equal(releases.searchParams.has("status"), false)
   assert.deepEqual(releases.searchParams.getAll("project"), [
     "checkout-api",
     "99",
@@ -1040,6 +1108,10 @@ test("project and release URLs are bounded and carry the configured scope", () =
   assert.deepEqual(health.searchParams.getAll("groupBy"), ["release"])
   assert.equal(health.searchParams.get("includeSeries"), "0")
   assert.equal(health.searchParams.get("per_page"), "250")
+  assert.deepEqual(health.searchParams.getAll("project"), [
+    "checkout-api",
+    "99",
+  ])
   assert.deepEqual(health.searchParams.getAll("environment"), [
     "production",
     "staging",
@@ -1392,28 +1464,29 @@ test("new clients fail closed on malformed identity, shape, and health truncatio
   )
 })
 
-test("API client fails closed if credentials change between pages", async () => {
+test("API client uses a rotated credential without pinning stale auth state", async () => {
   configureEnvironment()
   const scope = getSentryScope()
   process.env.SENTRY_AUTH_TOKEN = "rotated-token-with-different-access"
-  let fetched = false
-  globalThis.fetch = (async () => {
-    fetched = true
-    throw new Error("fetch should not be called")
+  let authorization: string | null = null
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    authorization = request.headers.get("authorization")
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { Link: terminalLink(new URL(request.url)) },
+    })
   }) as typeof fetch
 
-  await assert.rejects(
-    fetchIssuesPage(
-      async () => undefined,
-      {
-        start: "2026-06-02T15:00:00.000Z",
-        end: "2026-07-02T15:00:00.000Z",
-      },
-      scope
-    ),
-    /changed during Sentry issue pagination/
+  await fetchIssuesPage(
+    async () => undefined,
+    {
+      start: "2026-06-02T15:00:00.000Z",
+      end: "2026-07-02T15:00:00.000Z",
+    },
+    scope
   )
-  assert.equal(fetched, false)
+  assert.equal(authorization, "Bearer rotated-token-with-different-access")
 })
 
 test("API client rejects malformed JSON, shapes, and required issue fields", async () => {
@@ -1518,30 +1591,9 @@ test("429 becomes a platform-aware RateLimitError while ordinary 403 remains gen
   assert.match(permissionError.message, /Sentry API error \(403\)/)
 })
 
-type WorkerRunResult<State = unknown> = {
-  changes: Array<{
-    key: string
-    targetDatabaseKey: string
-    properties?: Record<string, unknown>
-  }>
-  hasMore: boolean
-  nextUserContext?: State
-}
+const noPacing = async () => undefined
 
-function sentryPacerContext<State>(state?: State) {
-  return {
-    state,
-    pacers: {
-      sentry: {
-        lastScheduledAtMs: 0,
-        allowedRequests: 1_000_000,
-        intervalMs: 1,
-      },
-    },
-  }
-}
-
-test("Worker run pins its 30-day window and advances opaque cursor state", async () => {
+test("issues sync pins its 30-day window and advances opaque cursor state", async () => {
   configureEnvironment()
   process.env.SENTRY_PROJECTS = "checkout-api"
   process.env.SENTRY_ENVIRONMENTS = "production"
@@ -1558,22 +1610,17 @@ test("Worker run pins its 30-day window and advances opaque cursor state", async
     })
   }) as typeof fetch
 
-  const first = (await worker.run(
-    "issuesSync",
-    sentryPacerContext<IssueSyncState>(),
-    { concreteOutput: true }
-  )) as WorkerRunResult<IssueSyncState>
+  const first = await executeIssuesSync(undefined, noPacing)
 
   assert.equal(first.hasMore, true)
   assert.equal(first.changes.length, 1)
   assert.equal(first.changes[0].key, fullIssue.id)
-  assert.equal(first.changes[0].targetDatabaseKey, "issues")
-  assert.equal(first.nextUserContext?.cursor, "cursor-page-2")
-  assert.deepEqual(first.nextUserContext?.scope.projects, ["checkout-api"])
-  assert.deepEqual(first.nextUserContext?.scope.environments, ["production"])
+  assert.equal(first.nextState?.cursor, "cursor-page-2")
+  assert.deepEqual(first.nextState?.scope.projects, ["checkout-api"])
+  assert.deepEqual(first.nextState?.scope.environments, ["production"])
   assert.equal(
-    Date.parse(first.nextUserContext?.end ?? "") -
-      Date.parse(first.nextUserContext?.start ?? ""),
+    Date.parse(first.nextState?.end ?? "") -
+      Date.parse(first.nextState?.start ?? ""),
     ISSUE_WINDOW_DAYS * 86_400_000
   )
 
@@ -1590,14 +1637,10 @@ test("Worker run pins its 30-day window and advances opaque cursor state", async
     })
   }) as typeof fetch
 
-  const second = (await worker.run(
-    "issuesSync",
-    sentryPacerContext(first.nextUserContext),
-    { concreteOutput: true }
-  )) as WorkerRunResult<IssueSyncState>
+  const second = await executeIssuesSync(first.nextState, noPacing)
 
   assert.equal(second.hasMore, false)
-  assert.equal(second.nextUserContext, undefined)
+  assert.equal(second.nextState, undefined)
   assert.equal(requestUrls[1].searchParams.get("cursor"), "cursor-page-2")
   assert.deepEqual(requestUrls[1].searchParams.getAll("project"), [
     "checkout-api",
@@ -1668,26 +1711,18 @@ test("projects Worker aggregates all issues before emitting enriched project row
     throw new Error(`unexpected request ${url}`)
   }) as typeof fetch
 
-  const first = (await worker.run(
-    "projectsSync",
-    sentryPacerContext<ProjectSyncState>(),
-    { concreteOutput: true }
-  )) as WorkerRunResult<ProjectSyncState>
+  const first = await executeProjectsSync(undefined, noPacing)
   assert.equal(first.hasMore, true)
   assert.equal(first.changes.length, 0)
-  assert.equal(first.nextUserContext?.phase, "issues")
+  assert.equal(first.nextState?.phase, "issues")
   assert.equal(requestUrls[0].searchParams.get("groupStatsPeriod"), "14d")
 
   process.env.SENTRY_PROJECTS = "another-project"
   process.env.SENTRY_ENVIRONMENTS = "staging"
-  const second = (await worker.run(
-    "projectsSync",
-    sentryPacerContext(first.nextUserContext),
-    { concreteOutput: true }
-  )) as WorkerRunResult<ProjectSyncState>
+  const second = await executeProjectsSync(first.nextState, noPacing)
   assert.equal(second.hasMore, true)
   assert.equal(second.changes.length, 0)
-  assert.equal(second.nextUserContext?.phase, "projects")
+  assert.equal(second.nextState?.phase, "projects")
   assert.deepEqual(requestUrls[1].searchParams.getAll("project"), [
     "checkout-api",
   ])
@@ -1695,15 +1730,10 @@ test("projects Worker aggregates all issues before emitting enriched project row
     "production",
   ])
 
-  const third = (await worker.run(
-    "projectsSync",
-    sentryPacerContext(second.nextUserContext),
-    { concreteOutput: true }
-  )) as WorkerRunResult<ProjectSyncState>
+  const third = await executeProjectsSync(second.nextState, noPacing)
   assert.equal(third.hasMore, false)
   assert.equal(third.changes.length, 1)
   assert.equal(third.changes[0].key, "99")
-  assert.equal(third.changes[0].targetDatabaseKey, "projects")
   assertPropertyContains(third.changes[0].properties?.["Events (7d)"], "15")
   assertPropertyContains(
     third.changes[0].properties?.["Issue Groups (30d)"],
@@ -1729,19 +1759,16 @@ test("projects Worker validates a resumed snapshot before making requests", asyn
     end: "2026-07-02T00:00:00.000Z",
     scope: defaultScope,
     aggregates: {},
-    unmatchedProjectIds: [],
   }
 
   await assert.rejects(
-    worker.run("projectsSync", sentryPacerContext(invalidState), {
-      concreteOutput: true,
-    }),
+    executeProjectsSync(invalidState, noPacing),
     /must start before/
   )
   assert.equal(fetched, false)
 })
 
-test("projects Worker rejects oversized continuation state before the runtime", async () => {
+test("projects Worker checkpoints oversized aggregation for a scope change", async () => {
   configureEnvironment()
   const now = Date.parse("2026-07-02T15:00:00.000Z")
   Date.now = () => now
@@ -1772,12 +1799,175 @@ test("projects Worker rejects oversized continuation state before the runtime", 
     })
   }) as typeof fetch
 
+  const first = await executeProjectsSync(undefined, noPacing)
+  assert.equal(first.hasMore, true)
+  assert.equal(first.changes.length, 0)
+  assert.equal(first.nextState?.phase, "scope-required")
+
+  let fetched = false
+  globalThis.fetch = (async () => {
+    fetched = true
+    throw new Error("fetch should not be called")
+  }) as typeof fetch
   await assert.rejects(
-    worker.run("projectsSync", sentryPacerContext<ProjectSyncState>(), {
-      concreteOutput: true,
-    }),
-    /project aggregation continuation state exceeded.*narrow SENTRY_PROJECTS/
+    executeProjectsSync(first.nextState, noPacing),
+    /paused before writing rows.*Narrow SENTRY_PROJECTS/
   )
+  assert.equal(fetched, false)
+
+  process.env.SENTRY_PROJECTS = "checkout-api"
+  Date.now = () => now + 86_400_000
+  let resumedUrl: URL | undefined
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    resumedUrl = url
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { Link: terminalLink(url) },
+    })
+  }) as typeof fetch
+  const resumed = await executeProjectsSync(first.nextState, noPacing)
+  assert.equal(resumed.nextState?.phase, "projects")
+  assert.equal(resumedUrl?.searchParams.has("cursor"), false)
+  assert.deepEqual(resumedUrl?.searchParams.getAll("project"), ["checkout-api"])
+})
+
+test("projects Worker checkpoints the active-project cap before writing rows", async () => {
+  configureEnvironment()
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  Date.now = () => now
+  const aggregates = Object.fromEntries(
+    Array.from({ length: 500 }, (_, index) => {
+      const projectId = `project-${index}`
+      return [projectId, projectAggregate(projectId)]
+    })
+  )
+  const state: ProjectSyncState = {
+    phase: "issues",
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+    scope: getSentryScope(),
+    aggregates,
+  }
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    return new Response(
+      JSON.stringify([
+        rawIssue({
+          id: "issue-over-cap",
+          project: {
+            id: "project-over-cap",
+            name: "Project over cap",
+            slug: "project-over-cap",
+            platform: "node",
+          },
+          stats: {
+            "14d": [[Date.parse("2026-07-01T15:00:00.000Z") / 1_000, 1]],
+          },
+        }),
+      ]),
+      { status: 200, headers: { Link: terminalLink(url) } }
+    )
+  }) as typeof fetch
+
+  const result = await executeProjectsSync(state, noPacing)
+  assert.equal(result.changes.length, 0)
+  assert.equal(result.nextState?.phase, "scope-required")
+  if (result.nextState?.phase === "scope-required") {
+    assert.equal(result.nextState.reason, "project-count")
+  }
+})
+
+test("projects Worker removes emitted aggregates from inventory state", async () => {
+  configureEnvironment()
+  const scope = getSentryScope()
+  const state: ProjectSyncState = {
+    phase: "projects",
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+    scope,
+    aggregates: {
+      "99": projectAggregate("99"),
+      "100": projectAggregate("100"),
+    },
+  }
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    const hasCursor = url.searchParams.has("cursor")
+    return new Response(
+      JSON.stringify(
+        hasCursor
+          ? [rawProject({ name: "Repeated Checkout", slug: "repeated" })]
+          : [rawProject()]
+      ),
+      {
+        status: 200,
+        headers: {
+          Link: hasCursor ? terminalLink(url) : nextLink(url, "project-page-2"),
+        },
+      }
+    )
+  }) as typeof fetch
+
+  const first = await executeProjectsSync(state, noPacing)
+  assert.deepEqual(
+    first.changes.map((change) => change.key),
+    ["99"]
+  )
+  assertPropertyContains(first.changes[0].properties?.["Events (7d)"], "1")
+  assert.equal(first.nextState?.phase, "projects")
+  if (first.nextState?.phase !== "projects") {
+    throw new Error("expected project inventory continuation")
+  }
+  assert.deepEqual(Object.keys(first.nextState.aggregates), ["100"])
+
+  const second = await executeProjectsSync(first.nextState, noPacing)
+  assert.equal(second.hasMore, false)
+  assert.deepEqual(
+    second.changes.map((change) => change.key),
+    ["100"]
+  )
+  assertPropertyContains(second.changes[0].properties?.Project, "Project 100")
+  assertPropertyContains(second.changes[0].properties?.["Events (7d)"], "1")
+})
+
+test("projects Worker migrates an in-flight legacy inventory state", async () => {
+  configureEnvironment()
+  const legacyState: ProjectSyncState = {
+    phase: "projects",
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+    scope: getSentryScope(),
+    aggregates: {
+      "99": projectAggregate("99"),
+      "100": projectAggregate("100"),
+    },
+    // Project 99 was emitted on page one; legacy state tracked only the IDs
+    // that had not yet matched project inventory.
+    unmatchedProjectIds: ["100"],
+    cursor: "project-page-2",
+  }
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    assert.equal(url.searchParams.get("cursor"), "project-page-2")
+    return new Response(JSON.stringify([rawProject()]), {
+      status: 200,
+      headers: { Link: terminalLink(url) },
+    })
+  }) as typeof fetch
+
+  const result = await executeProjectsSync(legacyState, noPacing)
+  assert.equal(result.hasMore, false)
+  assert.deepEqual(
+    result.changes.map((change) => change.key),
+    ["100"]
+  )
+  assertPropertyContains(result.changes[0].properties?.Project, "Project 100")
+  assertPropertyContains(result.changes[0].properties?.["Events (7d)"], "1")
 })
 
 test("releases Worker uses one bounded list and one aggregate health request", async () => {
@@ -1818,13 +2008,10 @@ test("releases Worker uses one bounded list and one aggregate health request", a
     throw new Error(`unexpected request ${url}`)
   }) as typeof fetch
 
-  const result = (await worker.run("releasesSync", sentryPacerContext(), {
-    concreteOutput: true,
-  })) as WorkerRunResult
+  const result = await executeReleasesSync(noPacing)
   assert.equal(result.hasMore, false)
   assert.equal(result.changes.length, 1)
   assert.equal(result.changes[0].key, "501")
-  assert.equal(result.changes[0].targetDatabaseKey, "releases")
   assertPropertyContains(
     result.changes[0].properties?.["Health Project Scope"],
     "checkout-api"
@@ -1839,7 +2026,7 @@ test("releases Worker uses one bounded list and one aggregate health request", a
   assert.equal(requestUrls[1].searchParams.get("includeSeries"), "0")
 })
 
-test("releases Worker preserves metadata when sessions returns 404", async () => {
+test("releases Worker surfaces sessions 404 instead of guessing its cause", async () => {
   configureEnvironment()
   globalThis.fetch = (async (input, init) => {
     const request = new Request(input, init)
@@ -1850,13 +2037,8 @@ test("releases Worker preserves metadata when sessions returns 404", async () =>
     return new Response("not found", { status: 404 })
   }) as typeof fetch
 
-  const result = (await worker.run("releasesSync", sentryPacerContext(), {
-    concreteOutput: true,
-  })) as WorkerRunResult
-  assert.equal(result.hasMore, false)
-  assert.equal(result.changes.length, 1)
-  assert.equal(result.changes[0].targetDatabaseKey, "releases")
-  assert.deepEqual(result.changes[0].properties?.["Health Data (7d)"], [])
-  assert.deepEqual(result.changes[0].properties?.["Window Start"], [])
-  assert.deepEqual(result.changes[0].properties?.["Window End"], [])
+  await assert.rejects(
+    executeReleasesSync(noPacing),
+    /Sentry API error \(404\)/
+  )
 })

--- a/workers/sentry-sync/test.ts
+++ b/workers/sentry-sync/test.ts
@@ -1,0 +1,823 @@
+// Offline regression tests for the Sentry sync Worker.
+// Run from this directory with `npm test`.
+
+import assert from "node:assert/strict"
+import { afterEach, test } from "node:test"
+
+import { RateLimitError } from "@notionhq/workers"
+
+import {
+  escapeMarkdown,
+  formatSentryLabel,
+  issuePageContent,
+  nonnegativeNumber,
+  safeHttpUrl,
+  selectText,
+  summedStats,
+  titleText,
+} from "./src/helpers.js"
+import worker from "./src/index.js"
+import { issueToChange } from "./src/issues.js"
+import {
+  buildIssuesUrl,
+  fetchIssuesPage,
+  getIssueScope,
+  nextCursorFromLink,
+  parseRetryAfterSeconds,
+  rateLimitRetryAfterSeconds,
+  type SentryIssue,
+  type SentryIssueScope,
+} from "./src/sentry.js"
+import {
+  ISSUE_WINDOW_DAYS,
+  issueWindow,
+  nextIssueState,
+  type IssueSyncState,
+} from "./src/sync-state.js"
+
+const originalFetch = globalThis.fetch
+const originalDateNow = Date.now
+const originalEnv = {
+  SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+  SENTRY_ORG_SLUG: process.env.SENTRY_ORG_SLUG,
+  SENTRY_PROJECTS: process.env.SENTRY_PROJECTS,
+  SENTRY_ENVIRONMENTS: process.env.SENTRY_ENVIRONMENTS,
+  SENTRY_BASE_URL: process.env.SENTRY_BASE_URL,
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  Date.now = originalDateNow
+  for (const [name, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+const fullIssue: SentryIssue = {
+  id: "4500000000000001",
+  shortId: "CHECKOUT-42",
+  title: "TypeError: Cannot read properties of undefined",
+  culprit: "checkout.submitOrder",
+  permalink: "https://acme.sentry.io/issues/4500000000000001/",
+  status: "unresolved",
+  substatus: "regressed",
+  priority: "high",
+  level: "fatal",
+  isUnhandled: true,
+  assignedTo: { name: "Ada Lovelace" },
+  project: {
+    id: "99",
+    name: "Checkout API",
+    slug: "checkout-api",
+    platform: "node",
+  },
+  platform: "node",
+  issueCategory: "error",
+  issueType: "error",
+  count: "1200",
+  userCount: 87,
+  lifetime: { count: "5000", userCount: 250 },
+  firstSeen: "2026-06-20T10:11:12.000Z",
+  lastSeen: "2026-07-02T14:15:16.000Z",
+  stats: {
+    "24h": [
+      [1_751_465_600, 20],
+      [1_751_469_200, 7],
+    ],
+  },
+}
+
+const minimalIssue: SentryIssue = {
+  id: "4500000000000002",
+  shortId: null,
+  title: "Needs triage",
+  culprit: null,
+  permalink: null,
+  status: null,
+  substatus: null,
+  priority: null,
+  level: null,
+  isUnhandled: null,
+  assignedTo: null,
+  project: null,
+  platform: null,
+  issueCategory: null,
+  issueType: null,
+  count: null,
+  userCount: null,
+  lifetime: null,
+  firstSeen: null,
+  lastSeen: null,
+  stats: null,
+}
+
+const defaultScope: SentryIssueScope = {
+  baseUrl: "https://sentry.io/",
+  organization: "acme",
+  projects: [],
+  environments: [],
+  credentialFingerprint: "test-only-fingerprint",
+}
+
+function propertyText(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function assertPropertyContains(value: unknown, expected: string): void {
+  assert.match(
+    propertyText(value),
+    new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  )
+}
+
+function configureEnvironment(): void {
+  process.env.SENTRY_AUTH_TOKEN = "sentry-test-token"
+  process.env.SENTRY_ORG_SLUG = "acme"
+  delete process.env.SENTRY_PROJECTS
+  delete process.env.SENTRY_ENVIRONMENTS
+  delete process.env.SENTRY_BASE_URL
+}
+
+function terminalLink(requestUrl: URL): string {
+  const previous = new URL(requestUrl)
+  previous.searchParams.set("cursor", "previous:0:0")
+  const next = new URL(requestUrl)
+  next.searchParams.set("cursor", "next:0:0")
+  return `<${previous}>; rel="previous"; results="false", <${next}>; rel="next"; results="false"`
+}
+
+function nextLink(requestUrl: URL, cursor = "next:100:0"): string {
+  const previous = new URL(requestUrl)
+  previous.searchParams.set("cursor", "previous:0:0")
+  const next = new URL(requestUrl)
+  next.searchParams.set("cursor", cursor)
+  return `<${previous}>; rel="previous"; results="false", <${next}>; rel="next"; results="true"`
+}
+
+function rawIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: fullIssue.id,
+    shortId: fullIssue.shortId,
+    title: fullIssue.title,
+    culprit: fullIssue.culprit,
+    permalink: fullIssue.permalink,
+    status: fullIssue.status,
+    substatus: fullIssue.substatus,
+    priority: fullIssue.priority,
+    level: fullIssue.level,
+    isUnhandled: fullIssue.isUnhandled,
+    assignedTo: {
+      type: "user",
+      id: "user-1",
+      name: fullIssue.assignedTo?.name,
+      email: "private@example.com",
+    },
+    project: fullIssue.project,
+    platform: fullIssue.platform,
+    issueCategory: fullIssue.issueCategory,
+    issueType: fullIssue.issueType,
+    count: fullIssue.count,
+    userCount: fullIssue.userCount,
+    lifetime: fullIssue.lifetime,
+    firstSeen: fullIssue.firstSeen,
+    lastSeen: fullIssue.lastSeen,
+    stats: fullIssue.stats,
+    metadata: { value: "sensitive metadata" },
+    latestEvent: { stacktrace: "sensitive stack trace" },
+    ...overrides,
+  }
+}
+
+test("manifest exposes one value-first rolling issue database", () => {
+  assert.deepEqual(
+    worker.manifest.databases.map((database) => ({
+      key: database.key,
+      title: database.config.initialTitle,
+      primaryKey: database.config.primaryKeyProperty,
+      icon: database.config.schema.databaseIcon,
+      firstSix: Object.keys(database.config.schema.properties).slice(0, 6),
+    })),
+    [
+      {
+        key: "issues",
+        title: "Sentry Issues — Last 30 Days",
+        primaryKey: "Sentry Issue ID",
+        icon: { type: "notion", icon: "bug", color: "gray" },
+        firstSix: [
+          "Issue",
+          "Status",
+          "Assignee",
+          "Issue Link",
+          "Last Seen",
+          "Priority",
+        ],
+      },
+    ]
+  )
+
+  assert.deepEqual(
+    worker.manifest.capabilities.map((capability) => {
+      assert.equal(capability._tag, "sync")
+      const config = capability.config as {
+        databaseKey: string
+        mode: string
+        schedule: { type: string; intervalMs: number }
+      }
+      return {
+        key: capability.key,
+        databaseKey: config.databaseKey,
+        mode: config.mode,
+        schedule: config.schedule,
+      }
+    }),
+    [
+      {
+        key: "issuesSync",
+        databaseKey: "issues",
+        mode: "replace",
+        schedule: { type: "interval", intervalMs: 15 * 60_000 },
+      },
+    ]
+  )
+
+  assert.deepEqual(worker.manifest.pacers, [
+    {
+      key: "sentry",
+      config: { allowedRequests: 60, intervalMs: 60_000 },
+    },
+  ])
+})
+
+test("issue transform keeps stable identity and actionable impact fields", () => {
+  const change = issueToChange(fullIssue)
+  const properties = change.properties as Record<string, unknown>
+
+  assert.equal(change.key, fullIssue.id)
+  assert.equal("upstreamUpdatedAt" in change, false)
+  assert.deepEqual(Object.keys(properties).slice(0, 6), [
+    "Issue",
+    "Status",
+    "Assignee",
+    "Issue Link",
+    "Last Seen",
+    "Priority",
+  ])
+  assertPropertyContains(properties.Issue, fullIssue.title)
+  assertPropertyContains(properties.Status, "Unresolved")
+  assertPropertyContains(properties["Status Detail"], "Regressed")
+  assertPropertyContains(properties.Assignee, "Ada Lovelace")
+  assertPropertyContains(properties["Events (24h)"], "27")
+  assertPropertyContains(properties["Events (30d)"], "1200")
+  assertPropertyContains(properties["Users (30d)"], "87")
+  assertPropertyContains(properties["Lifetime Events"], "5000")
+  assertPropertyContains(properties["Lifetime Users"], "250")
+  assertPropertyContains(properties.Project, "Checkout API")
+  assertPropertyContains(properties["Sentry Issue ID"], fullIssue.id)
+  assert.match(change.pageContentMarkdown, /Triage signals.*Regressed/)
+  assert.match(change.pageContentMarkdown, /High priority/)
+  assert.match(change.pageContentMarkdown, /Open this issue in Sentry/)
+})
+
+test("issue transform omits absent optional fields without inventing false values", () => {
+  const change = issueToChange(minimalIssue)
+  const properties = change.properties as Record<string, unknown>
+
+  assert.deepEqual(Object.keys(properties), ["Issue", "Sentry Issue ID"])
+  assert.equal(properties.Unhandled, undefined)
+  assert.equal(properties["Events (24h)"], undefined)
+  assert.equal(properties["Events (30d)"], undefined)
+  assert.equal(properties["Users (30d)"], undefined)
+  assert.equal(properties["Lifetime Events"], undefined)
+  assert.equal(properties["Lifetime Users"], undefined)
+  assert.match(change.pageContentMarkdown, /Status:\*\* Not provided/)
+})
+
+test("zero counts and false unhandled values remain meaningful", () => {
+  const change = issueToChange({
+    ...minimalIssue,
+    count: "0",
+    userCount: 0,
+    lifetime: { count: "0", userCount: 0 },
+    isUnhandled: false,
+    stats: { "24h": [] },
+  })
+  const properties = change.properties as Record<string, unknown>
+
+  assertPropertyContains(properties["Events (24h)"], "0")
+  assertPropertyContains(properties["Events (30d)"], "0")
+  assertPropertyContains(properties["Users (30d)"], "0")
+  assertPropertyContains(properties["Lifetime Events"], "0")
+  assertPropertyContains(properties["Lifetime Users"], "0")
+  assertPropertyContains(properties.Unhandled, "No")
+})
+
+test("display helpers preserve unknown values and bound provider text", () => {
+  assert.equal(
+    formatSentryLabel("archived_until_escalating"),
+    "Archived Until Escalating"
+  )
+  assert.equal(selectText("custom_future-state"), "Custom Future State")
+  assert.equal(nonnegativeNumber("12"), 12)
+  assert.equal(nonnegativeNumber("not-a-number"), null)
+  assert.equal(nonnegativeNumber(-1), null)
+  assert.equal(
+    summedStats(
+      {
+        "24h": [
+          [1, 0],
+          [2, 4],
+        ],
+      },
+      "24h"
+    ),
+    4
+  )
+  assert.equal(summedStats({ "24h": [[1, -1]] }, "24h"), null)
+  assert.equal(safeHttpUrl("javascript:alert(1)"), null)
+  assert.equal(escapeMarkdown("[prod] *fatal*"), "\\[prod\\] \\*fatal\\*")
+  assert.equal(Array.from(titleText("x".repeat(3_000))).length, 2_000)
+})
+
+test("triage page content is bounded and excludes data that was never selected", () => {
+  const content = issuePageContent({
+    ...fullIssue,
+    culprit: `danger [link] ${"x".repeat(2_000)}`,
+  })
+
+  assert.ok(content.length < 3_000)
+  assert.ok(content.includes("danger \\[link\\]"))
+  assert.doesNotMatch(content, /private@example\.com/)
+  assert.doesNotMatch(content, /stack trace|breadcrumbs|request body/i)
+})
+
+test("issue window is exactly 30 days and remains pinned between pages", () => {
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  const window = issueWindow(undefined, now)
+  assert.equal(
+    Date.parse(window.end) - Date.parse(window.start),
+    ISSUE_WINDOW_DAYS * 86_400_000
+  )
+
+  const state: IssueSyncState = {
+    ...window,
+    scope: defaultScope,
+    cursor: "cursor-a",
+    seenCursors: ["cursor-a"],
+  }
+  assert.deepEqual(issueWindow(state, now + 7 * 86_400_000), window)
+})
+
+test("cursor state catches immediate and longer pagination loops", () => {
+  const window = {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  }
+  const first = nextIssueState(undefined, window, defaultScope, "cursor-a")
+  const second = nextIssueState(first, window, defaultScope, "cursor-b")
+
+  assert.equal(first.cursor, "cursor-a")
+  assert.deepEqual(second.seenCursors, ["cursor-a", "cursor-b"])
+  assert.throws(
+    () => nextIssueState(first, window, defaultScope, "cursor-a"),
+    /repeated/
+  )
+  assert.throws(
+    () => nextIssueState(second, window, defaultScope, "cursor-a"),
+    /repeated/
+  )
+  assert.throws(
+    () => nextIssueState(second, window, defaultScope, undefined),
+    /missing/
+  )
+})
+
+test("request URL explicitly includes all statuses and repeatable filters", () => {
+  configureEnvironment()
+  process.env.SENTRY_BASE_URL = "https://errors.example.com/sentry/"
+  process.env.SENTRY_PROJECTS = "checkout, 42, checkout"
+  process.env.SENTRY_ENVIRONMENTS = "production, staging"
+
+  const url = buildIssuesUrl({
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+    cursor: "opaque:100:0",
+  })
+
+  assert.equal(url.pathname, "/sentry/api/0/organizations/acme/issues/")
+  assert.equal(url.searchParams.has("query"), true)
+  assert.equal(url.searchParams.get("query"), "")
+  assert.equal(url.searchParams.get("sort"), "new")
+  assert.equal(url.searchParams.get("groupStatsPeriod"), "24h")
+  assert.equal(url.searchParams.get("limit"), "100")
+  assert.deepEqual(url.searchParams.getAll("project"), ["checkout", "42"])
+  assert.deepEqual(url.searchParams.getAll("environment"), [
+    "production",
+    "staging",
+  ])
+  assert.equal(url.searchParams.get("cursor"), "opaque:100:0")
+})
+
+test("base URL validation rejects unsafe or ambiguous configuration", () => {
+  configureEnvironment()
+  process.env.SENTRY_BASE_URL = "file:///tmp/sentry"
+  assert.throws(
+    () =>
+      buildIssuesUrl({
+        start: "2026-06-02T15:00:00.000Z",
+        end: "2026-07-02T15:00:00.000Z",
+      }),
+    /must use HTTPS/
+  )
+
+  process.env.SENTRY_BASE_URL = "http://sentry.internal"
+  assert.throws(
+    () =>
+      buildIssuesUrl({
+        start: "2026-06-02T15:00:00.000Z",
+        end: "2026-07-02T15:00:00.000Z",
+      }),
+    /must use HTTPS/
+  )
+
+  process.env.SENTRY_BASE_URL = "http://127.0.0.1:8000"
+  assert.equal(
+    buildIssuesUrl({
+      start: "2026-06-02T15:00:00.000Z",
+      end: "2026-07-02T15:00:00.000Z",
+    }).origin,
+    "http://127.0.0.1:8000"
+  )
+
+  process.env.SENTRY_BASE_URL = "https://user:password@example.com"
+  assert.throws(
+    () =>
+      buildIssuesUrl({
+        start: "2026-06-02T15:00:00.000Z",
+        end: "2026-07-02T15:00:00.000Z",
+      }),
+    /cannot contain credentials/
+  )
+
+  process.env.SENTRY_BASE_URL = "https://example.com/api/0"
+  assert.throws(
+    () =>
+      buildIssuesUrl({
+        start: "2026-06-02T15:00:00.000Z",
+        end: "2026-07-02T15:00:00.000Z",
+      }),
+    /server root/
+  )
+
+  process.env.SENTRY_BASE_URL = "https://example.com"
+  process.env.SENTRY_ORG_SLUG = "../another-path"
+  assert.throws(
+    () =>
+      buildIssuesUrl({
+        start: "2026-06-02T15:00:00.000Z",
+        end: "2026-07-02T15:00:00.000Z",
+      }),
+    /SENTRY_ORG_SLUG/
+  )
+})
+
+test("Link parser follows next only when Sentry says results=true", () => {
+  configureEnvironment()
+  const requestUrl = buildIssuesUrl({
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  })
+
+  assert.equal(
+    nextCursorFromLink(nextLink(requestUrl), requestUrl),
+    "next:100:0"
+  )
+  assert.equal(
+    nextCursorFromLink(terminalLink(requestUrl), requestUrl),
+    undefined
+  )
+
+  const next = new URL(requestUrl)
+  next.searchParams.set("cursor", "cursor-with-comma")
+  const previous = new URL(requestUrl)
+  const quotedComma = `<${next}>; title="next, page"; results="true"; rel="next", <${previous}>; results="false"; rel="previous"`
+  assert.equal(nextCursorFromLink(quotedComma, requestUrl), "cursor-with-comma")
+})
+
+test("Link parser fails closed on missing, duplicate, malformed, or untrusted next links", () => {
+  configureEnvironment()
+  const requestUrl = buildIssuesUrl({
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  })
+  const valid = nextLink(requestUrl)
+
+  assert.throws(() => nextCursorFromLink(null, requestUrl), /missing its Link/)
+  assert.throws(
+    () => nextCursorFromLink(`${valid}, ${valid}`, requestUrl),
+    /one next Link/
+  )
+  assert.throws(
+    () =>
+      nextCursorFromLink(
+        `<${requestUrl}>; rel="next"; results="maybe"`,
+        requestUrl
+      ),
+    /invalid results/
+  )
+  assert.throws(
+    () =>
+      nextCursorFromLink(
+        `<https://attacker.example/api/0/issues/?cursor=stolen>; rel="next"; results="true"`,
+        requestUrl
+      ),
+    /untrusted/
+  )
+  assert.throws(
+    () =>
+      nextCursorFromLink(
+        `<${requestUrl}>; rel="next"; results="true"`,
+        requestUrl
+      ),
+    /missing its next cursor/
+  )
+})
+
+test("API client authenticates, paces once, and retains only selected group fields", async () => {
+  configureEnvironment()
+  let waits = 0
+  const requests: Request[] = []
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    requests.push(request)
+    return new Response(JSON.stringify([rawIssue()]), {
+      status: 200,
+      headers: { Link: terminalLink(new URL(request.url)) },
+    })
+  }) as typeof fetch
+
+  const page = await fetchIssuesPage(
+    async () => {
+      waits += 1
+    },
+    {
+      start: "2026-06-02T15:00:00.000Z",
+      end: "2026-07-02T15:00:00.000Z",
+    }
+  )
+
+  assert.equal(waits, 1)
+  assert.equal(requests.length, 1)
+  assert.equal(
+    requests[0].headers.get("Authorization"),
+    "Bearer sentry-test-token"
+  )
+  assert.equal(
+    requests[0].headers.get("User-Agent"),
+    "notion-cookbook-sentry-sync"
+  )
+  assert.equal(page.hasMore, false)
+  assert.equal(page.resources[0].id, fullIssue.id)
+  assert.equal(page.resources[0].assignedTo?.name, "Ada Lovelace")
+  assert.equal(page.resources[0].lifetime?.count, "5000")
+  assert.equal("email" in (page.resources[0].assignedTo ?? {}), false)
+  assert.equal("metadata" in page.resources[0], false)
+  assert.equal("latestEvent" in page.resources[0], false)
+})
+
+test("API client trusts Link results rather than page length", async () => {
+  configureEnvironment()
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    return new Response(JSON.stringify([rawIssue()]), {
+      status: 200,
+      headers: { Link: nextLink(new URL(request.url), "cursor-b") },
+    })
+  }) as typeof fetch
+
+  const page = await fetchIssuesPage(async () => undefined, {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  })
+  assert.equal(page.resources.length, 1)
+  assert.equal(page.hasMore, true)
+  assert.equal(page.nextCursor, "cursor-b")
+})
+
+test("API client fails closed if credentials change between pages", async () => {
+  configureEnvironment()
+  const scope = getIssueScope()
+  process.env.SENTRY_AUTH_TOKEN = "rotated-token-with-different-access"
+  let fetched = false
+  globalThis.fetch = (async () => {
+    fetched = true
+    throw new Error("fetch should not be called")
+  }) as typeof fetch
+
+  await assert.rejects(
+    fetchIssuesPage(
+      async () => undefined,
+      {
+        start: "2026-06-02T15:00:00.000Z",
+        end: "2026-07-02T15:00:00.000Z",
+      },
+      scope
+    ),
+    /changed during Sentry issue pagination/
+  )
+  assert.equal(fetched, false)
+})
+
+test("API client rejects malformed JSON, shapes, and required issue fields", async () => {
+  configureEnvironment()
+  const options = {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  }
+
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    return new Response("not json", {
+      status: 200,
+      headers: { Link: terminalLink(new URL(request.url)) },
+    })
+  }) as typeof fetch
+  await assert.rejects(
+    fetchIssuesPage(async () => undefined, options),
+    /invalid JSON/
+  )
+
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    return new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { Link: terminalLink(new URL(request.url)) },
+    })
+  }) as typeof fetch
+  await assert.rejects(
+    fetchIssuesPage(async () => undefined, options),
+    /must be a JSON array/
+  )
+
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    return new Response(JSON.stringify([rawIssue({ id: null })]), {
+      status: 200,
+      headers: { Link: terminalLink(new URL(request.url)) },
+    })
+  }) as typeof fetch
+  await assert.rejects(
+    fetchIssuesPage(async () => undefined, options),
+    /missing its immutable id/
+  )
+})
+
+test("rate-limit helpers accept delta/date headers and Sentry reset epochs", () => {
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  assert.equal(parseRetryAfterSeconds("7", now), 7)
+  assert.equal(parseRetryAfterSeconds("Thu, 02 Jul 2026 15:00:09 GMT", now), 9)
+  assert.equal(parseRetryAfterSeconds("invalid", now), undefined)
+  assert.equal(rateLimitRetryAfterSeconds(new Headers(), now), undefined)
+
+  assert.equal(
+    rateLimitRetryAfterSeconds(
+      new Headers({
+        "X-Sentry-Rate-Limit-Remaining": "0",
+        "X-Sentry-Rate-Limit-Reset": String(now / 1_000 + 12),
+        "Retry-After": "5",
+      }),
+      now
+    ),
+    12
+  )
+})
+
+test("429 becomes a platform-aware RateLimitError while ordinary 403 remains generic", async () => {
+  configureEnvironment()
+  const options = {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  }
+
+  globalThis.fetch = (async () =>
+    new Response("slow down", {
+      status: 429,
+      headers: { "Retry-After": "11" },
+    })) as typeof fetch
+  const rateError = await fetchIssuesPage(async () => undefined, options).catch(
+    (error: unknown) => error
+  )
+  assert.ok(rateError instanceof RateLimitError)
+  assert.equal(rateError.retryAfter, 11)
+
+  globalThis.fetch = (async () =>
+    new Response("slow down", { status: 429 })) as typeof fetch
+  const headerlessRateError = await fetchIssuesPage(
+    async () => undefined,
+    options
+  ).catch((error: unknown) => error)
+  assert.ok(headerlessRateError instanceof RateLimitError)
+  assert.equal(headerlessRateError.retryAfter, undefined)
+
+  globalThis.fetch = (async () =>
+    new Response("forbidden", { status: 403 })) as typeof fetch
+  const permissionError = await fetchIssuesPage(
+    async () => undefined,
+    options
+  ).catch((error: unknown) => error)
+  assert.ok(permissionError instanceof Error)
+  assert.equal(permissionError instanceof RateLimitError, false)
+  assert.match(permissionError.message, /Sentry API error \(403\)/)
+})
+
+type WorkerRunResult = {
+  changes: Array<{ key: string; targetDatabaseKey: string }>
+  hasMore: boolean
+  nextUserContext?: IssueSyncState
+}
+
+function sentryPacerContext(state?: IssueSyncState) {
+  return {
+    state,
+    pacers: {
+      sentry: {
+        lastScheduledAtMs: 0,
+        allowedRequests: 1_000_000,
+        intervalMs: 1,
+      },
+    },
+  }
+}
+
+test("Worker run pins its 30-day window and advances opaque cursor state", async () => {
+  configureEnvironment()
+  process.env.SENTRY_PROJECTS = "checkout-api"
+  process.env.SENTRY_ENVIRONMENTS = "production"
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  Date.now = () => now
+  const requestUrls: URL[] = []
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const requestUrl = new URL(request.url)
+    requestUrls.push(requestUrl)
+    return new Response(JSON.stringify([rawIssue()]), {
+      status: 200,
+      headers: { Link: nextLink(requestUrl, "cursor-page-2") },
+    })
+  }) as typeof fetch
+
+  const first = (await worker.run("issuesSync", sentryPacerContext(), {
+    concreteOutput: true,
+  })) as WorkerRunResult
+
+  assert.equal(first.hasMore, true)
+  assert.equal(first.changes.length, 1)
+  assert.equal(first.changes[0].key, fullIssue.id)
+  assert.equal(first.changes[0].targetDatabaseKey, "issues")
+  assert.equal(first.nextUserContext?.cursor, "cursor-page-2")
+  assert.deepEqual(first.nextUserContext?.scope.projects, ["checkout-api"])
+  assert.deepEqual(first.nextUserContext?.scope.environments, ["production"])
+  assert.equal(
+    Date.parse(first.nextUserContext?.end ?? "") -
+      Date.parse(first.nextUserContext?.start ?? ""),
+    ISSUE_WINDOW_DAYS * 86_400_000
+  )
+
+  Date.now = () => now + 7 * 86_400_000
+  process.env.SENTRY_PROJECTS = "billing-api"
+  process.env.SENTRY_ENVIRONMENTS = "staging"
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const requestUrl = new URL(request.url)
+    requestUrls.push(requestUrl)
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { Link: terminalLink(requestUrl) },
+    })
+  }) as typeof fetch
+
+  const second = (await worker.run(
+    "issuesSync",
+    sentryPacerContext(first.nextUserContext),
+    { concreteOutput: true }
+  )) as WorkerRunResult
+
+  assert.equal(second.hasMore, false)
+  assert.equal(second.nextUserContext, undefined)
+  assert.equal(requestUrls[1].searchParams.get("cursor"), "cursor-page-2")
+  assert.deepEqual(requestUrls[1].searchParams.getAll("project"), [
+    "checkout-api",
+  ])
+  assert.deepEqual(requestUrls[1].searchParams.getAll("environment"), [
+    "production",
+  ])
+  assert.equal(
+    requestUrls[1].searchParams.get("start"),
+    requestUrls[0].searchParams.get("start")
+  )
+  assert.equal(
+    requestUrls[1].searchParams.get("end"),
+    requestUrls[0].searchParams.get("end")
+  )
+  assert.equal(requestUrls.length, 2, "one request is made for each API page")
+})

--- a/workers/sentry-sync/test.ts
+++ b/workers/sentry-sync/test.ts
@@ -17,20 +17,42 @@ import {
   titleText,
 } from "./src/helpers.js"
 import worker from "./src/index.js"
+import type { ProjectSyncState } from "./src/index.js"
 import { issueToChange } from "./src/issues.js"
 import {
+  aggregateProjectIssues,
+  projectToChange,
+  type ProjectIssueAggregate,
+} from "./src/projects.js"
+import {
+  RELEASE_HEALTH_DAYS,
+  releaseHealthWindow,
+  releasesToChanges,
+  sentryReleaseUrl,
+} from "./src/releases.js"
+import {
   buildIssuesUrl,
+  buildProjectsUrl,
+  buildReleaseHealthUrl,
+  buildReleasesUrl,
   fetchIssuesPage,
+  fetchProjectsPage,
+  fetchRecentReleases,
+  fetchReleaseHealth,
   getIssueScope,
   nextCursorFromLink,
   parseRetryAfterSeconds,
   rateLimitRetryAfterSeconds,
   type SentryIssue,
   type SentryIssueScope,
+  type SentryProject,
+  type SentryRelease,
+  type SentryReleaseHealthSnapshot,
 } from "./src/sentry.js"
 import {
   ISSUE_WINDOW_DAYS,
   issueWindow,
+  nextCursorTraversal,
   nextIssueState,
   type IssueSyncState,
 } from "./src/sync-state.js"
@@ -120,6 +142,60 @@ const defaultScope: SentryIssueScope = {
   credentialFingerprint: "test-only-fingerprint",
 }
 
+const fullProject: SentryProject = {
+  id: "99",
+  name: "Checkout API",
+  slug: "checkout-api",
+  platform: "node",
+  platforms: ["node"],
+  teams: [{ id: "7", name: "Checkout", slug: "checkout" }],
+  dateCreated: "2025-01-01T00:00:00.000Z",
+  firstEvent: "2025-01-02T00:00:00.000Z",
+  hasSessions: true,
+}
+
+const fullRelease: SentryRelease = {
+  id: "501",
+  version: "checkout@2.4.0",
+  shortVersion: "2.4.0",
+  status: "open",
+  ref: "abcdef123",
+  url: "https://github.com/acme/checkout/releases/tag/2.4.0",
+  dateReleased: "2026-07-01T12:00:00.000Z",
+  dateCreated: "2026-07-01T11:00:00.000Z",
+  newGroups: 3,
+  commitCount: 12,
+  deployCount: 2,
+  firstEvent: "2026-07-01T12:01:00.000Z",
+  lastEvent: "2026-07-02T14:00:00.000Z",
+  projects: [
+    {
+      id: "99",
+      name: "Checkout API",
+      slug: "checkout-api",
+      newGroups: 3,
+      platform: "node",
+      platforms: ["node"],
+      hasHealthData: true,
+    },
+  ],
+}
+
+const fullReleaseHealth: SentryReleaseHealthSnapshot = {
+  available: true,
+  start: "2026-06-25T00:00:00.000Z",
+  end: "2026-07-02T00:00:00.000Z",
+  groups: [
+    {
+      release: "checkout@2.4.0",
+      sessions: 12_000,
+      users: 4_000,
+      crashFreeSessions: 99.95,
+      crashFreeUsers: 99.5,
+    },
+  ],
+}
+
 function propertyText(value: unknown): string {
   return JSON.stringify(value)
 }
@@ -189,7 +265,49 @@ function rawIssue(overrides: Record<string, unknown> = {}) {
   }
 }
 
-test("manifest exposes one value-first rolling issue database", () => {
+function rawProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: fullProject.id,
+    name: fullProject.name,
+    slug: fullProject.slug,
+    platform: fullProject.platform,
+    platforms: fullProject.platforms,
+    teams: fullProject.teams,
+    dateCreated: fullProject.dateCreated,
+    firstEvent: fullProject.firstEvent,
+    hasSessions: fullProject.hasSessions,
+    access: ["project:read"],
+    features: ["releases"],
+    ...overrides,
+  }
+}
+
+function rawRelease(overrides: Record<string, unknown> = {}) {
+  return {
+    id: Number(fullRelease.id),
+    version: fullRelease.version,
+    shortVersion: fullRelease.shortVersion,
+    status: fullRelease.status,
+    ref: fullRelease.ref,
+    url: fullRelease.url,
+    dateReleased: fullRelease.dateReleased,
+    dateCreated: fullRelease.dateCreated,
+    newGroups: fullRelease.newGroups,
+    commitCount: fullRelease.commitCount,
+    deployCount: fullRelease.deployCount,
+    firstEvent: fullRelease.firstEvent,
+    lastEvent: fullRelease.lastEvent,
+    projects: fullRelease.projects.map((project) => ({
+      ...project,
+      id: Number(project.id),
+    })),
+    authors: [{ id: "person", email: "private@example.com" }],
+    data: { sensitive: true },
+    ...overrides,
+  }
+}
+
+test("manifest enables all three value-first databases by default", () => {
   assert.deepEqual(
     worker.manifest.databases.map((database) => ({
       key: database.key,
@@ -201,7 +319,7 @@ test("manifest exposes one value-first rolling issue database", () => {
     [
       {
         key: "issues",
-        title: "Sentry Issues — Last 30 Days",
+        title: "Sentry Issues",
         primaryKey: "Sentry Issue ID",
         icon: { type: "notion", icon: "bug", color: "gray" },
         firstSix: [
@@ -211,6 +329,34 @@ test("manifest exposes one value-first rolling issue database", () => {
           "Issue Link",
           "Last Seen",
           "Priority",
+        ],
+      },
+      {
+        key: "projects",
+        title: "Sentry Projects",
+        primaryKey: "Sentry Project ID",
+        icon: { type: "notion", icon: "chart-line", color: "gray" },
+        firstSix: [
+          "Project",
+          "Unresolved Issues (30d)",
+          "Events (7d)",
+          "Most Active Issue (7d)",
+          "Issue Link",
+          "Last Seen",
+        ],
+      },
+      {
+        key: "releases",
+        title: "Sentry Releases",
+        primaryKey: "Sentry Release ID",
+        icon: { type: "notion", icon: "shield", color: "gray" },
+        firstSix: [
+          "Release",
+          "Projects",
+          "Crash-Free Users",
+          "Crash-Free Sessions",
+          "New Issues",
+          "Status",
         ],
       },
     ]
@@ -235,6 +381,18 @@ test("manifest exposes one value-first rolling issue database", () => {
       {
         key: "issuesSync",
         databaseKey: "issues",
+        mode: "replace",
+        schedule: { type: "interval", intervalMs: 15 * 60_000 },
+      },
+      {
+        key: "projectsSync",
+        databaseKey: "projects",
+        mode: "replace",
+        schedule: { type: "interval", intervalMs: 24 * 60 * 60_000 },
+      },
+      {
+        key: "releasesSync",
+        databaseKey: "releases",
         mode: "replace",
         schedule: { type: "interval", intervalMs: 15 * 60_000 },
       },
@@ -312,6 +470,292 @@ test("zero counts and false unhandled values remain meaningful", () => {
   assertPropertyContains(properties.Unhandled, "No")
 })
 
+test("project aggregation answers service-risk questions without double-counting users", () => {
+  const window = {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  }
+  const previous = Date.parse("2026-06-24T15:00:00.000Z") / 1_000
+  const current = Date.parse("2026-07-01T15:00:00.000Z") / 1_000
+  const aggregates = aggregateProjectIssues(
+    {},
+    [
+      {
+        ...fullIssue,
+        count: 100,
+        userCount: 80,
+        stats: {
+          "14d": [
+            [previous, 4],
+            [current, 10],
+          ],
+        },
+      },
+      {
+        ...fullIssue,
+        id: "4500000000000003",
+        title: "Resolved checkout warning",
+        status: "resolved",
+        substatus: null,
+        priority: "low",
+        isUnhandled: false,
+        assignedTo: null,
+        count: 50,
+        userCount: 80,
+        stats: {
+          "14d": [
+            [previous, 6],
+            [current, 5],
+          ],
+        },
+      },
+    ],
+    window
+  )
+
+  const aggregate = aggregates["99"]
+  assert.equal(aggregate.issueGroups, 2)
+  assert.equal(aggregate.unresolvedIssues, 1)
+  assert.equal(aggregate.highPriorityUnresolved, 1)
+  assert.equal(aggregate.regressedUnresolved, 1)
+  assert.equal(aggregate.unassignedUnresolved, 0)
+  assert.equal(aggregate.previous7dEvents, 10)
+  assert.equal(aggregate.events7d, 15)
+  assert.equal(aggregate.events30d, 150)
+  assert.equal(aggregate.mostActiveIssue?.id, fullIssue.id)
+  assert.equal("users" in aggregate, false)
+
+  const change = projectToChange(
+    fullProject,
+    aggregate,
+    window.end,
+    defaultScope
+  )
+  const properties = change.properties as Record<string, unknown>
+  assert.deepEqual(Object.keys(properties).slice(0, 6), [
+    "Project",
+    "Unresolved Issues (30d)",
+    "Events (7d)",
+    "Most Active Issue (7d)",
+    "Issue Link",
+    "Last Seen",
+  ])
+  assertPropertyContains(properties["Events (7d)"], "15")
+  assertPropertyContains(properties["Previous 7d Events"], "10")
+  assertPropertyContains(properties["Event Change vs Prior 7d"], "5")
+  assertPropertyContains(properties["Environment Scope"], "All environments")
+  assert.equal(properties["Users (30d)"], undefined)
+  assert.match(change.pageContentMarkdown, /Ownership gaps/)
+})
+
+test("project event buckets use exact seven-day boundaries and omit incomplete totals", () => {
+  const window = {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  }
+  const start14d = Date.parse("2026-06-18T15:00:00.000Z") / 1_000
+  const split7d = Date.parse("2026-06-25T15:00:00.000Z") / 1_000
+  const end = Date.parse(window.end) / 1_000
+  const complete = aggregateProjectIssues(
+    {},
+    [
+      {
+        ...fullIssue,
+        stats: {
+          "14d": [
+            [start14d, 2],
+            [split7d, 3],
+            [end, 5],
+          ],
+        },
+      },
+    ],
+    window
+  )["99"]
+  assert.equal(complete.previous7dEvents, 2)
+  assert.equal(complete.events7d, 8)
+
+  const incomplete = aggregateProjectIssues(
+    {},
+    [{ ...fullIssue, stats: null, count: null }],
+    window
+  )["99"]
+  const change = projectToChange(
+    fullProject,
+    incomplete,
+    window.end,
+    defaultScope
+  )
+  const properties = change.properties as Record<string, unknown>
+  assert.equal(properties["Events (7d)"], undefined)
+  assert.equal(properties["Previous 7d Events"], undefined)
+  assert.equal(properties["Event Change"], undefined)
+  assert.equal(properties["Events (30d)"], undefined)
+  assert.equal(properties["Most Active Issue (7d)"], undefined)
+})
+
+test("project aggregation fails closed without immutable or consistent identity", () => {
+  const window = {
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+  }
+  assert.throws(
+    () =>
+      aggregateProjectIssues(
+        {},
+        [{ ...fullIssue, project: { ...fullIssue.project!, id: null } }],
+        window
+      ),
+    /immutable project ID/
+  )
+  assert.throws(
+    () =>
+      aggregateProjectIssues(
+        {},
+        [
+          fullIssue,
+          {
+            ...fullIssue,
+            id: "different-issue",
+            project: { ...fullIssue.project!, slug: "different-slug" },
+          },
+        ],
+        window
+      ),
+    /conflicting slugs/
+  )
+})
+
+test("release transform combines metadata and aggregate health with stable identity", () => {
+  const changes = releasesToChanges(
+    [fullRelease],
+    fullReleaseHealth,
+    defaultScope
+  )
+  assert.equal(changes.length, 1)
+  const change = changes[0]
+  const properties = change.properties as Record<string, unknown>
+  assert.equal(change.key, "501")
+  assert.deepEqual(Object.keys(properties).slice(0, 6), [
+    "Release",
+    "Projects",
+    "Crash-Free Users",
+    "Crash-Free Sessions",
+    "New Issues",
+    "Status",
+  ])
+  assertPropertyContains(properties["Crash-Free Sessions"], "0.9995")
+  assertPropertyContains(properties["Crash-Free Users"], "0.995")
+  assertPropertyContains(properties["Sessions (7d)"], "12000")
+  assertPropertyContains(properties["New Issues"], "3")
+  assertPropertyContains(
+    properties["Health Project Scope"],
+    "All accessible projects"
+  )
+  assertPropertyContains(properties["Environment Scope"], "All environments")
+  assert.doesNotMatch(change.pageContentMarkdown, /private@example\.com/)
+})
+
+test("release rows remain useful when health is absent and preserve explicit zeroes", () => {
+  const noHealth = releasesToChanges(
+    [
+      {
+        ...fullRelease,
+        newGroups: 0,
+        projects: [
+          {
+            ...fullRelease.projects[0],
+            hasHealthData: false,
+            newGroups: 0,
+          },
+        ],
+      },
+    ],
+    { ...fullReleaseHealth, groups: [] },
+    defaultScope
+  )[0]
+  const noHealthProperties = noHealth.properties as Record<string, unknown>
+  assertPropertyContains(noHealthProperties["Health Data (7d)"], "No")
+  assertPropertyContains(noHealthProperties["New Issues"], "0")
+  assert.equal(noHealthProperties["Crash-Free Sessions"], undefined)
+  assert.equal(noHealthProperties["Sessions (7d)"], undefined)
+
+  const zeroHealth = releasesToChanges(
+    [fullRelease],
+    {
+      ...fullReleaseHealth,
+      groups: [
+        {
+          ...fullReleaseHealth.groups[0],
+          sessions: 0,
+          users: 0,
+          crashFreeSessions: 0,
+          crashFreeUsers: 0,
+        },
+      ],
+    },
+    defaultScope
+  )[0].properties as Record<string, unknown>
+  assertPropertyContains(zeroHealth["Sessions (7d)"], "0")
+  assertPropertyContains(zeroHealth["Crash-Free Sessions"], "0")
+})
+
+test("release links encode opaque versions and crash-free percentages are bounded", () => {
+  const link = sentryReleaseUrl(defaultScope, "mobile/1.0 @ 日本?")
+  assert.match(link, /mobile%2F1\.0%20%40%20%E6%97%A5%E6%9C%AC%3F/)
+  const parenthesized = releasesToChanges(
+    [{ ...fullRelease, version: "mobile)1.0" }],
+    { ...fullReleaseHealth, groups: [] },
+    defaultScope
+  )[0]
+  assert.match(parenthesized.pageContentMarkdown, /mobile%291\.0/)
+  assert.throws(
+    () =>
+      releasesToChanges(
+        [fullRelease],
+        {
+          ...fullReleaseHealth,
+          groups: [{ ...fullReleaseHealth.groups[0], crashFreeSessions: 101 }],
+        },
+        defaultScope
+      ),
+    /invalid crash-free percentage/
+  )
+  assert.throws(
+    () =>
+      releasesToChanges(
+        [
+          {
+            ...fullRelease,
+            projects: Array.from({ length: 101 }, (_, index) => ({
+              ...fullRelease.projects[0],
+              id: String(index),
+              name: `Project ${index}`,
+              slug: `project-${index}`,
+            })),
+          },
+        ],
+        fullReleaseHealth,
+        defaultScope
+      ),
+    /more than 100 projects/
+  )
+})
+
+test("a project with no recent issues remains visible with truthful zeroes", () => {
+  const change = projectToChange(
+    fullProject,
+    undefined,
+    "2026-07-02T15:00:00.000Z",
+    defaultScope
+  )
+  const properties = change.properties as Record<string, unknown>
+  assertPropertyContains(properties["Unresolved Issues (30d)"], "0")
+  assertPropertyContains(properties["Events (7d)"], "0")
+  assertPropertyContains(properties["Issue Groups (30d)"], "0")
+  assertPropertyContains(properties["Events (30d)"], "0")
+})
+
 test("display helpers preserve unknown values and bound provider text", () => {
   assert.equal(
     formatSentryLabel("archived_until_escalating"),
@@ -368,6 +812,16 @@ test("issue window is exactly 30 days and remains pinned between pages", () => {
   assert.deepEqual(issueWindow(state, now + 7 * 86_400_000), window)
 })
 
+test("release health window is exactly seven days", () => {
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  const window = releaseHealthWindow(now)
+  assert.equal(
+    Date.parse(window.end) - Date.parse(window.start),
+    RELEASE_HEALTH_DAYS * 86_400_000
+  )
+  assert.throws(() => releaseHealthWindow(Number.NaN), /invalid time/)
+})
+
 test("cursor state catches immediate and longer pagination loops", () => {
   const window = {
     start: "2026-06-02T15:00:00.000Z",
@@ -389,6 +843,16 @@ test("cursor state catches immediate and longer pagination loops", () => {
   assert.throws(
     () => nextIssueState(second, window, defaultScope, undefined),
     /missing/
+  )
+  assert.throws(
+    () =>
+      nextCursorTraversal(
+        "project-b",
+        ["project-a", "project-b"],
+        "project-a",
+        "project"
+      ),
+    /project pagination repeated/
   )
 })
 
@@ -416,6 +880,58 @@ test("request URL explicitly includes all statuses and repeatable filters", () =
     "staging",
   ])
   assert.equal(url.searchParams.get("cursor"), "opaque:100:0")
+
+  const projectHealthUrl = buildIssuesUrl({
+    start: "2026-06-02T15:00:00.000Z",
+    end: "2026-07-02T15:00:00.000Z",
+    statsPeriod: "14d",
+  })
+  assert.equal(projectHealthUrl.searchParams.get("groupStatsPeriod"), "14d")
+})
+
+test("project and release URLs are bounded and carry the configured scope", () => {
+  configureEnvironment()
+  process.env.SENTRY_PROJECTS = "checkout-api,99"
+  process.env.SENTRY_ENVIRONMENTS = "production,staging"
+
+  const projects = buildProjectsUrl("project:100:0")
+  assert.equal(projects.pathname, "/api/0/organizations/acme/projects/")
+  assert.equal(projects.searchParams.get("per_page"), "100")
+  assert.equal(projects.searchParams.get("cursor"), "project:100:0")
+
+  const releases = buildReleasesUrl()
+  assert.equal(releases.pathname, "/api/0/organizations/acme/releases/")
+  assert.equal(releases.searchParams.get("per_page"), "100")
+  assert.equal(releases.searchParams.has("status"), true)
+  assert.equal(releases.searchParams.get("status"), "")
+  assert.deepEqual(releases.searchParams.getAll("project"), [
+    "checkout-api",
+    "99",
+  ])
+  assert.deepEqual(releases.searchParams.getAll("environment"), [
+    "production",
+    "staging",
+  ])
+  assert.equal(releases.searchParams.has("cursor"), false)
+
+  const health = buildReleaseHealthUrl(
+    "2026-06-25T15:00:00.000Z",
+    "2026-07-02T15:00:00.000Z"
+  )
+  assert.equal(health.pathname, "/api/0/organizations/acme/sessions/")
+  assert.deepEqual(health.searchParams.getAll("field"), [
+    "sum(session)",
+    "count_unique(user)",
+    "crash_free_rate(session)",
+    "crash_free_rate(user)",
+  ])
+  assert.deepEqual(health.searchParams.getAll("groupBy"), ["release"])
+  assert.equal(health.searchParams.get("includeSeries"), "0")
+  assert.equal(health.searchParams.get("per_page"), "250")
+  assert.deepEqual(health.searchParams.getAll("environment"), [
+    "production",
+    "staging",
+  ])
 })
 
 test("base URL validation rejects unsafe or ambiguous configuration", () => {
@@ -604,6 +1120,166 @@ test("API client trusts Link results rather than page length", async () => {
   assert.equal(page.nextCursor, "cursor-b")
 })
 
+test("project and release clients retain selected fields and pace every request", async () => {
+  configureEnvironment()
+  let waits = 0
+  const urls: URL[] = []
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    urls.push(url)
+    if (url.pathname.endsWith("/projects/")) {
+      return new Response(JSON.stringify([rawProject()]), {
+        status: 200,
+        headers: { Link: terminalLink(url) },
+      })
+    }
+    if (url.pathname.endsWith("/releases/")) {
+      return new Response(JSON.stringify([rawRelease()]), { status: 200 })
+    }
+    if (url.pathname.endsWith("/sessions/")) {
+      return new Response(
+        JSON.stringify({
+          start: fullReleaseHealth.start,
+          end: fullReleaseHealth.end,
+          intervals: [],
+          query: "",
+          groups: [
+            {
+              by: { project: 99, release: fullRelease.version },
+              totals: {
+                "sum(session)": 12_000,
+                "count_unique(user)": 4_000,
+                "crash_free_rate(session)": 99.95,
+                "crash_free_rate(user)": 99.5,
+              },
+              series: {},
+              ignored: "not retained",
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    }
+    throw new Error(`unexpected request ${url}`)
+  }) as typeof fetch
+  const wait = async () => {
+    waits += 1
+  }
+
+  const projectPage = await fetchProjectsPage(wait, undefined)
+  const releases = await fetchRecentReleases(wait)
+  const health = await fetchReleaseHealth(
+    wait,
+    fullReleaseHealth.start!,
+    fullReleaseHealth.end!
+  )
+
+  assert.equal(waits, 3)
+  assert.equal(urls.length, 3)
+  assert.equal(projectPage.resources[0].teams[0].name, "Checkout")
+  assert.equal("access" in projectPage.resources[0], false)
+  assert.equal(releases[0].id, "501")
+  assert.equal(releases[0].projects[0].id, "99")
+  assert.equal("authors" in releases[0], false)
+  assert.equal("data" in releases[0], false)
+  assert.deepEqual(health, fullReleaseHealth)
+})
+
+test("release client accepts documented name-and-slug-only project references", async () => {
+  configureEnvironment()
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify([
+        rawRelease({
+          projects: [{ name: "Checkout API", slug: "checkout-api" }],
+        }),
+      ]),
+      { status: 200 }
+    )) as typeof fetch
+
+  const releases = await fetchRecentReleases(async () => undefined)
+  assert.equal(releases[0].projects[0].id, null)
+  assert.equal(releases[0].projects[0].name, "Checkout API")
+})
+
+test("new clients fail closed on malformed identity, shape, and health truncation", async () => {
+  configureEnvironment()
+
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    return new Response(JSON.stringify([rawProject({ id: null })]), {
+      status: 200,
+      headers: { Link: terminalLink(new URL(request.url)) },
+    })
+  }) as typeof fetch
+  await assert.rejects(
+    fetchProjectsPage(async () => undefined, undefined),
+    /immutable id/
+  )
+
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify([rawRelease({ projects: undefined })]), {
+      status: 200,
+    })) as typeof fetch
+  await assert.rejects(
+    fetchRecentReleases(async () => undefined),
+    /projects/
+  )
+
+  const groups = Array.from({ length: 250 }, (_, index) => ({
+    by: { project: index + 1, release: `release-${index}` },
+    totals: { "sum(session)": 1 },
+    series: {},
+  }))
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        start: fullReleaseHealth.start,
+        end: fullReleaseHealth.end,
+        groups,
+      }),
+      { status: 200 }
+    )) as typeof fetch
+  await assert.rejects(
+    fetchReleaseHealth(
+      async () => undefined,
+      fullReleaseHealth.start!,
+      fullReleaseHealth.end!
+    ),
+    /250-group safety limit/
+  )
+
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    return new Response(
+      JSON.stringify({
+        start: fullReleaseHealth.start,
+        end: fullReleaseHealth.end,
+        groups: [
+          {
+            by: { release: "checkout@2.4.0" },
+            totals: { "sum(session)": 1 },
+            series: {},
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: { Link: nextLink(new URL(request.url), "health-page-2") },
+      }
+    )
+  }) as typeof fetch
+  await assert.rejects(
+    fetchReleaseHealth(
+      async () => undefined,
+      fullReleaseHealth.start!,
+      fullReleaseHealth.end!
+    ),
+    /returned another page/
+  )
+})
+
 test("API client fails closed if credentials change between pages", async () => {
   configureEnvironment()
   const scope = getIssueScope()
@@ -730,13 +1406,17 @@ test("429 becomes a platform-aware RateLimitError while ordinary 403 remains gen
   assert.match(permissionError.message, /Sentry API error \(403\)/)
 })
 
-type WorkerRunResult = {
-  changes: Array<{ key: string; targetDatabaseKey: string }>
+type WorkerRunResult<State = unknown> = {
+  changes: Array<{
+    key: string
+    targetDatabaseKey: string
+    properties?: Record<string, unknown>
+  }>
   hasMore: boolean
-  nextUserContext?: IssueSyncState
+  nextUserContext?: State
 }
 
-function sentryPacerContext(state?: IssueSyncState) {
+function sentryPacerContext<State>(state?: State) {
   return {
     state,
     pacers: {
@@ -766,9 +1446,11 @@ test("Worker run pins its 30-day window and advances opaque cursor state", async
     })
   }) as typeof fetch
 
-  const first = (await worker.run("issuesSync", sentryPacerContext(), {
-    concreteOutput: true,
-  })) as WorkerRunResult
+  const first = (await worker.run(
+    "issuesSync",
+    sentryPacerContext<IssueSyncState>(),
+    { concreteOutput: true }
+  )) as WorkerRunResult<IssueSyncState>
 
   assert.equal(first.hasMore, true)
   assert.equal(first.changes.length, 1)
@@ -800,7 +1482,7 @@ test("Worker run pins its 30-day window and advances opaque cursor state", async
     "issuesSync",
     sentryPacerContext(first.nextUserContext),
     { concreteOutput: true }
-  )) as WorkerRunResult
+  )) as WorkerRunResult<IssueSyncState>
 
   assert.equal(second.hasMore, false)
   assert.equal(second.nextUserContext, undefined)
@@ -820,4 +1502,210 @@ test("Worker run pins its 30-day window and advances opaque cursor state", async
     requestUrls[0].searchParams.get("end")
   )
   assert.equal(requestUrls.length, 2, "one request is made for each API page")
+})
+
+test("projects Worker aggregates all issues before emitting enriched project rows", async () => {
+  configureEnvironment()
+  process.env.SENTRY_PROJECTS = "checkout-api"
+  process.env.SENTRY_ENVIRONMENTS = "production"
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  Date.now = () => now
+  const requestUrls: URL[] = []
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    requestUrls.push(url)
+    if (url.pathname.endsWith("/issues/")) {
+      const secondPage = url.searchParams.has("cursor")
+      return new Response(
+        JSON.stringify([
+          rawIssue({
+            id: secondPage ? "4500000000000003" : fullIssue.id,
+            title: secondPage ? "Second checkout issue" : fullIssue.title,
+            count: secondPage ? 50 : 100,
+            stats: {
+              "14d": [
+                [
+                  Date.parse("2026-06-24T15:00:00.000Z") / 1_000,
+                  secondPage ? 6 : 4,
+                ],
+                [
+                  Date.parse("2026-07-01T15:00:00.000Z") / 1_000,
+                  secondPage ? 5 : 10,
+                ],
+              ],
+            },
+          }),
+        ]),
+        {
+          status: 200,
+          headers: {
+            Link: secondPage
+              ? terminalLink(url)
+              : nextLink(url, "project-issues-page-2"),
+          },
+        }
+      )
+    }
+    if (url.pathname.endsWith("/projects/")) {
+      return new Response(JSON.stringify([rawProject()]), {
+        status: 200,
+        headers: { Link: terminalLink(url) },
+      })
+    }
+    throw new Error(`unexpected request ${url}`)
+  }) as typeof fetch
+
+  const first = (await worker.run(
+    "projectsSync",
+    sentryPacerContext<ProjectSyncState>(),
+    { concreteOutput: true }
+  )) as WorkerRunResult<ProjectSyncState>
+  assert.equal(first.hasMore, true)
+  assert.equal(first.changes.length, 0)
+  assert.equal(first.nextUserContext?.phase, "issues")
+  assert.equal(requestUrls[0].searchParams.get("groupStatsPeriod"), "14d")
+
+  process.env.SENTRY_PROJECTS = "another-project"
+  process.env.SENTRY_ENVIRONMENTS = "staging"
+  const second = (await worker.run(
+    "projectsSync",
+    sentryPacerContext(first.nextUserContext),
+    { concreteOutput: true }
+  )) as WorkerRunResult<ProjectSyncState>
+  assert.equal(second.hasMore, true)
+  assert.equal(second.changes.length, 0)
+  assert.equal(second.nextUserContext?.phase, "projects")
+  assert.deepEqual(requestUrls[1].searchParams.getAll("project"), [
+    "checkout-api",
+  ])
+  assert.deepEqual(requestUrls[1].searchParams.getAll("environment"), [
+    "production",
+  ])
+
+  const third = (await worker.run(
+    "projectsSync",
+    sentryPacerContext(second.nextUserContext),
+    { concreteOutput: true }
+  )) as WorkerRunResult<ProjectSyncState>
+  assert.equal(third.hasMore, false)
+  assert.equal(third.changes.length, 1)
+  assert.equal(third.changes[0].key, "99")
+  assert.equal(third.changes[0].targetDatabaseKey, "projects")
+  assertPropertyContains(third.changes[0].properties?.["Events (7d)"], "15")
+  assertPropertyContains(
+    third.changes[0].properties?.["Issue Groups (30d)"],
+    "2"
+  )
+  assertPropertyContains(
+    third.changes[0].properties?.["Environment Scope"],
+    "production"
+  )
+  assert.equal(requestUrls.length, 3)
+})
+
+test("projects Worker validates a resumed snapshot before making requests", async () => {
+  configureEnvironment()
+  let fetched = false
+  globalThis.fetch = (async () => {
+    fetched = true
+    throw new Error("fetch should not be called")
+  }) as typeof fetch
+  const invalidState: ProjectSyncState = {
+    phase: "projects",
+    start: "2026-07-03T00:00:00.000Z",
+    end: "2026-07-02T00:00:00.000Z",
+    scope: defaultScope,
+    aggregates: {},
+    unmatchedProjectIds: [],
+  }
+
+  await assert.rejects(
+    worker.run("projectsSync", sentryPacerContext(invalidState), {
+      concreteOutput: true,
+    }),
+    /must start before/
+  )
+  assert.equal(fetched, false)
+})
+
+test("releases Worker uses one bounded list and one aggregate health request", async () => {
+  configureEnvironment()
+  process.env.SENTRY_PROJECTS = "checkout-api"
+  process.env.SENTRY_ENVIRONMENTS = "production"
+  const now = Date.parse("2026-07-02T15:00:00.000Z")
+  Date.now = () => now
+  const requestUrls: URL[] = []
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    requestUrls.push(url)
+    if (url.pathname.endsWith("/releases/")) {
+      return new Response(JSON.stringify([rawRelease()]), { status: 200 })
+    }
+    if (url.pathname.endsWith("/sessions/")) {
+      return new Response(
+        JSON.stringify({
+          start: url.searchParams.get("start"),
+          end: url.searchParams.get("end"),
+          groups: [
+            {
+              by: { project: 99, release: fullRelease.version },
+              totals: {
+                "sum(session)": 12_000,
+                "count_unique(user)": 4_000,
+                "crash_free_rate(session)": 99.95,
+                "crash_free_rate(user)": 99.5,
+              },
+              series: {},
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    }
+    throw new Error(`unexpected request ${url}`)
+  }) as typeof fetch
+
+  const result = (await worker.run("releasesSync", sentryPacerContext(), {
+    concreteOutput: true,
+  })) as WorkerRunResult
+  assert.equal(result.hasMore, false)
+  assert.equal(result.changes.length, 1)
+  assert.equal(result.changes[0].key, "501")
+  assert.equal(result.changes[0].targetDatabaseKey, "releases")
+  assertPropertyContains(
+    result.changes[0].properties?.["Health Project Scope"],
+    "checkout-api"
+  )
+  assertPropertyContains(
+    result.changes[0].properties?.["Environment Scope"],
+    "production"
+  )
+  assert.equal(requestUrls.length, 2)
+  assert.equal(requestUrls[0].searchParams.get("per_page"), "100")
+  assert.equal(requestUrls[0].searchParams.has("cursor"), false)
+  assert.equal(requestUrls[1].searchParams.get("includeSeries"), "0")
+})
+
+test("releases Worker preserves metadata when an older server lacks sessions", async () => {
+  configureEnvironment()
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    if (url.pathname.endsWith("/releases/")) {
+      return new Response(JSON.stringify([rawRelease()]), { status: 200 })
+    }
+    return new Response("not found", { status: 404 })
+  }) as typeof fetch
+
+  const result = (await worker.run("releasesSync", sentryPacerContext(), {
+    concreteOutput: true,
+  })) as WorkerRunResult
+  assert.equal(result.hasMore, false)
+  assert.equal(result.changes.length, 1)
+  assert.equal(result.changes[0].targetDatabaseKey, "releases")
+  assert.equal(result.changes[0].properties?.["Health Data (7d)"], undefined)
+  assert.equal(result.changes[0].properties?.["Window Start"], undefined)
+  assert.equal(result.changes[0].properties?.["Window End"], undefined)
 })

--- a/workers/sentry-sync/test.ts
+++ b/workers/sentry-sync/test.ts
@@ -9,7 +9,6 @@ import { RateLimitError } from "@notionhq/workers"
 import {
   escapeMarkdown,
   formatSentryLabel,
-  issuePageContent,
   nonnegativeNumber,
   safeHttpUrl,
   selectText,
@@ -18,7 +17,7 @@ import {
 } from "./src/helpers.js"
 import worker from "./src/index.js"
 import type { ProjectSyncState } from "./src/index.js"
-import { issueToChange } from "./src/issues.js"
+import { issuePageContent, issueToChange } from "./src/issues.js"
 import {
   aggregateProjectIssues,
   projectToChange,
@@ -39,15 +38,15 @@ import {
   fetchProjectsPage,
   fetchRecentReleases,
   fetchReleaseHealth,
-  getIssueScope,
+  getSentryScope,
   nextCursorFromLink,
   parseRetryAfterSeconds,
   rateLimitRetryAfterSeconds,
   type SentryIssue,
-  type SentryIssueScope,
   type SentryProject,
   type SentryRelease,
   type SentryReleaseHealthSnapshot,
+  type SentryScope,
 } from "./src/sentry.js"
 import {
   ISSUE_WINDOW_DAYS,
@@ -136,7 +135,7 @@ const minimalIssue: SentryIssue = {
   stats: null,
 }
 
-const defaultScope: SentryIssueScope = {
+const defaultScope: SentryScope = {
   baseUrl: "https://sentry.io/",
   organization: "acme",
   projects: [],
@@ -309,7 +308,7 @@ function rawRelease(overrides: Record<string, unknown> = {}) {
   }
 }
 
-test("manifest enables all three value-first databases by default", () => {
+test("manifest enables all three databases by default", () => {
   assert.deepEqual(
     worker.manifest.databases.map((database) => ({
       key: database.key,
@@ -848,7 +847,37 @@ test("display helpers preserve unknown values and bound provider text", () => {
   assert.equal(summedStats({ "24h": [[1, -1]] }, "24h"), null)
   assert.equal(safeHttpUrl("javascript:alert(1)"), null)
   assert.equal(escapeMarkdown("[prod] *fatal*"), "\\[prod\\] \\*fatal\\*")
-  assert.equal(Array.from(titleText("x".repeat(3_000))).length, 2_000)
+  assert.equal(
+    Array.from(titleText("x".repeat(3_000), "Fallback title")).length,
+    2_000
+  )
+  assert.equal(
+    titleText("  ", "Untitled Sentry project"),
+    "Untitled Sentry project"
+  )
+})
+
+test("resource transforms use resource-specific fallback titles", () => {
+  const issueProperties = issueToChange({
+    ...minimalIssue,
+    title: " ",
+  }).properties as Record<string, unknown>
+  assertPropertyContains(issueProperties.Issue, "Untitled Sentry issue")
+
+  const projectProperties = projectToChange(
+    { ...fullProject, name: " " },
+    undefined,
+    "2026-07-02T15:00:00.000Z",
+    defaultScope
+  ).properties as Record<string, unknown>
+  assertPropertyContains(projectProperties.Project, "Untitled Sentry project")
+
+  const releaseProperties = releasesToChanges(
+    [{ ...fullRelease, shortVersion: " " }],
+    fullReleaseHealth,
+    defaultScope
+  )[0].properties as Record<string, unknown>
+  assertPropertyContains(releaseProperties.Release, "Untitled Sentry release")
 })
 
 test("triage page content is bounded and excludes data that was never selected", () => {
@@ -1365,7 +1394,7 @@ test("new clients fail closed on malformed identity, shape, and health truncatio
 
 test("API client fails closed if credentials change between pages", async () => {
   configureEnvironment()
-  const scope = getIssueScope()
+  const scope = getSentryScope()
   process.env.SENTRY_AUTH_TOKEN = "rotated-token-with-different-access"
   let fetched = false
   globalThis.fetch = (async () => {
@@ -1810,7 +1839,7 @@ test("releases Worker uses one bounded list and one aggregate health request", a
   assert.equal(requestUrls[1].searchParams.get("includeSeries"), "0")
 })
 
-test("releases Worker preserves metadata when an older server lacks sessions", async () => {
+test("releases Worker preserves metadata when sessions returns 404", async () => {
   configureEnvironment()
   globalThis.fetch = (async (input, init) => {
     const request = new Request(input, init)

--- a/workers/sentry-sync/tsconfig.json
+++ b/workers/sentry-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/sentry-sync/tsconfig.test.json
+++ b/workers/sentry-sync/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds a self-contained Sentry Worker example at `workers/sentry-sync` that creates three managed Notion databases:

- **Sentry Issues** — rolling 30-day issue triage, refreshed every 15 minutes
- **Sentry Projects** — daily project inventory with 7- and 30-day issue activity summaries
- **Sentry Releases** — the 100 most recent releases with seven-day release-health metrics, refreshed every 15 minutes

Teams can review issue ownership and activity, compare project reliability workload, and monitor rollout health in Notion while Sentry remains the system of record.

## Implementation

- uses only public, documented Sentry REST endpoints and parameters; no Sentry alpha, early-access, internal, or undocumented API is used
- uses immutable Sentry IDs, replace-mode reconciliation, trusted cursor pagination, and pinned query windows and scopes
- recovers safely when project aggregation exceeds the continuation budget, migrates in-flight legacy state, and prevents project renames or repeated inventory rows from wedging or degrading a refresh
- bounds cursor history and continuation state without imposing an artificial page limit
- shares a 60-request-per-minute pacer and propagates documented Sentry retry delays
- fails visibly on Release Health API errors instead of guessing that a 404 means telemetry is unavailable
- explicitly clears properties when upstream values disappear and statically requires every schema property in each upsert
- stores selected issue-group, project, release, and aggregate session metadata without copying raw events
- imports only public `@notionhq/workers` exports and documents that Workers is currently Beta
- documents permissions, scoping, privacy, customization, current CLI commands, and local preview verification
- adds the example to the root catalog and README indexes

## Validation

From `workers/sentry-sync`:

- `npm run check`
- `npm test` — 42 tests passed
- `npm run build`

From the repository root:

- `npm run verify`
- `git diff --check`
