### PR TITLE
Simplify operations sync recipes and cookbook onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Create `workers/<integration>-<capability>/`, with the integration or domain
 first so related capabilities sort together. Use one of these catalog kinds:
 
 - `worker-sync` for an external-data sync into a managed Notion database.
-- `worker-tool` for a capability callable by a Notion agent.
+- `worker-tool` for a capability callable by a Notion Agent.
 - `worker-webhook` for an externally triggered event handler.
 
 New Workers should:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ directory.
   [Linear](workers/linear-sync/), [PagerDuty](workers/pagerduty-sync/),
   [Salesforce](workers/salesforce-sync/), [Sentry](workers/sentry-sync/),
   [Snowflake](workers/snowflake-sync/), or [Zendesk](workers/zendesk-sync/).
-- **Give a Notion Agent a new tool:** connect it to
-  [Airflow](workers/airflow/), [CloudWatch Logs](workers/cloudwatch-logs/),
-  [Postgres](workers/postgres-query/), or one of the other Worker tools below.
+- **Give a Notion Agent a reliable new capability:** execute a repeatable API
+  workflow in one tool call, or connect to [Airflow](workers/airflow/),
+  [CloudWatch Logs](workers/cloudwatch-logs/),
+  [Postgres](workers/postgres-query/), and more.
 - **React to external events:** receive and verify
   [Zendesk webhooks](workers/zendesk-webhook/).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ directory.
   [Linear](workers/linear-sync/), [PagerDuty](workers/pagerduty-sync/),
   [Salesforce](workers/salesforce-sync/), [Sentry](workers/sentry-sync/),
   [Snowflake](workers/snowflake-sync/), or [Zendesk](workers/zendesk-sync/).
-- **Give a Notion agent a new tool:** connect it to
+- **Give a Notion Agent a new tool:** connect it to
   [Airflow](workers/airflow/), [CloudWatch Logs](workers/cloudwatch-logs/),
   [Postgres](workers/postgres-query/), or one of the other Worker tools below.
 - **React to external events:** receive and verify
@@ -100,7 +100,7 @@ See the [API examples guide](examples/) for shared setup information.
 ## Worker examples
 
 Workers are server-side extensions deployed to Notion. A **sync** maintains a
-managed Notion database, a **tool** gives a Notion agent a callable capability,
+managed Notion database, a **tool** gives a Notion Agent a callable capability,
 and a **webhook** handles events from another service. See the complete
 [Workers guide](workers/) for setup and deployment.
 
@@ -120,7 +120,7 @@ and a **webhook** handles events from another service. See the complete
 | Sync the result of a warehouse query                        | [Snowflake sync](workers/snowflake-sync/)   | Snowflake  |
 | Sync tickets, users, organizations, and support metrics     | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
 
-### Add tools to a Notion agent
+### Add tools to a Notion Agent
 
 | Task                                                | Worker                                            | Integration         |
 | --------------------------------------------------- | ------------------------------------------------- | ------------------- |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,60 @@ directory.
 - **React to external events:** receive and verify
   [Zendesk webhooks](workers/zendesk-webhook/).
 
+## Quickstarts
+
+### Using this cookbook with a coding agent
+
+Tell the agent the outcome or integration you need, then point it to:
+
+- [`catalog.json`](catalog.json), the machine-readable index of every runnable
+  project and its supported commands.
+- [`AGENTS.md`](AGENTS.md), the canonical instructions for finding, running,
+  adapting, adding, and validating recipes.
+- The selected project's README and entrypoint, which are authoritative for its
+  setup and implementation.
+
+For example: "Use `catalog.json` to find the Linear sync recipe. Explain its
+data flow, adapt it to include issue labels, and run its offline checks."
+
+### Run an API example
+
+The introductory example is the best first project. Create a
+[Notion integration](https://www.notion.com/my-integrations), share a test page
+with it, then:
+
+```sh
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/examples/intro-to-notion-api
+npm install
+cp .env.example .env
+# Add NOTION_API_KEY and NOTION_PAGE_ID to .env
+npm run basic:1
+```
+
+Other API examples use different scripts and may require additional services.
+Use the command in the selected example's README rather than assuming
+`npm start`.
+
+### Deploy a Worker
+
+The DuckDB query Worker is self-contained and needs no secrets:
+
+```sh
+npm install --global ntn
+git clone https://github.com/makenotion/notion-cookbook.git
+cd notion-cookbook/workers/duckdb-query
+npm install
+npm run check
+npm test
+ntn login
+ntn workers deploy --name duckdb-query
+```
+
+After deployment, add the Worker to a custom agent under **Tools and access >
+Add connection**. Other Workers may need service credentials or database
+configuration; follow their READMEs.
+
 ## API examples
 
 These examples use the official JavaScript SDK and run locally with Node.js.
@@ -84,60 +138,6 @@ and a **webhook** handles events from another service. See the complete
 | Task                                                 | Worker                                      | Integration |
 | ---------------------------------------------------- | ------------------------------------------- | ----------- |
 | Verify ticket events and upsert tickets and comments | [Zendesk webhook](workers/zendesk-webhook/) | Zendesk     |
-
-## Quickstarts
-
-### Run an API example
-
-The introductory example is the best first project. Create a
-[Notion integration](https://www.notion.com/my-integrations), share a test page
-with it, then:
-
-```sh
-git clone https://github.com/makenotion/notion-cookbook.git
-cd notion-cookbook/examples/intro-to-notion-api
-npm install
-cp .env.example .env
-# Add NOTION_API_KEY and NOTION_PAGE_ID to .env
-npm run basic:1
-```
-
-Other API examples use different scripts and may require additional services.
-Use the command in the selected example's README rather than assuming
-`npm start`.
-
-### Deploy a Worker
-
-The DuckDB query Worker is self-contained and needs no secrets:
-
-```sh
-npm install --global ntn
-git clone https://github.com/makenotion/notion-cookbook.git
-cd notion-cookbook/workers/duckdb-query
-npm install
-npm run check
-npm test
-ntn login
-ntn workers deploy --name duckdb-query
-```
-
-After deployment, add the Worker to a custom agent under **Tools and access >
-Add connection**. Other Workers may need service credentials or database
-configuration; follow their READMEs.
-
-## Using this cookbook with a coding agent
-
-Tell the agent the outcome or integration you need, then point it to:
-
-- [`catalog.json`](catalog.json), the machine-readable index of every runnable
-  project and its supported commands.
-- [`AGENTS.md`](AGENTS.md), the canonical instructions for finding, running,
-  adapting, adding, and validating recipes.
-- The selected project's README and entrypoint, which are authoritative for its
-  setup and implementation.
-
-For example: "Use `catalog.json` to find the Linear sync recipe. Explain its
-data flow, adapt it to include issue labels, and run its offline checks."
 
 ## More resources
 

--- a/catalog.json
+++ b/catalog.json
@@ -142,7 +142,7 @@
     {
       "id": "airflow",
       "title": "Airflow agent tool",
-      "summary": "Let a Notion agent inspect Airflow DAGs, runs, tasks, logs, and service health through the stable REST API.",
+      "summary": "Let a Notion Agent inspect Airflow DAGs, runs, tasks, logs, and service health through the stable REST API.",
       "path": "workers/airflow",
       "kind": "worker-tool",
       "status": "ready",
@@ -161,7 +161,7 @@
     {
       "id": "chart-generator",
       "title": "Chart generator agent tool",
-      "summary": "Render a Vega-Lite specification to PNG and let a Notion agent insert the image into a page.",
+      "summary": "Render a Vega-Lite specification to PNG and let a Notion Agent insert the image into a page.",
       "path": "workers/chart-generator",
       "kind": "worker-tool",
       "status": "ready",
@@ -180,7 +180,7 @@
     {
       "id": "cloudwatch-logs",
       "title": "CloudWatch Logs agent tool",
-      "summary": "Let a Notion agent find AWS CloudWatch log groups and streams and read their events.",
+      "summary": "Let a Notion Agent find AWS CloudWatch log groups and streams and read their events.",
       "path": "workers/cloudwatch-logs",
       "kind": "worker-tool",
       "status": "ready",
@@ -351,7 +351,7 @@
     {
       "id": "postgres-query",
       "title": "Postgres query agent tool",
-      "summary": "Let a Notion agent discover PostgreSQL tables and execute bounded, read-only SQL queries.",
+      "summary": "Let a Notion Agent discover PostgreSQL tables and execute bounded, read-only SQL queries.",
       "path": "workers/postgres-query",
       "kind": "worker-tool",
       "status": "ready",
@@ -426,7 +426,7 @@
     {
       "id": "snowflake-query",
       "title": "Snowflake query agent tool",
-      "summary": "Let a Notion agent discover Snowflake tables and execute bounded, read-only SQL queries.",
+      "summary": "Let a Notion Agent discover Snowflake tables and execute bounded, read-only SQL queries.",
       "path": "workers/snowflake-query",
       "kind": "worker-tool",
       "status": "ready",

--- a/catalog.json
+++ b/catalog.json
@@ -275,7 +275,7 @@
     {
       "id": "intercom-sync",
       "title": "Intercom sync",
-      "summary": "Sync Intercom companies, contacts, conversations, and tickets into a connected support workspace in Notion.",
+      "summary": "Keep Intercom companies, contacts, conversations, and tickets current in connected Notion databases, including daily full refreshes.",
       "path": "workers/intercom-sync",
       "kind": "worker-sync",
       "status": "ready",

--- a/workers/README.md
+++ b/workers/README.md
@@ -6,7 +6,7 @@ and deployable project.
 
 - A **sync** imports external records into a managed Notion database on a
   schedule or on demand.
-- A **tool** gives a Notion agent a callable capability.
+- A **tool** gives a Notion Agent a callable capability.
 - A **webhook** verifies and handles events sent by another service.
 
 For local programs built directly on the Notion API, see the

--- a/workers/README.md
+++ b/workers/README.md
@@ -6,7 +6,8 @@ and deployable project.
 
 - A **sync** imports external records into a managed Notion database on a
   schedule or on demand.
-- A **tool** gives a Notion Agent a callable capability.
+- A tool lets a Notion Agent query context or execute a repeatable API workflow
+  in one step.
 - A **webhook** verifies and handles events sent by another service.
 
 For local programs built directly on the Notion API, see the

--- a/workers/airflow/README.md
+++ b/workers/airflow/README.md
@@ -1,6 +1,6 @@
 # Worker tool: Airflow
 
-**TL;DR:** Connect Airflow to a Notion agent so it can inspect DAGs, trace failed runs down to task logs, and check platform health without sending you to the Airflow UI.
+**TL;DR:** Connect Airflow to a Notion Agent so it can inspect DAGs, trace failed runs down to task logs, and check platform health without sending you to the Airflow UI.
 
 ## Quickstart
 

--- a/workers/chart-generator/README.md
+++ b/workers/chart-generator/README.md
@@ -1,6 +1,6 @@
 # Worker tool: Chart generator
 
-**TL;DR:** Let a Notion agent turn data into a polished chart and place the image directly on a page.
+**TL;DR:** Let a Notion Agent turn data into a polished chart and place the image directly on a page.
 
 ## Quickstart
 

--- a/workers/cloudwatch-logs/README.md
+++ b/workers/cloudwatch-logs/README.md
@@ -1,6 +1,6 @@
 # Worker tool: CloudWatch Logs
 
-**TL;DR:** Connect AWS CloudWatch Logs to a Notion agent so it can find the right log stream and investigate recent errors without opening the AWS console.
+**TL;DR:** Connect AWS CloudWatch Logs to a Notion Agent so it can find the right log stream and investigate recent errors without opening the AWS console.
 
 ## Quickstart
 

--- a/workers/duckdb-query/README.md
+++ b/workers/duckdb-query/README.md
@@ -1,6 +1,6 @@
 # Worker tool: DuckDB query
 
-**TL;DR:** Give a Notion agent an instant, zero-configuration SQL sandbox with
+**TL;DR:** Give a Notion Agent an instant, zero-configuration SQL sandbox with
 sample sales data. It is ideal for demos, workshops, and learning how agents
 discover tables and answer questions with DuckDB.
 

--- a/workers/intercom-sync/README.md
+++ b/workers/intercom-sync/README.md
@@ -1,275 +1,256 @@
 # Worker sync: Intercom
 
-Turn Intercom into a connected support workspace in Notion. One deploy creates
-four related databases—**Companies**, **Contacts**, **Conversations**, and
-**Tickets**—so support and customer-success teams can triage work, spot account
-risk, and understand service quality without assembling separate recipes.
+Bring Intercom companies, contacts, conversations, and tickets into one
+connected workspace in Notion. Use the resulting databases to review customer
+context, triage support work, and spot service trends without sending every
+collaborator into Intercom.
 
-The Worker only reads from Intercom. It writes to managed Notion databases;
-Intercom remains the system of record, and later syncs overwrite edits to
-managed properties in Notion.
+The worker creates and maintains all four databases for you. Companies and
+contacts refresh every hour. Conversation and ticket changes arrive every five
+minutes, with an automatic daily refresh to repair drift and remove records
+that are no longer visible.
 
 ## Quickstart
 
-You need Node.js 22+, Notion CLI 0.18.1 or newer, an Intercom workspace,
-and a token from a
-[private Intercom app](https://developers.intercom.com/docs/build-an-integration/learn-more/authentication).
-Grant only these permissions:
+You need Node.js 22+, an Intercom workspace, and a
+[private-app access token](#intercom-access-and-credentials). Give the app these
+permissions:
 
 - **Read and list users and companies**
 - **Read conversations**
 - **Read admins**
-- **Read tickets**—only when you intend to sync Tickets
+- **Read tickets**, if your Intercom plan includes Tickets
 
-Tickets API access also depends on your Intercom plan. If your workspace does
-not use Tickets, leave `ticketsSync` paused and do not trigger
-`ticketsReconciliation`. The other three databases work independently; you do
-not need to edit the bundle.
-
-### Preview locally
-
-Install the example and preview one page from each core resource locally before
-deploying. Local preview calls Intercom but never writes to Notion:
+From the repository root:
 
 ```sh
 npm install --global ntn@latest
-ntn --version
 cd workers/intercom-sync
 npm install
-cp .env.example .env
-# Add INTERCOM_ACCESS_TOKEN and the correct INTERCOM_REGION to .env.
-ntn workers sync trigger contactsSync --local --preview
-ntn workers sync trigger conversationsSync --local --preview
-ntn workers sync trigger companiesSync --local --preview
-```
-
-Run the optional Ticket preview too if you intend to use Tickets. A successful
-preview confirms that the private app and workspace plan can read them:
-
-```sh
-ntn workers sync trigger ticketsSync --local --preview
-```
-
-Company preview opens Intercom's single app-wide Company Scroll. `--preview`
-executes one page. To inspect every preview page, rerun the command with
-`--context '<nextContext>'` from the previous result until it completes. After
-the last Company preview request, let its scroll expire before deployment:
-
-```sh
-sleep 65
-```
-
-### Deploy and initialize
-
-Now deploy without cloud credentials and pause every schedule:
-
-```sh
 ntn login
 ntn workers deploy --name intercom-sync
-for sync in companiesSync contactsSync conversationsSync ticketsSync; do
-  ntn workers sync pause "$sync"
-done
-ntn workers sync status --no-watch
-```
-
-Stop here unless status reports all four scheduled capabilities paused with no
-active run. Then set the region before the token:
-
-```sh
 ntn workers env set INTERCOM_REGION=us
 ntn workers env set INTERCOM_ACCESS_TOKEN=your-private-app-token
 ```
 
-Use `eu` or `au` instead of `us` for those hosting regions. Trigger each core
-backfill in dependency order and wait for it to complete before continuing.
-Each status command watches the run; press Ctrl-C after it reports completion.
+Use `eu` or `au` instead of `us` when that is where Intercom hosts your data.
+The schedules start automatically after deployment; no recurring CLI action is
+required.
 
-```sh
-ntn workers sync trigger companiesSync
-ntn workers sync status companiesSync
-ntn workers sync trigger contactsSync
-ntn workers sync status contactsSync
-ntn workers sync trigger conversationsSync
-ntn workers sync status conversationsSync
-```
+The synced records can include contact details and selected support content.
+Review the managed databases' Notion sharing settings before giving them a
+broader audience.
 
-If the Ticket preview succeeded, initialize and enable Tickets too. Otherwise
-leave Ticket syncing disabled:
+## What you can answer
 
-```sh
-ntn workers sync trigger ticketsSync
-ntn workers sync status ticketsSync
-ntn workers sync resume ticketsSync
-```
+| Managed database  | Questions it helps answer                                                                                               |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Companies**     | Which accounts are active, high-usage, high-spend, or in a key segment? Which contacts and support work belong to them? |
+| **Contacts**      | Who are our users and leads, who owns them, and who is inactive or cannot receive email?                                |
+| **Conversations** | Which open, unread, or priority conversations are waiting? Where are response time, SLA, CSAT, or AI signals weak?      |
+| **Tickets**       | Which structured requests are open, waiting, snoozed, or unassigned? Which customer and teammate own the next step?     |
 
-Finally, enable the core schedules:
+## Reference
 
-```sh
-for sync in companiesSync contactsSync conversationsSync; do
-  ntn workers sync resume "$sync"
-done
-```
+### Synced databases and schedules
 
-These first runs backfill every Company, Contact, and Conversation visible to
-the private app and returned by these APIs. The optional Ticket run does the
-same for Tickets.
+| Database          | Intercom resource | Schedule                         |
+| ----------------- | ----------------- | -------------------------------- |
+| **Companies**     | Companies         | Full refresh every hour          |
+| **Contacts**      | Contacts          | Full refresh every hour          |
+| **Conversations** | Conversations     | Changes every 5 min + daily full |
+| **Tickets**       | Tickets           | Changes every 5 min + daily full |
 
-Notion creates and manages all four databases; you do not provide a Notion API
-token. New Conversation and Ticket changes inside the one-minute consistency
-buffer arrive on the next five-minute cycle.
+#### Companies
 
-### Redeploy safely
+| Notion property     | Intercom field or meaning         | Type        |
+| ------------------- | --------------------------------- | ----------- |
+| Name                | `name`                            | title       |
+| Plan                | `plan.name`                       | select      |
+| Industry            | `industry`                        | select      |
+| Website             | `website`                         | url         |
+| Employees           | `size`                            | number      |
+| Users               | `user_count`                      | number      |
+| Sessions            | `session_count`                   | number      |
+| Monthly Spend       | `monthly_spend`                   | number      |
+| Last Active         | `last_request_at`                 | date        |
+| Tags                | `tags.tags[].name`                | multiSelect |
+| Segments            | `segments.segments[].name`        | multiSelect |
+| Updated             | `updated_at`                      | date        |
+| Created             | `created_at`                      | date        |
+| Created at Source   | `remote_created_at`               | date        |
+| External Company ID | `company_id`                      | richText    |
+| Contacts            | Related Intercom contact IDs      | relation    |
+| Conversations       | Related Intercom conversation IDs | relation    |
+| Company ID          | Immutable Intercom `id`           | richText    |
 
-Use `--name intercom-sync` only for the first deployment. Before redeploying an
-existing credentialed Worker, pause every capability that is scheduled or
-running and wait for status to show no active run because stored credentials
-survive deployments. Older versions also scheduled both reconciliation keys,
-so pause those while upgrading. If a Company run did not finish successfully,
-wait another 65 seconds before redeploying so its Intercom scroll expires.
+Intercom's Company Scroll omits companies with no associated users. Those
+companies do not appear until Intercom includes them in that result.
 
-Then update the existing Worker:
+#### Contacts
 
-```sh
-ntn workers deploy
-```
+| Notion property         | Intercom field or meaning                  | Type        |
+| ----------------------- | ------------------------------------------ | ----------- |
+| Name                    | `name`, then an available identity field   | title       |
+| Role                    | `role`                                     | select      |
+| Owner                   | Admin name resolved from `owner_id`        | richText    |
+| Updated                 | `updated_at`                               | date        |
+| Email                   | `email`                                    | email       |
+| Phone                   | `phone`                                    | phoneNumber |
+| Companies               | `companies.data[].id`                      | relation    |
+| Country                 | `location.country`                         | select      |
+| Tags                    | `tags.data[].name`                         | multiSelect |
+| Incomplete Associations | Companies or Tags when the list is partial | multiSelect |
+| Last Seen               | `last_seen_at`                             | date        |
+| Signed Up               | `signed_up_at`                             | date        |
+| Last Contacted          | `last_contacted_at`                        | date        |
+| Last Replied            | `last_replied_at`                          | date        |
+| Email Restrictions      | Unsubscribe, spam, and bounce flags        | multiSelect |
+| Created                 | `created_at`                               | date        |
+| External ID             | `external_id`                              | richText    |
+| Conversations           | Related Intercom conversation IDs          | relation    |
+| Tickets                 | Related Intercom ticket IDs                | relation    |
+| Contact ID              | Immutable Intercom `id`                    | richText    |
 
-## What you get
+Intercom embeds at most ten companies and ten tags in a Contact result. When
+more exist, **Incomplete Associations** identifies the list that may be
+partial.
 
-| Database          | Useful questions                                                                                                                                     |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Companies**     | Which accounts are active, high-usage, high-spend, or in a key segment? What support work and contacts belong to each account?                       |
-| **Contacts**      | Who are our users and leads, who owns them, and who is inactive or cannot receive email? Which companies, conversations, and tickets relate to them? |
-| **Conversations** | Which open, unread, or priority conversations are waiting? Where are reply time, handling time, reopen, SLA, CSAT, or AI-resolution signals weak?    |
-| **Tickets**       | Which structured requests are open, waiting on a customer, snoozed, or unassigned? Which customer and teammate own the next step?                    |
+#### Conversations
 
-Relations connect Companies to Contacts and Conversations, and Contacts to
-Conversations and Tickets. Each related property is visible from both sides.
+| Notion property     | Intercom field or meaning                            | Type        |
+| ------------------- | ---------------------------------------------------- | ----------- |
+| Title               | `title`, subject, or opening-message fallback        | title       |
+| State               | `state`                                              | select      |
+| Priority            | `priority`                                           | checkbox    |
+| Unread              | Inverse of `read`                                    | checkbox    |
+| Contacts            | `contacts.contacts[].id`                             | relation    |
+| Assignee            | Admin name resolved from `admin_assignee_id`         | richText    |
+| Team                | Team name resolved from `team_assignee_id`           | richText    |
+| Updated             | `updated_at`                                         | date        |
+| Waiting Since       | `waiting_since`                                      | date        |
+| Channel             | `source.type`                                        | select      |
+| Tags                | `tags.tags[].name`                                   | multiSelect |
+| SLA Status          | `sla_applied.sla_status`                             | select      |
+| Rating              | `conversation_rating.rating`                         | number      |
+| Company             | `company.id`                                         | relation    |
+| First Reply (min)   | `statistics.time_to_admin_reply`, converted to min   | number      |
+| Median Reply (min)  | `statistics.median_time_to_reply`, converted to min  | number      |
+| Handling Time (min) | Adjusted or standard handling time, converted to min | number      |
+| Last Contact Reply  | `statistics.last_contact_reply_at`                   | date        |
+| Reopens             | `statistics.count_reopens`                           | number      |
+| AI Resolution       | `ai_agent.resolution_state`                          | select      |
+| Snoozed Until       | `snoozed_until`                                      | date        |
+| Created             | `created_at`                                         | date        |
+| Conversation ID     | Immutable Intercom `id`                              | richText    |
 
-## Sync behavior
+Each page body contains the sanitized opening message and customer rating
+comment when available. It does not copy the full transcript, attachments, or
+internal notes.
 
-| Capability                    | Database      | Mode        | Schedule | Why it exists                                                         |
-| ----------------------------- | ------------- | ----------- | -------- | --------------------------------------------------------------------- |
-| `companiesSync`               | Companies     | replace     | hourly   | Refresh the canonical Company scroll and remove missing records.      |
-| `contactsSync`                | Contacts      | replace     | hourly   | Avoid unsafe day-granularity Contact timestamp cursors.               |
-| `conversationsSync`           | Conversations | incremental | 5 min    | Deliver changed Conversations quickly with a buffered, pinned window. |
-| `conversationsReconciliation` | Conversations | replace     | manual   | Repair drift and remove deleted or newly hidden records.              |
-| `ticketsSync`                 | Tickets       | incremental | 5 min    | Deliver changed Tickets quickly with the same overlap strategy.       |
-| `ticketsReconciliation`       | Tickets       | replace     | manual   | Repair drift and remove Tickets no longer returned by Intercom.       |
+#### Tickets
 
-Incremental searches pin their upper timestamp across every page, request and
-verify ascending order by immutable Intercom ID, wait one minute for indexing,
-and replay a five-minute overlap. Manual replacement is still necessary because
-Intercom search cursors are not snapshots and deleted records do not appear in
-search results. Conversation and Ticket replacements pin Intercom's
-`total_count` and abort if it changes or the completed sweep does not match it,
-so incomplete or count-drifting runs fail before replacement deletion.
+| Notion property      | Intercom field or meaning                    | Type     |
+| -------------------- | -------------------------------------------- | -------- |
+| Title                | Default title, then ticket type and number   | title    |
+| State                | Internal or external ticket-state label      | select   |
+| State Category       | `ticket_state.category`                      | select   |
+| Ticket Type          | `ticket_type.name`                           | select   |
+| Category             | `category`                                   | select   |
+| Contacts             | `contacts.contacts[].id`                     | relation |
+| Assignee             | Admin name resolved from `admin_assignee_id` | richText |
+| Team                 | Team name resolved from `team_assignee_id`   | richText |
+| Updated              | `updated_at`                                 | date     |
+| Open                 | `open`                                       | checkbox |
+| Snoozed Until        | `snoozed_until`                              | date     |
+| Shared with Customer | `is_shared`                                  | checkbox |
+| Created              | `created_at`                                 | date     |
+| Inbox Ticket ID      | Human-facing `ticket_id`                     | richText |
+| Ticket ID            | Immutable Intercom `id`                      | richText |
 
-Trigger the manual reconciliations when you need to repair drift or remove
-deleted or newly hidden records, such as after an outage or access change.
+Each page body contains only the sanitized default Ticket description.
+Arbitrary custom attributes and Ticket parts are not copied.
 
-Keep replacement and delta runs from overlapping: pause `conversationsSync` or
-`ticketsSync`, use `ntn workers sync status <key>` to confirm it is idle,
-trigger the matching reconciliation, wait for that run to finish, then resume
-the delta. This follows the Workers backfill pattern and prevents a replacement
-from deleting a newer row written by a concurrent delta.
-
-```sh
-ntn workers sync pause conversationsSync
-ntn workers sync status conversationsSync
-ntn workers sync trigger conversationsReconciliation
-ntn workers sync status conversationsReconciliation
-ntn workers sync resume conversationsSync
-```
-
-For Tickets, use `ticketsSync` and `ticketsReconciliation` in the same sequence.
-
-Every record is keyed by Intercom's immutable API `id`. The human-facing
-`ticket_id` is copied only as **Inbox Ticket ID** and is never used for API
-queries.
-
-## Data copied
-
-- Companies: plan, industry, website, employee/user/session counts, monthly
-  spend, activity, tags, segments, and timestamps.
-- Contacts: identity, role, owner, email/phone, company relations, tags,
-  association completeness, country, activity, and email restrictions.
-- Conversations: state, priority, contacts/company, assignment, channel, tags,
-  SLA, CSAT, first/median reply time, handling time, last reply, reopens, and AI
-  resolution. The page body contains a sanitized opening message and rating
-  comment when present.
-- Tickets: state, type, category, contacts, assignment, visibility, snooze and
-  timestamps. The page body contains only the sanitized default description.
-
-Arbitrary custom attributes, full Conversation transcripts, Ticket parts,
-attachments, internal notes, and temporary file URLs are deliberately omitted.
-They vary by workspace, can expose sensitive data, or are incomplete in list
-responses. Add only fields your team has reviewed and needs.
-
-The copied data can include customer names, contact details, support messages,
-and rating comments. Review the managed databases' Notion sharing settings
-before granting broader access, and store the Intercom token only with
-`ntn workers env set`.
-
-## Project map and extension points
+### Project structure
 
 ```text
 src/
-├── index.ts          — database registration, schedules, pacing, and caches
-├── intercom.ts       — regional Intercom client, API types, and lookups
-├── pagination.ts     — bounded cursor and record-order protection
-├── companies.ts      — Company schema, transform, and scroll execution
-├── contacts.ts       — Contact schema, transform, and replacement execution
-├── conversations.ts  — Conversation schema, transform, windows, and execution
-├── tickets.ts        — Ticket schema, transform, windows, and execution
-└── helpers.ts        — timestamps, text sanitization, and formatting
+├── index.ts          — registers the databases and schedules
+├── intercom.ts       — regional API client and Intercom types
+├── pagination.ts     — shared cursor and ordering safeguards
+├── companies.ts      — Company schema, transform, and sync
+├── contacts.ts       — Contact schema, transform, and sync
+├── conversations.ts  — Conversation schema, transform, and syncs
+├── tickets.ts        — Ticket schema, transform, and syncs
+└── helpers.ts        — timestamps, safe text, and formatting
 ```
 
-For an agent extending one resource, start in that resource file: its schema,
-transform, state policy, and page executor live together. Then update the API
-DTO in `intercom.ts`, this README, and `test.ts`. Preserve these invariants:
+### How it works
 
-- emit `[]` when an upstream nullable value clears;
-- use API `id` as the key and `updated_at` as `upstreamUpdatedAt`;
-- keep incremental time bounds fixed while a cursor is active;
-- bound text and pagination state;
-- add custom attributes through an explicit allowlist, not a generic dump.
+1. The worker creates four managed databases and connects them with relations
+   based on immutable Intercom IDs.
+2. Companies and contacts receive a complete refresh every hour. Records that
+   Intercom no longer returns are removed after a successful refresh.
+3. Conversation and ticket changes are applied every five minutes. Intercom's
+   search index can lag briefly, so a very recent change may arrive on the next
+   cycle.
+4. An automatic daily full refresh catches missed changes and removes deleted
+   or newly hidden conversations and tickets. Incomplete refreshes do not
+   remove records from a partial result.
 
-Good extensions include selected Company/Contact/Ticket custom attributes,
-webhook-triggered refreshes, or a reviewed subset of Conversation parts.
-Intercom publishes no supported Company, Conversation, or Ticket Inbox deep-link
-format, so this example does not invent one.
+### Intercom access and credentials
 
-## Limitations
+1. Open Intercom's **Developer Hub**, select **Your Apps**, and click **New
+   App**.
+2. Name the app and select the workspace whose data you want to sync.
+3. Under **Configure > Authentication**, grant the read permissions listed in
+   the [Quickstart](#quickstart).
+4. Copy the app's access token from the same Authentication page.
 
-- Intercom permits only one active Company scroll per app, expires it after one
-  idle minute, and may return the same scroll token for multiple distinct pages.
-  Never overlap Company runs, previews, or deployments that share a private-app
-  token. The Worker detects expired/repeated pages, performs at most two full
-  restarts, and fails before replacement deletion if it cannot finish safely.
-- Company Scroll omits Companies with no associated users.
-- Companies and Contacts use hourly replacement sweeps. Notion recommends
-  replacement for sources with fewer than roughly 10,000 records; above that,
-  validate runtime and API load, then lower the cadence or adapt the example
-  before production use.
-- A Contact embeds at most ten Companies and ten Tags; those relation/tag lists
-  can therefore be partial. Filter **Incomplete Associations** for affected
-  Contacts before relying on either list as exhaustive.
-- Ticket APIs can return `403 api_plan_restricted` when the workspace plan does
-  not include them. Keep `ticketsSync` paused and do not trigger
-  `ticketsReconciliation` in that case.
-- Ticket requests use pages of 20 because Intercom may include large
-  `ticket_parts` collections even though this example does not copy them.
-- Full transcripts are not copied; Intercom caps returned Conversation/Ticket
-  parts and those parts may include internal or redacted content.
+Private apps do not require OAuth or App Store review. Store the token with
+`ntn workers env set`, not in source control.
 
-See Intercom's official guides for
-[regional hosts and API versioning](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis),
-[cursor behavior](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination),
-and [Company Scroll](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/scrollOverAllCompanies).
+### Configuration reference
 
-## Verify
+| Variable                | Required | Default | Description                                     |
+| ----------------------- | -------- | ------- | ----------------------------------------------- |
+| `INTERCOM_ACCESS_TOKEN` | Yes      | —       | Token from one workspace's private Intercom app |
+| `INTERCOM_REGION`       | No       | `us`    | Data-hosting region: `us`, `eu`, or `au`        |
 
-Offline checks make no Intercom or Notion calls:
+No `NOTION_API_TOKEN` is needed—the Workers platform supplies Notion access.
+Tickets run automatically when the plan and private app include access. If the
+workspace does not use Tickets, pause those two schedules; the other databases
+continue independently:
+
+```sh
+ntn workers sync pause ticketsSync
+ntn workers sync pause ticketsReconciliation
+```
+
+To enable Tickets later, add **Read tickets** and resume the same two schedule
+names.
+
+### Adapting the schema
+
+Each resource keeps its schema and transform in one file:
+
+| Resource      | File                   |
+| ------------- | ---------------------- |
+| Companies     | `src/companies.ts`     |
+| Contacts      | `src/contacts.ts`      |
+| Conversations | `src/conversations.ts` |
+| Tickets       | `src/tickets.ts`       |
+
+To add an Intercom field:
+
+1. Add the provider field to its narrow type in `src/intercom.ts`.
+2. Add the Notion property to the resource schema and transform.
+3. Update this README and add tests for present and missing values. Add custom
+   attributes through an explicit allowlist.
+
+### Local testing
+
+Run the offline checks; they make no Intercom or Notion calls:
 
 ```sh
 npm run check
@@ -277,9 +258,21 @@ npm test
 npm run build
 ```
 
-For a live smoke test, follow the Quickstart's local-preview and paused-deploy
-flow. Confirm that the Company run reaches a terminal state, Company and Contact
-counts are plausible, relations resolve, and a recently updated Conversation
-and optional Ticket appear after the consistency buffer. Compare a small sample
-against Intercom and check **Incomplete Associations** before treating Contact
-relations or tags as exhaustive.
+For an optional live preview, copy `.env.example` to `.env`, add credentials
+for a test workspace, and preview one sync without writing to Notion:
+
+```sh
+ntn workers sync trigger contactsSync --local --preview
+```
+
+You can substitute `conversationsSync` or `ticketsSync`; preview Tickets only
+when the plan supports them.
+
+## Learn more
+
+- [Notion Workers overview](https://developers.notion.com/workers/get-started/overview)
+- [Intercom authentication](https://developers.intercom.com/docs/build-an-integration/learn-more/authentication)
+- [Intercom regional hosts and versioning](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis)
+- [Intercom pagination](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination)
+- [Intercom Company Scroll](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/scrollOverAllCompanies)
+- [Contributing guide](../../CONTRIBUTING.md)

--- a/workers/intercom-sync/README.md
+++ b/workers/intercom-sync/README.md
@@ -43,12 +43,12 @@ broader audience.
 
 ## What you can answer
 
-| Managed database  | Questions it helps answer                                                                                               |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **Companies**     | Which accounts are active, high-usage, high-spend, or in a key segment? Which contacts and support work belong to them? |
-| **Contacts**      | Who are our users and leads, who owns them, and who is inactive or cannot receive email?                                |
-| **Conversations** | Which open, unread, or priority conversations are waiting? Where are response time, SLA, CSAT, or AI signals weak?      |
-| **Tickets**       | Which structured requests are open, waiting, snoozed, or unassigned? Which customer and teammate own the next step?     |
+| Managed database  | Questions it helps answer                                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Companies**     | Which high-spend or high-usage accounts have gone quiet? Which segments are generating the most conversations, and which contacts belong to each account?                                         |
+| **Contacts**      | Which users or leads need follow-up based on when they were last seen, contacted, or replied? Who owns them, and who is unsubscribed, marked as spam, or hard bounced?                            |
+| **Conversations** | Which open, unread, or priority conversations have waited longest, missed SLA, or lack an assignee? Which teams and channels have slow replies, low ratings, repeated reopens, or AI escalations? |
+| **Tickets**       | Which open tickets are unassigned, waiting on a customer, or ready for follow-up after snoozing? How is the queue distributed by team, ticket type, and category?                                 |
 
 ## Reference
 

--- a/workers/intercom-sync/src/index.ts
+++ b/workers/intercom-sync/src/index.ts
@@ -172,7 +172,7 @@ worker.sync("conversationsSync", {
 worker.sync("conversationsReconciliation", {
   database: conversations,
   mode: "replace",
-  schedule: "manual",
+  schedule: "1d",
   execute: async (state: ConversationReconciliationState | undefined) => {
     if (!state) reconciliationConversationDirectories.clear()
     const client = createClient()
@@ -191,7 +191,7 @@ worker.sync("conversationsReconciliation", {
 
 // ---------------------------------------------------------------------------
 // Tickets — optional in Intercom plans, but included in the same deploy. Keep
-// the scheduled sync paused and do not trigger reconciliation without access.
+// both Ticket schedules paused when the workspace does not have API access.
 // ---------------------------------------------------------------------------
 
 const tickets = worker.database("tickets", {
@@ -220,7 +220,7 @@ worker.sync("ticketsSync", {
 worker.sync("ticketsReconciliation", {
   database: tickets,
   mode: "replace",
-  schedule: "manual",
+  schedule: "1d",
   execute: async (state: TicketReconciliationState | undefined) => {
     if (!state) reconciliationTicketDirectories.clear()
     const client = createClient()

--- a/workers/intercom-sync/test.ts
+++ b/workers/intercom-sync/test.ts
@@ -1731,11 +1731,11 @@ test("worker manifest exposes one connected four-database support bundle", () =>
       "incremental",
       { type: "interval", intervalMs: 5 * 60_000 },
       "replace",
-      { type: "manual" },
+      { type: "interval", intervalMs: 24 * 60 * 60_000 },
       "incremental",
       { type: "interval", intervalMs: 5 * 60_000 },
       "replace",
-      { type: "manual" },
+      { type: "interval", intervalMs: 24 * 60 * 60_000 },
     ]
   )
   assert.deepEqual(worker.manifest.pacers, [

--- a/workers/pagerduty-sync/README.md
+++ b/workers/pagerduty-sync/README.md
@@ -1,127 +1,85 @@
 # Worker sync: PagerDuty
 
-Use this Worker as a read-only operations awareness and reliability handoff hub
-in Notion. It brings active and recent PagerDuty incidents together with service
-ownership, response state, current primary on-call coverage, integrations, and
-support hours. The Worker creates two managed databases, links each incident to
-its PagerDuty service, and preserves direct links back to PagerDuty.
+Bring PagerDuty incidents and service readiness into Notion so operations,
+engineering, support, and leadership can share the same view of active response
+and recent reliability work. The worker creates two related databases and keeps
+them current every five minutes.
 
-PagerDuty remains the response console and authoritative incident timeline.
-Responders still use PagerDuty to acknowledge, reassign, escalate, resolve, and
-inspect the complete event history. Notion provides a shared operational view
-and a place to coordinate durable follow-up; it does not replace paging or
-incident command.
+PagerDuty remains the place to page, acknowledge, escalate, and resolve. This is
+a read-only coordination view with direct links back to the live source.
 
 ## Quickstart
 
-You need Node.js 22+, npm 10.9.2+, the Notion Workers CLI, and a PagerDuty REST
-API key that can read the incidents, services, and current on-calls you want to
-copy. For an account-wide sync, an Admin or Account Owner can create a
-**read-only** key under
-**Integrations > Developer Tools > API Access Keys**. Then run from the
-repository root:
+You need Node.js 22+, npm 10.9.2+, a PagerDuty account, and a read-only REST API
+key. From the repository root:
 
 ```sh
 npm install --global ntn
 cd workers/pagerduty-sync
 npm install
-cp .env.example .env
-# Edit .env: add the token, select the EU region if needed, and set any scope.
 ntn login
 ntn workers deploy --name pagerduty-sync
-ntn workers env push
+ntn workers env set PAGERDUTY_API_TOKEN=your-read-only-api-key
 ```
 
-Using the gitignored `.env` file keeps the token out of the command itself and
-your shell history. EU service-region accounts set `PAGERDUTY_REGION=eu` in
-that file before pushing it.
+EU service-region accounts also set:
 
-Preview both syncs without writing rows:
+```sh
+ntn workers env set PAGERDUTY_REGION=eu
+```
+
+Both databases refresh automatically every five minutes. To preview without
+writing, or populate them immediately instead of waiting for the first scheduled
+run, use these optional commands:
 
 ```sh
 ntn workers sync trigger servicesSync --preview
 ntn workers sync trigger incidentsSync --preview
-```
 
-A preview invokes one callback, while a normal sync cycle follows callbacks
-until `hasMore` is false. Every unscoped service discovery callback and the
-incident confirmation callback are validation-only, so an empty `changes`
-array is expected during those phases. Whenever `hasMore` is true, copy the
-preview's `nextContext` value and continue:
-
-```sh
-ntn workers sync trigger servicesSync --preview --context '<nextContext JSON>'
-```
-
-Repeat with each returned `nextContext` until `hasMore` is false. Use the same
-continuation flow for incidents to inspect the open, confirmation, and recent
-history phases.
-
-Then populate the service directory before its incident relations:
-
-```sh
 ntn workers sync trigger servicesSync
 ntn workers sync trigger incidentsSync
 ```
 
-The worker targets a five-minute cadence for both databases. A complete cycle
-can take longer when PagerDuty returns many pages or asks the Worker to retry.
-No `NOTION_API_TOKEN` is needed: the Workers platform supplies the Notion client
-and owns authentication to the managed databases.
+Run Services first when populating immediately so Incident relations can
+resolve. No `NOTION_API_TOKEN` is needed; the Workers platform handles Notion
+authentication. Review the two databases' sharing settings before giving a
+broader audience access to incident and on-call details.
 
 ## What you can answer
 
-| Managed database        | Questions it helps answer                                                                                                                                                   |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **PagerDuty Incidents** | Which incidents need attention? Who is assigned? What changes automatically next? Is there a conference bridge? What was the resolution duration?                           |
-| **PagerDuty Services**  | What response state is PagerDuty reporting? Who is primary on call? Which services lack primary coverage or ownership? What integrations, support hours, and routing apply? |
-
-The sync is deliberately read-only. Responders follow **Incident Link** or
-**Service Link** back to PagerDuty for action and live detail. It does not copy
-stakeholder status updates, business-impact records, notes, or the full
-timeline. **Response State** is a readable form of PagerDuty's service status;
-it is not an independently calculated health score, uptime measurement, or open
-incident count.
+| Managed database        | Questions it helps answer                                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PagerDuty Incidents** | What needs attention now? Who owns the response? Which services are affected? What resolved recently, and which incidents may need follow-up?                     |
+| **PagerDuty Services**  | Which services are degraded or in maintenance? Where is primary on-call coverage missing? Who owns each service, and what routing and support arrangements apply? |
 
 ## Reference
 
-### Databases and schedules
+### Synced databases and schedules
 
-| Database                | Sync            | Mode    | Schedule    | Default scope                                       |
-| ----------------------- | --------------- | ------- | ----------- | --------------------------------------------------- |
-| **PagerDuty Incidents** | `incidentsSync` | replace | Every 5 min | All open incidents plus the last 90 days of history |
-| **PagerDuty Services**  | `servicesSync`  | replace | Every 5 min | All services visible to the key                     |
-
-The incident sweep first reads every Triggered or Acknowledged incident, without
-a creation-time cutoff. It then reads all statuses whose incident creation time
-falls in the rolling lookback, so recent Resolved incidents remain available for
-review. An old incident stays in Notion while it is open and ages out only after
-it is resolved and outside the lookback.
-
-Both syncs use replacement sweeps. At the end of a successful cycle, a row is
-removed when its upstream record was deleted, became invisible to the key, or
-fell outside the relevant service/team/history scope. A failed or incomplete
-sweep does not intentionally present itself as a complete snapshot.
+| Database                | PagerDuty resource            | Schedule    | Default scope                                       |
+| ----------------------- | ----------------------------- | ----------- | --------------------------------------------------- |
+| **PagerDuty Incidents** | Incidents                     | Every 5 min | All open incidents plus the last 90 days of history |
+| **PagerDuty Services**  | Services and current on-calls | Every 5 min | All services visible to the API key                 |
 
 #### PagerDuty Incidents
 
-| Notion property           | PagerDuty field                                 | Type        |
+| Notion property           | PagerDuty field or meaning                      | Type        |
 | ------------------------- | ----------------------------------------------- | ----------- |
 | Title                     | `title`                                         | title       |
 | Status                    | `status`                                        | select      |
 | Urgency                   | `urgency`                                       | select      |
-| Assigned To               | all `assignments[].assignee` names              | multiSelect |
+| Assigned To               | `assignments[].assignee` names                  | multiSelect |
 | Incident Link             | `html_url`                                      | url         |
 | Service                   | relation keyed by `service.id`                  | relation    |
-| Incident Type             | readable `incident_type.name`                   | select      |
+| Incident Type             | `incident_type.name`                            | select      |
 | Last Changed By           | `last_status_change_by` name                    | select      |
 | Next Automatic Action     | earliest valid `pending_actions[]` entry        | select      |
-| Next Action At            | timestamp paired with Next Automatic Action     | date        |
+| Next Action At            | time of the next automatic action               | date        |
 | Conference Link           | safe HTTP(S) `conference_bridge.conference_url` | url         |
 | Conference Dial-in        | `conference_bridge.conference_number`           | richText    |
-| Resolution Duration (min) | elapsed time from `created_at` to `resolved_at` | number      |
+| Resolution Duration (min) | time from `created_at` to `resolved_at`         | number      |
 | Priority                  | `priority.summary` or `priority.name`           | select      |
-| Teams                     | all `teams[]` names                             | multiSelect |
+| Teams                     | `teams[]` names                                 | multiSelect |
 | Escalation Policy         | `escalation_policy` name                        | select      |
 | Last Status Change        | `last_status_change_at`                         | date        |
 | Updated                   | `updated_at`                                    | date        |
@@ -132,412 +90,125 @@ sweep does not intentionally present itself as a complete snapshot.
 | Assigned Via              | `assigned_via`                                  | select      |
 | Created                   | `created_at`                                    | date        |
 | Resolved                  | `resolved_at`                                   | date        |
-| Incident Number           | `incident_number`                               | number      |
-| PagerDuty Incident ID     | immutable `id`                                  | richText    |
+| Incident Number           | human-facing `incident_number`                  | number      |
+| PagerDuty Incident ID     | immutable `id`; the Notion primary key          | richText    |
 
-**PagerDuty Incident ID** is the primary key. The familiar incident number is
-retained for searching and sorting but is not used as sync identity.
-
-**Service** is a two-way relation keyed by the immutable service ID. Notion
-adds the reciprocal **Incidents** property to each related service so a service
-page can show or count its synced incidents.
-
-PagerDuty returns assignments only while an incident is open and returns
-acknowledgements only for an acknowledged incident. The transform therefore
-clears those Notion values when PagerDuty no longer returns them; it does not
-turn missing history into a misleading zero. Priority and Incident Type are
-also left empty for accounts or incidents where the features are unavailable.
-
-**Next Automatic Action** is the chronologically earliest valid pending action
-PagerDuty returns, with action type and destination used as deterministic tie
-breakers. It describes provider automation such as escalation, unacknowledgment,
-auto-resolution, or an urgency change; it is not a task assigned in Notion.
-**Resolution Duration (min)** is rounded to one decimal and appears only when
-both timestamps form a valid nonnegative interval. Last Changed By may identify
-a user, service, or integration. Conference fields are cleared independently
-when PagerDuty does not return a safe web URL or a dial-in number.
-
-The incident page body is a bounded initial-trigger snapshot: the first-trigger
-description, an included email trigger message rendered as plain text, and safe
-HTTP(S) context links. It does not copy the incident body, arbitrary structured
-trigger details, notes, status updates, or the PagerDuty timeline. Follow
-**Incident Link** for the full record and response history.
+The **Service** relation uses PagerDuty's immutable service ID and adds the
+reciprocal **Incidents** property. Each page contains a bounded initial-trigger
+summary; assignments and acknowledgements reflect current response state.
 
 #### PagerDuty Services
 
-| Notion property            | PagerDuty field or derivation                                  | Type        |
-| -------------------------- | -------------------------------------------------------------- | ----------- |
-| Name                       | `name`                                                         | title       |
-| Response State             | readable `status`                                              | select      |
-| Primary On Call            | level-one current on-call user names for the escalation policy | multiSelect |
-| Primary Coverage           | service status, policy presence, and current level-one entries | select      |
-| Teams                      | all `teams[]` names                                            | multiSelect |
-| Service Link               | `html_url`                                                     | url         |
-| Coverage Checked           | cycle-pinned on-call observation time                          | date        |
-| Integrations               | all `integrations[]` names                                     | multiSelect |
-| Integration Count          | number of unique returned integration IDs                      | number      |
-| Support Hours              | readable `support_hours` window and time zone                  | richText    |
-| Last Incident              | `last_incident_timestamp`                                      | date        |
-| Escalation Policy          | `escalation_policy` name                                       | select      |
-| Description                | `description`                                                  | richText    |
-| Urgency Rule               | readable `incident_urgency_rule` summary                       | richText    |
-| Auto Resolve (min)         | `auto_resolve_timeout` converted from seconds                  | number      |
-| Re-trigger After Ack (min) | `acknowledgement_timeout` converted from seconds               | number      |
-| Created                    | `created_at`                                                   | date        |
-| PagerDuty Service ID       | immutable `id`                                                 | richText    |
+| Notion property            | PagerDuty field or meaning                       | Type        |
+| -------------------------- | ------------------------------------------------ | ----------- |
+| Name                       | `name`                                           | title       |
+| Response State             | readable `status`                                | select      |
+| Primary On Call            | current level-one on-call names                  | multiSelect |
+| Primary Coverage           | level-one coverage status                        | select      |
+| Teams                      | `teams[]` names                                  | multiSelect |
+| Service Link               | `html_url`                                       | url         |
+| Coverage Checked           | sync cycle's pinned observation time             | date        |
+| Integrations               | `integrations[]` names                           | multiSelect |
+| Integration Count          | unique returned integration IDs                  | number      |
+| Support Hours              | readable `support_hours` window and time zone    | richText    |
+| Last Incident              | `last_incident_timestamp`                        | date        |
+| Escalation Policy          | `escalation_policy` name                         | select      |
+| Description                | `description`                                    | richText    |
+| Urgency Rule               | readable `incident_urgency_rule`                 | richText    |
+| Auto Resolve (min)         | `auto_resolve_timeout` converted from seconds    | number      |
+| Re-trigger After Ack (min) | `acknowledgement_timeout` converted from seconds | number      |
+| Created                    | `created_at`                                     | date        |
+| PagerDuty Service ID       | immutable `id`; the Notion primary key           | richText    |
 
-The complete service description is also used as page content. A disabled or
-unavailable timeout is left empty instead of being presented as a duration.
-Integration Count preserves zero; Integrations is empty when there are no
-names to display. Support Hours is empty when the service has no configured
-window.
+Response State translates PagerDuty's status into **No Open Incidents**,
+**Response in Progress**, **Awaiting Response**, **Maintenance**, or
+**Disabled**. It is the provider's service state, not a separately calculated
+health score or open-incident count.
 
-Every upsert includes every schema property, using an explicit empty value when
-PagerDuty removes data. This lets a populated incident or service converge to
-its new empty state instead of retaining stale Notion values. Provider-authored
-select and multi-select labels normalize ASCII commas, de-duplicate
-case-insensitively, sort deterministically, and bound long names with a stable
-digest suffix. A row with more than Notion's 100-value multi-select limit fails
-visibly rather than silently dropping ownership, responder, or integration
-data.
-
-Response State maps PagerDuty's service status as follows: `active` becomes
-**No Open Incidents**, `warning` becomes **Response in Progress**, `critical`
-becomes **Awaiting Response**, and maintenance and disabled services become
-**Maintenance** and **Disabled**. This is the service-level status PagerDuty
-returned at observation time, not a separately traversed incident aggregate.
-
-Primary Coverage describes only the first escalation level and uses exactly
-four states:
-
-- **Covered:** PagerDuty returned at least one current level-one on-call entry
-  for the service's escalation policy.
-- **No Primary On Call:** the service has an escalation policy, but the complete
-  current snapshot returned no level-one entry. A fallback escalation level may
-  still be staffed; this label does not claim that every policy level is empty.
-- **No Escalation Policy:** an enabled service has no policy to query.
-- **Not Applicable:** the service is disabled.
-
-Primary On Call contains the deduplicated, sorted names from those level-one
-entries. Coverage can still be **Covered** when an entry exists but its user
-reference has no displayable name. The Worker never converts a failed,
-unauthorized, malformed, changing, or incomplete `/oncalls` traversal into the
-**No Primary On Call** state; the service replacement cycle fails instead and
-does not perform replacement deletion. Upserts from successful earlier publish
-pages may already be visible, so a failed multi-page cycle is not described as
-transactional.
-
-PagerDuty's service response has no general `updated_at` timestamp. Each row's
-`upstreamUpdatedAt` is therefore the cycle's pinned observation time so response
-state, coverage, ownership, integrations, support hours, description, and
-timeout changes are reapplied rather than skipped against the service's creation
-time. **Coverage Checked** exposes that same instant. It is evidence of when
-the snapshot was taken, not a promise that the person remains on call after the
-row was written.
-
-### Recommended Notion views
-
-Deployment creates the databases and properties, but not saved views. Add these
-after the first successful sync.
-
-#### Operations awareness
-
-Create this view in **PagerDuty Incidents**:
-
-- Advanced filter: `(Status is Triggered) OR (Status is Acknowledged)`.
-- Group by **Status**.
-- Sort by **Priority** ascending, **Urgency** ascending, **Next Action At**
-  ascending, then **Last Status Change** descending.
-- Show **Title**, **Status**, **Urgency**, **Priority**, **Service**,
-  **Incident Type**, **Assigned To**, **Active Alert Count**,
-  **Next Automatic Action**, **Next Action At**, **Last Changed By**,
-  **Conference Link**, **Conference Dial-in**, and **Incident Link**.
-
-This is the shared awareness view. Use Incident Link for live response, because
-the five-minute sync cadence and a cycle's API work make it intentionally less
-current than PagerDuty.
-
-#### Service readiness and primary coverage gaps
-
-Create **Service readiness** in **PagerDuty Services**:
-
-- Filter **Response State** to anything except **Disabled**.
-- Group by **Response State**.
-- Sort by **Primary Coverage** ascending, then **Name** ascending.
-- Show **Name**, **Response State**, **Primary On Call**,
-  **Primary Coverage**, **Coverage Checked**, **Teams**,
-  **Escalation Policy**, **Support Hours**, **Integrations**,
-  **Integration Count**, and **Service Link**.
-
-Duplicate that view as **Primary coverage gaps**, then add the advanced filter
-`(Primary Coverage is No Primary On Call) OR (Primary Coverage is No Escalation Policy)`
-while retaining `Response State is not Disabled`. Group by **Primary Coverage**
-and sort by **Response State** ascending, then **Name** ascending.
-
-#### Review intake
-
-Create this view in **PagerDuty Incidents**:
-
-- Filter **Status** to **Resolved** and **Resolved** to within the past 30 days.
-- Sort by **Priority** ascending, **Resolution Duration (min)** descending, then
-  **Resolved** descending.
-- Show **Title**, **Priority**, **Service**, **Incident Type**, **Resolved**,
-  **Resolution Duration (min)**, **Last Changed By**, and **Incident Link**.
-
-Use this as intake for a native Notion review workflow, not as a claim that
-PagerDuty already classified an incident as requiring review.
-
-### User-owned Incident Reviews
-
-Do not add mutable review ownership or status to either managed sync database.
-Instead, create a normal Notion database named **Incident Reviews** with these
-properties:
-
-| Property            | Type             | Purpose                                                          |
-| ------------------- | ---------------- | ---------------------------------------------------------------- |
-| Review              | title            | Durable review or post-incident record                           |
-| PagerDuty Incident  | one-way relation | Links to PagerDuty Incidents without changing its managed schema |
-| Review Status       | status           | Needed, In progress, Complete, or Not required                   |
-| Review Owner        | people           | Notion-native follow-up owner                                    |
-| Review Due          | date             | Review deadline                                                  |
-| Review Document     | url              | Optional external postmortem                                     |
-| Service             | rollup           | Service from the related incident                                |
-| Priority            | rollup           | Priority from the related incident                               |
-| Resolved            | rollup           | Resolution time from the related incident                        |
-| Resolution Duration | rollup           | Resolution Duration (min) from the related incident              |
-
-From **Review intake**, decide whether a review is needed, create and relate an
-Incident Reviews page, assign its owner and due date, and keep notes, decisions,
-and action items in that native page. Use **Incident Link** for PagerDuty's
-authoritative history. A review page and all user-entered mutable fields remain
-owned by the workspace and are never written or replaced by this Worker. The
-related managed incident can age out after the configured lookback, so copy any
-facts that must remain durable instead of relying indefinitely on rollups.
-
-In Incident Reviews, a useful **Review queue** filters Review Status to Needed
-or In progress, groups by Review Status, and sorts Review Due ascending, then
-Priority ascending.
-
-### Configuration
-
-| Variable                           | Required | Default | Description                                                                                                 |
-| ---------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
-| `PAGERDUTY_API_TOKEN`              | yes      | —       | REST API key sent only in the `Authorization` header                                                        |
-| `PAGERDUTY_REGION`                 | no       | `us`    | `us` uses `api.pagerduty.com`; `eu` uses `api.eu.pagerduty.com`                                             |
-| `PAGERDUTY_INCIDENT_LOOKBACK_DAYS` | no       | `90`    | Resolved/recent history in days, from 1 through 180; open incidents are retained regardless of age          |
-| `PAGERDUTY_SERVICE_IDS`            | no       | all     | Comma-separated service IDs; scopes incidents and directly selects the service rows to fetch                |
-| `PAGERDUTY_TEAM_IDS`               | no       | all     | Comma-separated team IDs applied only to incident queries; requires the PagerDuty account's `teams` ability |
-
-`PAGERDUTY_SERVICE_IDS` scopes both databases. When it is set, the service sync
-fetches those services directly by ID instead of scanning the service directory.
-A configured ID that is missing or invisible fails the cycle visibly instead of
-silently producing an incomplete service table. `PAGERDUTY_TEAM_IDS` scopes
-incidents only: the service directory remains unfiltered so Incident → Service
-relations can resolve. When both filters are set, they intersect for incidents,
-while the service database still follows only the service-ID scope. Omit the team
-filter when the PagerDuty account does not have the `teams` ability.
-
-PagerDuty describes the maximum incident search range as six months. This
-recipe accepts a conservative 1–180 day rolling lookback. Configured IDs are
-case-sensitive opaque values rather than values matched to an assumed provider
-format. Each is limited to 255 characters; control characters and the `.` and
-`..` service-ID values are rejected because they cannot be preserved as URL path
-segments, while duplicate IDs and surrounding whitespace are removed.
-Configuration is copied into serializable sync state at the beginning of a
-cycle, so an environment change cannot alter an in-progress traversal; the next
-cycle uses the new value.
-
-To retain 30 days and limit both databases to two services, edit `.env`:
-
-```dotenv
-PAGERDUTY_INCIDENT_LOOKBACK_DAYS=30
-PAGERDUTY_SERVICE_IDS=PABC123,PDEF456
-```
-
-Then run `ntn workers env push` and repeat both preview commands before writing.
-PagerDuty service and team IDs appear in their web-app URLs and API responses.
-The `.env` file is gitignored; never put a real token in `.env.example`,
-`workers.json`, tests, or source control.
-
-### Authentication, visibility, and privacy
-
-The client uses PagerDuty REST API v2's `Token token=...` authorization scheme
-and accepts REST API access keys, not OAuth bearer tokens. A read-only account
-key is the simplest choice because this Worker makes only `GET` requests. A user
-API key also works, but its PagerDuty role and team access limit which incidents,
-services, and on-call entries appear. A `403` from `/oncalls` fails the service
-cycle; it is not represented as missing primary coverage.
-
-Incident titles, responder and current on-call names, team ownership,
-initial-trigger descriptions and messages, context links, conference URLs and
-dial-in numbers, integration names, support hours, and service descriptions may
-be sensitive. A conference URL or number may grant access to a live response
-call, and integration names can reveal internal architecture. The key's
-visibility defines what can be copied, but Notion sharing controls who can read
-the copy afterward. Hiding a property in one view is not an access boundary.
-
-Review the PagerDuty scope and destination sharing before the first write and
-before sharing either managed database broadly. Give a user-owned Incident
-Reviews database its own appropriate sharing policy. Preview output can contain
-the same source data, so treat it as sensitive too.
-
-### Pagination and consistency
-
-PagerDuty's list endpoints use offset pagination and expose at most 10,000
-records through an offset traversal. One complete Worker cycle follows these
-phase flows:
-
-```text
-Incidents: open → open confirmation → recent window(s) → complete
-Services: discover → publish → complete
-Configured services: publish directly → complete
-```
-
-`src/sync-state.ts` contains pure transitions for these phases; the Workers
-runtime persists the returned `nextState` between callbacks. The worker protects
-completeness as follows:
-
-1. An incident cycle pins the recent-history upper boundary and the service/team
-   scope before its first request. Recent-history incidents created later wait
-   for the next cycle.
-2. The all-open phase is intentionally a live set with no creation-time cutoff,
-   so it can include an incident created during the cycle. The Worker scans this
-   set twice, and the confirmation pass must reproduce every first-pass ID in
-   order. Every continuing page also re-reads the preceding boundary incident
-   and verifies its immutable ID and incident number. A substitution, boundary
-   shift, total drift, or order drift therefore fails the replacement cycle
-   instead of silently skipping an older open incident. Because this set cannot
-   be divided by creation time, a total above 10,000 also fails with guidance to
-   narrow the service or team scope.
-3. The rolling-history phase requests all statuses in initial seven-day windows.
-   Any window above 10,000 records is divided into smaller time windows until
-   each part can be traversed completely. If an oversized remaining window is
-   one minute or less, the cycle fails with guidance to narrow the service or
-   team scope.
-4. History windows share their exact boundary, and the open and history phases
-   can return the same incident. Both cases intentionally replay the immutable
-   incident ID, so the upserts converge on one row instead of missing a boundary
-   record.
-5. Every list page requests `total=true`. The client checks the echoed offset,
-   full continuing pages, overlapping record boundary, continuation progress,
-   stable total, processed count, and strictly increasing incident numbers. An
-   inconsistent traversal fails visibly instead of committing a knowingly
-   partial replacement.
-6. Without `PAGERDUTY_SERVICE_IDS`, the Worker first discovers the complete
-   service identity set without emitting rows, then traverses the directory
-   again to publish it. The publish pass must reproduce the same set, so an
-   equal-count delete/create race or mutable-name page shift fails before
-   replacement deletion instead of silently removing a still-live service. A
-   visible directory above 10,000 fails with guidance to configure explicit
-   service IDs. With IDs configured, each service is fetched directly and
-   published without discovery; a missing/invisible ID fails visibly, and the
-   offset ceiling does not apply.
-7. Each service publish callback collects the unique escalation policies
-   referenced by that service page and reads their current on-calls at the
-   cycle-pinned **Coverage Checked** instant. The request uses the same timestamp
-   for `since` and `until`, follows every offset page, requires a stable reported
-   total and processed count, validates each entry, and fails above 10,000
-   entries. If the result spans multiple pages, the Worker repeats the complete
-   traversal and requires the same raw identity multiset before publishing
-   coverage. The Worker transforms the service page only after this traversal
-   completes. A page with no escalation policies makes no `/oncalls` request.
-
-All state is plain serializable data; the sync never relies on a module-global
-cache surviving between Worker executions.
-
-### Rate limits
-
-Every request from both syncs shares one pacer capped at 120 requests per
-minute. This leaves substantial headroom beneath PagerDuty's general REST API
-allowance and for other applications sharing the same user or key. Actual
-limits can also vary by operation and credential.
-
-Per cycle, the open confirmation costs twice the number of open-incident pages,
-and recent history costs one request per page and subwindow. The new incident
-properties come from those list responses and do not add per-incident requests.
-
-An unfiltered service cycle reads every `/services` page twice: discovery emits
-no rows and makes no `/oncalls` requests, then publish reproduces the discovered
-identity set. Each publish callback reads up to 100 services and queries
-`/oncalls` for the unique escalation policies on that page. A one-page directory
-with one-page coverage therefore costs three requests. A multi-page on-call
-result costs twice its page count because the Worker confirms the complete raw
-identity set with a second traversal. An explicit service scope skips discovery,
-reads one configured service per callback, and queries that service's policy; a
-policy shared by services on different pages can therefore be queried again. A
-page with no policies skips the on-call request. Integrations and support hours
-come from the service response and add no per-service lookup. The shared pacer
-applies to all incident, service, and on-call requests combined.
-
-The Worker deliberately does not duplicate the bounded incident traversal to
-calculate service-level open-incident counts. It also makes no per-incident
-stakeholder-status or business-impact calls. Those additions would materially
-increase request volume and could turn an awareness sync into an unbounded
-fan-out.
-
-When PagerDuty returns HTTP 429, the client raises the Workers runtime's
-`RateLimitError`. It honors `Retry-After` and PagerDuty's `ratelimit-reset`
-header, with a conservative fallback when neither is usable. Invalid JSON,
-non-success responses, malformed pages, and non-advancing pagination all fail
-closed.
+Primary Coverage describes escalation level one: **Covered**, **No Primary On
+Call**, **No Escalation Policy**, or **Not Applicable** for a disabled service.
+A fallback escalation level may still be staffed when the primary level is
+empty. **Coverage Checked** records the sync cycle's pinned observation time;
+it does not promise that the same person remains on call afterward. The
+complete service description is also used as the page body.
 
 ### Project structure
 
 ```text
 src/
-├── index.ts       — registers databases, syncs, and pacing; orchestrates callbacks
-├── pagerduty.ts   — list/direct API reads, configuration, and validation
-├── sync-state.ts  — incident/service phases, windows, and identity checks
+├── index.ts       — registers the databases and sync schedules
+├── pagerduty.ts   — PagerDuty client, configuration, and response validation
+├── sync-state.ts  — incident and service pagination state
 ├── incidents.ts   — incident schema and transform
 ├── services.ts    — service schema, coverage context, and transform
-└── helpers.ts     — labels, durations, support hours, and safe page formatting
+└── helpers.ts     — labels, durations, support hours, and page formatting
 ```
 
-### Extending the example
+### How it works
 
-The confirmation, overlap, and window-splitting state machine is specific to
-PagerDuty's live offset pagination. For a provider with stable cursors, start
-from the [Linear sync](../linear-sync/); for incremental change tracking plus a
-replacement repair path, start from the [Salesforce sync](../salesforce-sync/).
+1. Every five minutes, **PagerDuty Incidents** reads all Triggered and
+   Acknowledged incidents, regardless of age, plus every incident status created
+   within the rolling lookback. An old incident remains until it is resolved and
+   outside the lookback.
+2. **PagerDuty Services** reads the service directory and a current level-one
+   on-call snapshot for each referenced escalation policy. Services without
+   recent incidents still appear.
+3. Immutable PagerDuty IDs key both databases. Incident rows relate to stable
+   Service rows even when the display names change.
+4. A successful refresh removes records deleted upstream, hidden from the key,
+   or outside the configured scope. An incomplete refresh does not remove rows
+   from a partial result.
 
-Use this checklist when extending the recipe:
+PagerDuty listings are capped at 10,000 records. For larger accounts, use
+service or team filters to keep each synced scope complete.
 
-1. Add the provider field to the relevant validated API type in
-   `src/pagerduty.ts`; do not trust an unvalidated response shape.
-2. Add its `Schema.*` property and matching `Builder.*` value in the same order.
-   Keep the first six columns focused on triage, ownership, relation, and source
-   actions.
-3. Define the behavior for populated, missing, empty, zero, and plan-dependent
-   values. Prefer human-readable `summary` or `name` fields over opaque IDs.
-4. Preserve deterministic primary keys and the two-way Incident → Service
-   relation. Do not let a team filter remove service rows needed by relations.
-5. If another endpoint is required, use a bounded batch or one lookup per cycle.
-   Do not introduce an unbounded per-incident request, and keep all calls on the
-   shared pacer.
-6. Revisit the 10,000-record boundary. List traversals need a deterministic split
-   strategy or a clear fail-closed scope requirement; explicit service IDs should
-   continue to use direct lookups.
-7. Whitelist any page content, render provider text as plain text, accept only
-   safe context-link protocols, bound its size, and update the privacy inventory.
-   Do not copy arbitrary provider payloads or credentials.
-8. Add offline tests for populated and explicitly cleared values, request
-   parameters, pagination, split boundaries, duplicate detection, filter
-   semantics, and rate limits. Add a safe live preview for behavior that fixtures
-   cannot prove.
-9. Update the property/configuration tables, expected output, extension notes,
-   and verification steps. If behavior, entrypoints, integrations, or commands
-   change, update the recipe's `catalog.json` entry too.
+### PagerDuty access and credentials
 
-The default intentionally stops at current level-one coverage on each service.
-It does not create a third Worker-managed on-call or review database, browse
-future shifts, or copy incident timelines. The native Incident Reviews workflow
-above owns mutable follow-up in Notion. Any extension for upcoming schedules,
-stakeholder updates, or business impact should first define a bounded batch or
-hard scope; do not add an unbounded per-record request path.
+#### Getting a PagerDuty API key
 
-### Verification
+1. Sign in as a PagerDuty Admin or Account Owner.
+2. Open **Integrations > Developer Tools > API Access Keys**.
+3. Create an API key dedicated to this worker and select **Read-only API Key**.
+4. Copy the key and store it with `ntn workers env set`.
 
-Run all deterministic checks without contacting PagerDuty or Notion:
+The worker makes only `GET` requests. A user API key also works, with visibility
+limited by that user's role and team access.
+
+### Configuration reference
+
+| Variable                           | Required | Default | Description                                                                                          |
+| ---------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `PAGERDUTY_API_TOKEN`              | yes      | —       | PagerDuty REST API key                                                                               |
+| `PAGERDUTY_REGION`                 | no       | `us`    | `us` for `api.pagerduty.com`; `eu` for `api.eu.pagerduty.com`                                        |
+| `PAGERDUTY_INCIDENT_LOOKBACK_DAYS` | no       | `90`    | Recent history from 1 through 180 days; open incidents remain regardless of age                      |
+| `PAGERDUTY_SERVICE_IDS`            | no       | all     | Comma-separated service IDs; scopes both databases and directly selects service rows                 |
+| `PAGERDUTY_TEAM_IDS`               | no       | all     | Comma-separated team IDs applied only to incidents; requires the PagerDuty account's `teams` ability |
+
+Service IDs scope both databases. A missing or invisible configured service
+fails the cycle instead of silently producing an incomplete directory. Team IDs
+scope Incidents only, leaving Services available for relations. When both are
+set, they intersect for Incidents.
+
+### Adapting the schema
+
+Each database has its schema and transform in one resource file:
+
+| Resource  | File               |
+| --------- | ------------------ |
+| Incidents | `src/incidents.ts` |
+| Services  | `src/services.ts`  |
+
+To add a PagerDuty field:
+
+1. Add and validate the provider field in `src/pagerduty.ts`.
+2. Add its `Schema.*` property and matching `Builder.*` value in the resource
+   file.
+3. Preserve the immutable primary keys and Incident-to-Service relation.
+4. Update this README and add tests for populated and missing values.
+
+### Local testing
+
+Run deterministic checks without contacting PagerDuty or Notion:
 
 ```sh
 npm run check
@@ -545,42 +216,19 @@ npm test
 npm run build
 ```
 
-With a safe test account and `.env` configured, inspect each live result before
-writing:
+To test locally against a safe PagerDuty account, use the gitignored environment
+file:
 
 ```sh
-ntn workers exec servicesSync --local
+cp .env.example .env
+# Add PAGERDUTY_API_TOKEN and any optional region or scope values to .env.
 ntn workers exec incidentsSync --local
-ntn workers sync trigger servicesSync --preview
-ntn workers sync trigger incidentsSync --preview
 ```
-
-The `workers exec --local` commands validate local wiring and one callback. For
-a complete deployed preview, follow the `nextContext` continuation loop from
-the Quickstart until `hasMore` is false.
-
-For live verification, confirm that names are resolved, removed upstream values
-clear their prior Notion properties, source and conference links open safely,
-the two-way Incident → Service relation resolves, and resolution duration agrees
-with the source timestamps.
-For services, confirm Response State matches PagerDuty, Primary On Call contains
-only current level-one responders, Primary Coverage reflects that level rather
-than every fallback, Coverage Checked matches the snapshot instant, and
-integrations and support hours match the service. Also confirm EU accounts use
-the EU host, all open incidents are present regardless of age, and Resolved
-history stops at the configured lookback.
-
-The offline suite cannot prove workspace permissions, API-key visibility, the
-current person on call, live conference access, or plan-specific fields such as
-priorities. A permission or completeness failure must stop the preview or sync;
-do not reinterpret it as an empty or healthy result.
 
 ## Learn more
 
 - [Notion sync guide](https://developers.notion.com/workers/guides/syncs)
-- [Notion secrets guide](https://developers.notion.com/workers/guides/secrets)
 - [PagerDuty REST API reference](https://developer.pagerduty.com/api-reference/)
-- [PagerDuty OpenAPI schema](https://github.com/PagerDuty/api-schema)
 - [PagerDuty API access keys](https://support.pagerduty.com/main/docs/api-access-keys)
 - [PagerDuty service regions](https://support.pagerduty.com/main/docs/service-regions)
 - [PagerDuty REST API rate limits](https://support.pagerduty.com/main/docs/rest-api-rate-limits)

--- a/workers/pagerduty-sync/README.md
+++ b/workers/pagerduty-sync/README.md
@@ -47,10 +47,10 @@ broader audience access to incident and on-call details.
 
 ## What you can answer
 
-| Managed database        | Questions it helps answer                                                                                                                                         |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **PagerDuty Incidents** | What needs attention now? Who owns the response? Which services are affected? What resolved recently, and which incidents may need follow-up?                     |
-| **PagerDuty Services**  | Which services are degraded or in maintenance? Where is primary on-call coverage missing? Who owns each service, and what routing and support arrangements apply? |
+| Managed database        | Questions it helps answer                                                                                                                                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PagerDuty Incidents** | Which high-urgency incidents still need acknowledgment, who is handling them, and which services are affected? Will an incident escalate, change urgency, or resolve automatically next—and when? Which services have the most recent incidents or longest resolution times? |
+| **PagerDuty Services**  | Which services are awaiting response, already responding, or in maintenance? Where is primary on-call coverage missing, and who is currently on call elsewhere? How do support hours, paging urgency, auto-resolution, and re-trigger timing differ by service?              |
 
 ## Reference
 

--- a/workers/postgres-query/README.md
+++ b/workers/postgres-query/README.md
@@ -1,6 +1,6 @@
 # Worker tool: Postgres query
 
-**TL;DR:** Connect a read-only slice of Postgres to a Notion agent so it can
+**TL;DR:** Connect a read-only slice of Postgres to a Notion Agent so it can
 discover your schema, write SQL, and answer data questions in the conversation.
 
 ## Quickstart

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -42,11 +42,11 @@ record; changes in Notion never update it.
 
 ## What you can answer
 
-| Managed database    | Questions it helps answer                                                                |
-| ------------------- | ---------------------------------------------------------------------------------------- |
-| **Sentry Issues**   | What is new, regressed, escalating, high-impact, unhandled, or missing an owner?         |
-| **Sentry Projects** | Which services carry unresolved risk, ownership gaps, or rising week-over-week activity? |
-| **Sentry Releases** | Are recent rollouts crash-free, broadly exercised, and reporting session health?         |
+| Managed database    | Questions it helps answer                                                                                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sentry Issues**   | What should we triage first among new, regressed, escalating, high-priority, and unhandled issues? Which unassigned issues have the most 24-hour events or 30-day affected users?                                             |
+| **Sentry Projects** | Which services have the largest unresolved or high-priority backlog, and what is each service's most active issue? Where is seven-day event volume rising, and which projects lack team ownership or session instrumentation? |
+| **Sentry Releases** | Which recent releases need investigation because crash-free session or user rates are low, new issues appeared, or health data is missing? Which rollouts have enough seven-day sessions and users to assess confidently?     |
 
 ## Reference
 

--- a/workers/sentry-sync/README.md
+++ b/workers/sentry-sync/README.md
@@ -1,29 +1,17 @@
 # Worker sync: Sentry
 
-Bring Sentry's operational signals into Notion so engineering, product, and
-support can coordinate reliability work without turning Notion into another
-error console. Out of the box, this Worker helps teams see what is breaking,
-which services carry the most unresolved risk, whether ownership gaps are
-growing, and how the newest releases are behaving.
-
-The example creates three complementary databases by default:
-
-- **Sentry Issues** keeps a rolling triage view current every 15 minutes.
-- **Sentry Projects** adds a daily service-level reliability summary to the
-  complete project inventory.
-- **Sentry Releases** combines the 100 newest releases with seven-day rollout
-  health every 15 minutes.
-
-All three are registered intentionally. It is easier to remove a database and
-its sync from a fork than to discover and wire up a valuable view later. There
-are no hidden enable flags, relations, invented health scores, or raw-event
-copies.
+Bring Sentry issue triage, project trends, and release health into Notion. The
+worker maintains three databases automatically: issues and releases refresh
+every 15 minutes, and projects refresh daily. Use them to coordinate reliability
+work without sending every collaborator into Sentry.
 
 ## Quickstart
 
 You need Node.js 22+, a Sentry organization, and an
 [internal integration token](#create-a-sentry-token) with `event:read`,
-`org:read`, and `project:releases`. From the repository root:
+`org:read`, and `project:releases`.
+
+From the repository root:
 
 ```sh
 npm install --global ntn
@@ -38,12 +26,8 @@ ntn workers env set \
   SENTRY_ENVIRONMENTS=production
 ```
 
-Apply the credentials and initial scope together before the first run so they
-are not saved as separate partial environment updates. Start with one or two
-production projects; replace `checkout-api` with a comma-separated list of
-Sentry project IDs or slugs.
-
-Create and populate all three databases:
+Schedules run automatically, without recurring CLI commands. To populate them
+immediately:
 
 ```sh
 ntn workers sync trigger issuesSync
@@ -51,394 +35,222 @@ ntn workers sync trigger projectsSync
 ntn workers sync trigger releasesSync
 ```
 
-After all three commands complete, the workspace contains managed databases
-named **Sentry Issues**, **Sentry Projects**, and **Sentry Releases**, populated
-with any records matching the configured scope. Subsequent runs update those
-databases on the schedules below.
+The worker copies issue-group, project, and release metadata plus aggregate
+sessions—not raw events or stack traces. Review the databases' Notion sharing
+settings before syncing production data broadly. Sentry remains the system of
+record; changes in Notion never update it.
 
 ## What you can answer
 
-| Question                                                      | Signals to use                                                          |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| What is breaking now?                                         | Issue status, priority, 24-hour events, 30-day users                    |
-| What is new, regressed, escalating, or unowned?               | Status detail, assignee, unhandled, last seen                           |
-| Which services carry the most current reliability burden?     | Unresolved issues, seven-day events, high-priority and lifecycle counts |
-| Is service activity rising compared with the prior week?      | Events (7d), Previous 7d Events, Event Change vs Prior 7d               |
-| Where are ownership and instrumentation gaps concentrated?    | Unassigned Unresolved (30d), Teams, Has Sessions                        |
-| Are the newest rollouts stable and broadly exercised?         | Crash-Free Sessions, Crash-Free Users, Sessions (7d), Users (7d)        |
-| Which releases introduced new issue groups or lack telemetry? | New Issues, Health Data (7d), First Event, Last Event                   |
-
-These are coordination views. Sentry remains the system of record for event
-details, investigation, alerting, and mutations.
+| Managed database    | Questions it helps answer                                                                |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| **Sentry Issues**   | What is new, regressed, escalating, high-impact, unhandled, or missing an owner?         |
+| **Sentry Projects** | Which services carry unresolved risk, ownership gaps, or rising week-over-week activity? |
+| **Sentry Releases** | Are recent rollouts crash-free, broadly exercised, and reporting session health?         |
 
 ## Reference
 
-### Databases and schedules
+### Synced databases and schedules
 
-| Database            | Sync           | Mode    | Schedule     | Membership                                                    |
-| ------------------- | -------------- | ------- | ------------ | ------------------------------------------------------------- |
-| **Sentry Issues**   | `issuesSync`   | replace | Every 15 min | Every issue status seen in the pinned prior 30 days           |
-| **Sentry Projects** | `projectsSync` | replace | Daily        | Visible projects, enriched from the pinned prior 30 days      |
-| **Sentry Releases** | `releasesSync` | replace | Every 15 min | The first 100 rows returned by the configured release request |
+| Database            | Sentry resource                    | Schedule     |
+| ------------------- | ---------------------------------- | ------------ |
+| **Sentry Issues**   | Issue groups seen in prior 30 days | Every 15 min |
+| **Sentry Projects** | Projects + issue-derived summaries | Every day    |
+| **Sentry Releases** | Newest 100 releases + health       | Every 15 min |
 
-`replace` means complete reconciliation. The Worker updates stable rows and
-removes rows absent from a completed refresh; it does not delete and recreate
-the database. A failed or partial multi-page refresh is not treated as a
-complete snapshot. Every returned row also emits explicit empty property values
-when a Sentry field disappears, so an earlier value cannot remain stale.
+#### Sentry Issues
 
-### Issue fields
+| Notion property | Sentry field or meaning                | Type     |
+| --------------- | -------------------------------------- | -------- |
+| Issue           | `title`                                | title    |
+| Status          | `status`                               | select   |
+| Status Detail   | `substatus`                            | select   |
+| Priority        | `priority`                             | select   |
+| Level           | `level`                                | select   |
+| Assignee        | `assignedTo.name`                      | richText |
+| Unhandled       | `isUnhandled`                          | checkbox |
+| Events (24h)    | Sum of 24-hour statistics              | number   |
+| Events (30d)    | 30-day query-window `count`            | number   |
+| Users (30d)     | 30-day query-window `userCount`        | number   |
+| Lifetime Events | `lifetime.count`                       | number   |
+| Lifetime Users  | `lifetime.userCount`                   | number   |
+| Project         | Project name or slug                   | select   |
+| Category        | `issueCategory`                        | select   |
+| Issue Type      | `issueType`                            | select   |
+| Platform        | Issue or project `platform`            | select   |
+| Culprit         | `culprit`                              | richText |
+| First Seen      | `firstSeen`                            | date     |
+| Last Seen       | `lastSeen`                             | date     |
+| Issue Key       | `shortId`                              | richText |
+| Issue Link      | `permalink`                            | url      |
+| Sentry Issue ID | Immutable `id`; the Notion primary key | richText |
 
-| Notion property | Sentry issue-group field               |
-| --------------- | -------------------------------------- |
-| Issue           | `title`                                |
-| Status          | `status`                               |
-| Assignee        | `assignedTo.name`                      |
-| Issue Link      | `permalink`                            |
-| Last Seen       | `lastSeen`                             |
-| Priority        | `priority`                             |
-| Status Detail   | `substatus`                            |
-| Level           | `level`                                |
-| Unhandled       | `isUnhandled`                          |
-| Events (24h)    | sum of `stats["24h"]`                  |
-| Events (30d)    | query-window `count`                   |
-| Users (30d)     | query-window `userCount`               |
-| Lifetime Events | `lifetime.count`                       |
-| Lifetime Users  | `lifetime.userCount`                   |
-| Project         | `project.name` or `project.slug`       |
-| Category        | `issueCategory`                        |
-| Issue Type      | `issueType`                            |
-| Platform        | issue or project `platform`            |
-| Culprit         | `culprit`                              |
-| First Seen      | `firstSeen`                            |
-| Issue Key       | `shortId` (for example, `CHECKOUT-42`) |
-| Sentry Issue ID | immutable `id`                         |
+The pinned 30-day query includes all statuses. Page bodies are bounded triage
+snapshots; missing nullable values are cleared after a complete refresh.
 
-The immutable Sentry issue ID is the primary key. Each page body contains a
-short, bounded triage snapshot assembled from these same group-level fields.
+#### Sentry Projects
 
-### Project fields
+| Notion property                | Sentry field or meaning                              | Type        |
+| ------------------------------ | ---------------------------------------------------- | ----------- |
+| Project                        | Project `name`                                       | title       |
+| Unresolved Issues (30d)        | Scoped unresolved issue count                        | number      |
+| High-Priority Unresolved (30d) | Scoped high-priority unresolved count                | number      |
+| New Unresolved (30d)           | Scoped new unresolved count                          | number      |
+| Regressed Unresolved (30d)     | Scoped regressed unresolved count                    | number      |
+| Escalating Unresolved (30d)    | Scoped escalating unresolved count                   | number      |
+| Unhandled Unresolved (30d)     | Scoped unhandled unresolved count                    | number      |
+| Unassigned Unresolved (30d)    | Scoped unassigned unresolved count                   | number      |
+| Events (7d)                    | Current seven-day issue-stat bucket                  | number      |
+| Previous 7d Events             | Previous seven-day issue-stat bucket                 | number      |
+| Event Change vs Prior 7d       | Difference between the two buckets                   | number      |
+| Issue Groups (30d)             | Scoped issue-group count                             | number      |
+| Events (30d)                   | Scoped event count                                   | number      |
+| Most Active Issue (7d)         | Issue with the highest current seven-day event count | richText    |
+| Issue Link                     | Link to the most active issue                        | url         |
+| Project Link                   | Direct Sentry project link                           | url         |
+| Last Seen                      | Latest scoped issue activity                         | date        |
+| Platform                       | Project or issue platform                            | select      |
+| Teams                          | Project teams                                        | multiSelect |
+| Has Sessions                   | Project session instrumentation                      | checkbox    |
+| First Event                    | Project `firstEvent`                                 | date        |
+| Environment Scope              | Configured environments                              | richText    |
+| As Of                          | Summary snapshot time                                | date        |
+| Project Slug                   | Project `slug`                                       | richText    |
+| Sentry Project ID              | Immutable `id`; the Notion primary key               | richText    |
 
-The project database combines Sentry's project inventory with aggregates from
-the complete issue scan. It includes:
+The daily sync joins visible projects to a scoped 30-day issue scan. Projects
+without recent issues show zeroes; incomplete statistics leave trend or event
+totals empty. User totals are omitted to avoid cross-group double counting.
 
-- unresolved, high-priority, new, regressed, escalating, unhandled, and
-  unassigned issue-group counts;
-- event volume in the current and previous seven-day windows, with the exact
-  change rather than a subjective score;
-- 30-day issue-group and event totals;
-- the most active issue in the current seven-day window and its source link;
-- last activity, team, platform, session-instrumentation, and first-event
-  context;
-- the environment scope used for every issue-derived aggregate.
+#### Sentry Releases
 
-The immutable project ID is the primary key. A project with no issue activity
-in the 30-day window still appears with zero issue counts. If any returned
-issue lacks 14-day statistics, the project row clears its seven-day totals and
-top issue rather than publishing an understated result. The same rule applies
-to an incomplete 30-day event count.
+| Notion property      | Sentry field or meaning                         | Type             |
+| -------------------- | ----------------------------------------------- | ---------------- |
+| Release              | `shortVersion` or `version`                     | title            |
+| Projects             | Release project metadata                        | multiSelect      |
+| Crash-Free Users     | Seven-day Release Health rate                   | number (percent) |
+| Crash-Free Sessions  | Seven-day Release Health rate                   | number (percent) |
+| New Issues           | Organization-release total                      | number           |
+| Status               | `status`                                        | select           |
+| Sessions (7d)        | Scoped Release Health sessions                  | number           |
+| Users (7d)           | Scoped Release Health users                     | number           |
+| Sentry Link          | Direct Sentry release link                      | url              |
+| Released At          | `dateReleased`                                  | date             |
+| Created At           | `dateCreated`                                   | date             |
+| Health Data (7d)     | Whether Sentry returned a matching health group | checkbox         |
+| Release URL          | Provider-supplied external URL                  | url              |
+| First Event          | `firstEvent`                                    | date             |
+| Last Event           | `lastEvent`                                     | date             |
+| Deploys              | Organization-release deploy count               | number           |
+| Commits              | Organization-release commit count               | number           |
+| Platforms            | Release platform metadata                       | multiSelect      |
+| Version              | Full release `version`                          | richText         |
+| Reference            | `ref`                                           | richText         |
+| Window Start         | Release Health window start                     | date             |
+| Window End           | Release Health window end                       | date             |
+| Health Project Scope | Configured projects                             | richText         |
+| Environment Scope    | Configured environments                         | richText         |
+| Sentry Release ID    | Immutable `id`; the Notion primary key          | richText         |
 
-There is deliberately no project-level affected-users total: one person can
-appear in several issue groups, so summing `userCount` would double-count them.
+The database contains the newest 100 organization releases in scope. Health is
+a separate scoped seven-day aggregate; other metadata remains organization
+level. Missing health stays empty, while explicit zeroes remain zero.
 
-### Release fields
-
-Each release row represents one Sentry organization release, keyed by its
-immutable release ID. The newest 100 releases contribute status, projects,
-dates, new issue groups, deploy and commit counts, platforms, version, a direct
-Sentry link, and the provider-supplied external release URL. One aggregate
-Release Health query adds:
-
-- crash-free session and user rates;
-- sessions and unique users in the returned seven-day window;
-- the exact rounded window Sentry evaluated;
-- the configured project and environment scope used for health.
-
-Sentry reports crash-free rates as percentage points; the transform converts
-them to Notion's percent-property representation without changing their
-meaning. A release without session telemetry still gets a metadata row.
-Absent health values remain empty—never stale, `0`, `100%`, or an invented
-“Healthy” status. Explicit zeroes from Sentry remain zero.
-
-`New Issues`, deploys, and commits remain organization-release values. Projects
-lists every project Sentry associates with the release, while health metrics
-are aggregated only over the explicit **Health Project Scope** and
-**Environment Scope**. Keeping both scopes visible prevents a shared release
-from implying that scoped health covers every listed project. The base example
-avoids duplicated rows with misleading per-project copies of release-level
-metrics.
-
-## Suggested Notion views
-
-- **Active triage:** Status is Unresolved; sort by Priority, Events (24h), and
-  Users (30d).
-- **New and regressed:** Status Detail is New, Regressed, or Escalating; sort
-  by Last Seen descending.
-- **Needs an owner:** Status is Unresolved and Assignee is empty; sort by
-  Unhandled, Priority, and Events (24h).
-- **Services needing attention:** sort projects by Unresolved Issues (30d),
-  Events (7d), Event Change vs Prior 7d, and Unassigned Unresolved (30d).
-- **Regression concentration:** sort projects by Regressed Unresolved (30d)
-  and High-Priority Unresolved (30d); group by Team or Platform.
-- **Rollout watch:** sort releases by Released At descending, then Crash-Free
-  Sessions and Sessions (7d).
-- **Missing release telemetry:** filter Health Data (7d) unchecked. Empty means
-  a successful Sentry response returned no matching health row or no session
-  telemetry exists for that release and scope.
-
-## How it works
-
-### Contract boundary
-
-All provider calls use the four public Sentry REST endpoints linked below and
-only parameters documented for those endpoints. The example does not use
-Sentry alpha, early-access, internal, or undocumented APIs. Sentry's `/api/0`
-path is its documented public REST namespace, not an API maturity label.
-
-On the Notion side, the example imports only public exports documented for
-`@notionhq/workers`; it does not import SDK internals. The current Notion CLI
-labels Workers as Beta, which is a platform-level constraint shared by Worker
-examples rather than a hidden dependency of this integration. The conservative
-continuation-state budget and explicit property clearing reflect current
-Workers runtime behavior and should be revalidated when upgrading the Beta SDK.
-
-### Rolling issue triage
-
-The Worker calls Sentry's current organization issue-search endpoint with an
-explicit empty `query=`. Sentry otherwise defaults the endpoint to unresolved
-issues, while this example needs recently active resolved and ignored groups
-for review as well. The first page pins an exact 30-day `start` and `end`, base
-URL, organization, and filters. Each request reads the currently configured
-token so routine rotation cannot strand an in-progress refresh.
-
-Every page requests 100 groups and 24-hour group statistics. Sentry's `Link`
-header is authoritative: the Worker continues only when the one trusted
-`rel="next"` entry declares `results="true"`. Missing or malformed links,
-untrusted origins/paths, duplicate next links, and repeated recent cursors fail
-closed. Cursor fingerprints use a fixed-size history so long traversals do not
-grow continuation state or introduce an artificial page limit.
-
-### Service-level reliability
-
-The daily project refresh has two phases:
-
-1. Scan the same pinned 30-day issue scope with 14-day statistics and keep only
-   compact per-project counters in serializable state.
-2. Page through the organization project inventory and enrich each project
-   with those aggregates.
-
-Configured project IDs or slugs are applied to issue search and locally to the
-project inventory; configured environments scope the issue-derived signals.
-Projects with no matching issues still appear. An issue aggregate whose
-project was deleted or became inaccessible is retained using the issue's
-project metadata so risk does not disappear silently.
-
-Continuation state remains below Workers' 256 KiB runtime limit, with reserved
-headroom for compact cursor history and a secondary cap of 500 active projects.
-Metadata length varies, so the serialized-state budget can be reached first.
-If either aggregation boundary is reached, the Worker checkpoints before any
-project rows are written and asks for a narrower project or environment scope.
-After the configured scope changes, it automatically restarts from a fresh
-window instead of retrying an unrecoverable oversized state. During project
-inventory pagination, emitted aggregates are removed so continuation state
-shrinks while rows are written.
-
-Apply the narrower scope with `ntn workers env set`, then rerun
-`ntn workers sync trigger projectsSync`. No sync-state reset is required.
-
-### Recent rollout health
-
-The release refresh deliberately requests the maximum 100 releases from
-Sentry's documented most-recent-first organization endpoint, so this is an
-explicit useful set rather than accidental pagination truncation. The Worker
-uses only the endpoint's documented project and environment filters. The
-separate Release Health query applies the same explicit project and environment
-scope shown in Notion.
-
-One additional sessions request groups the prior seven days by release across
-the configured project and environment scope, requests totals without
-time-series payloads, and orders by session volume. This avoids per-release
-detail calls. The Worker requests at most 250 groups and fails if Sentry reaches
-that boundary, because treating a potentially capped result as complete could
-remove valid rows or omit health. With four fields and seven daily buckets,
-that conservative request also remains below Sentry's documented
-10,000-data-point constraint even if the service computes series before
-omitting them from the response.
-
-A successful empty health result is valid and clears unavailable metrics. API
-errors, including 404s, remain visible failures rather than being interpreted
-as absent telemetry. Because the release sync uses replacement semantics, a
-failed health request does not publish a partial snapshot or clear previously
-valid rows.
-
-### Rate limits and request safety
-
-All three syncs share a conservative 60-request-per-minute pacer. Sentry uses
-caller- and endpoint-specific quotas instead of publishing one universal
-limit. On HTTP 429, the Worker passes usable `Retry-After` and
-`X-Sentry-Rate-Limit-Reset` delays to the Workers runtime.
-
-Requests have a 30-second timeout, reject redirects, and send the bearer token
-only to a validated HTTPS base URL. Loopback HTTP is allowed for local testing.
-Authentication and authorization errors remain visible rather than being
-reinterpreted as empty provider data.
-
-## Sentry access and configuration
-
-### Create a Sentry token
-
-Prefer an organization **internal integration** for a deployed Worker:
-
-“Internal integration” is Sentry's name for an organization-owned credential;
-it does not mean this example calls an internal or alpha API.
-
-1. Open **Organization Settings > Developer Settings > Internal
-   Integrations**.
-2. Create an integration dedicated to this Worker.
-3. Grant `event:read` for issue groups, `org:read` for projects and aggregate
-   Release Health, and `project:releases` for release metadata.
-4. Store the token only with `ntn workers env set`.
-
-A broader `project:read` permission also authorizes release listing, but
-`project:releases` is the narrower purpose-specific choice. A personal token is
-convenient for testing but follows that user's access and lifecycle.
-
-### Environment variables
-
-| Variable              | Required | Description                                                                           |
-| --------------------- | -------- | ------------------------------------------------------------------------------------- |
-| `SENTRY_AUTH_TOKEN`   | Yes      | Bearer token with `event:read`, `org:read`, and `project:releases`                    |
-| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                 |
-| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; scopes issues, projects, releases, and health   |
-| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environments; scopes issues, project aggregates, releases, and health |
-| `SENTRY_BASE_URL`     | No       | HTTPS root for self-hosted Sentry; defaults to `https://sentry.io`, without API path  |
-
-For self-hosted Sentry:
-
-```sh
-ntn workers env set SENTRY_BASE_URL=https://sentry.example.com
-```
-
-Self-hosted versions can lag Sentry SaaS. Optional fields and unknown future
-enum values are tolerated; missing identity, pagination, and completeness
-contracts fail visibly.
-
-## Privacy and operational boundaries
-
-The Worker requests issue-group metadata, project metadata, release metadata,
-and aggregate session totals. It does not request raw events, stack traces,
-breadcrumbs, request bodies, headers, query strings, tags, attachments, event
-users, IP addresses, or event contexts. Sentry's standard release response can
-contain owners, release authors, and commit-author metadata; the parser
-discards those fields immediately and never persists them in Notion or sync
-state. The issue parser retains an assignee display name but likewise discards
-email and other unselected response fields.
-
-Issue titles, culprits, project names, and release versions can still contain
-customer, code, or infrastructure details. Review Sentry's data-scrubbing
-settings and the Notion databases' sharing permissions before syncing
-production data broadly.
-
-This is a one-way mirror. Changes in Notion do not update Sentry.
-
-## Project structure
+### Project structure
 
 ```text
 src/
-├── index.ts      — registers all databases, schedules, phases, and shared pacer
-├── sentry.ts     — REST client, response validation, pagination, and rate limits
-├── sync-state.ts — pinned windows, cursor safeguards, and continuation limits
+├── index.ts      — databases, schedules, and sync phases
+├── sentry.ts     — REST client, response validation, and pagination
+├── sync-state.ts — pinned windows and continuation safety
 ├── issues.ts     — issue schema and triage transform
-├── projects.ts   — project schema and truthful issue aggregation
+├── projects.ts   — project schema and issue aggregation
 ├── releases.ts   — release schema and aggregate health merge
-└── helpers.ts    — bounded labels, safe values, statistics, and summaries
+└── helpers.ts    — bounded values, statistics, and summaries
 ```
 
-## Local validation
+### How it works
 
-All tests are offline and mock `fetch`; they do not need a Sentry token:
+1. Every 15 minutes, issues scans all statuses in a pinned 30-day window and
+   follows pagination to completion.
+2. Daily, projects aggregates current and prior seven-day events, then enriches
+   the inventory. Recent issue data for an inaccessible project is retained.
+3. Every 15 minutes, releases fetches the newest 100 releases and one aggregate
+   seven-day health response, with no per-release requests.
+4. Filters remain fixed for a complete refresh; changes apply next cycle.
+5. Immutable IDs update rows. Complete replacement removes records that leave
+   the defined membership and clears properties that disappear upstream.
+
+### Sentry access and credentials
+
+#### Create a Sentry token
+
+Create an organization-owned internal integration for a deployed worker:
+
+1. Open **Organization Settings > Developer Settings > Internal
+   Integrations**.
+2. Create an integration dedicated to this worker.
+3. Grant `event:read`, `org:read`, and `project:releases`.
+4. Store the token with `ntn workers env set`.
+
+“Internal integration” is Sentry's credential name. `project:read` also permits
+release listing, but `project:releases` is narrower. A personal test token
+follows that user's access and lifecycle.
+
+### Configuration reference
+
+| Variable              | Required | Description                                                                           |
+| --------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `SENTRY_AUTH_TOKEN`   | Yes      | Token with `event:read`, `org:read`, and `project:releases`                           |
+| `SENTRY_ORG_SLUG`     | Yes      | Organization slug from the Sentry URL                                                 |
+| `SENTRY_PROJECTS`     | No       | Comma-separated project IDs or slugs; scopes every database                           |
+| `SENTRY_ENVIRONMENTS` | No       | Comma-separated environments; scopes issues, project aggregates, releases, and health |
+| `SENTRY_BASE_URL`     | No       | Self-hosted Sentry root; defaults to `https://sentry.io` and must omit `/api/0`       |
+
+No `NOTION_API_TOKEN` is needed. Self-hosted Sentry must use HTTPS, except for a
+loopback development server, and its root must not include `/api/0`.
+
+Large organizations should start with `SENTRY_PROJECTS` or
+`SENTRY_ENVIRONMENTS`. Project summaries support up to 500 active projects;
+Release Health supports one page of fewer than 250 groups.
+
+### Adapting the schema
+
+Schemas and transforms live in `src/issues.ts`, `src/projects.ts`, and
+`src/releases.ts`. To add a field:
+
+1. Add the narrow response type and runtime parser in `src/sentry.ts`.
+2. Add the property to the resource schema and transform.
+3. Emit the empty property value when nullable upstream data disappears.
+4. Update this README and add transform tests.
+
+### Local testing
+
+Run the offline checks; mocked requests need no Sentry credentials:
 
 ```sh
-cd workers/sentry-sync
-npm install
 npm run check
 npm test
 npm run build
 ```
 
-For live verification without writing to Notion, copy `.env.example` to `.env`,
-add credentials for a small test project, and run:
+For a live read-only preview, copy `.env.example` to `.env`, add a small scope,
+and run:
 
 ```sh
 ntn workers sync trigger issuesSync --local --preview
-ntn workers sync trigger projectsSync --local --preview
-ntn workers sync trigger releasesSync --local --preview
 ```
 
-Keep generated and machine-local files out of commits. `.env`, `workers.json`,
-`workers.*.json`, `package-lock.json`, `dist/`, and `node_modules/` are
-gitignored; `.env.example` is the tracked configuration template. A test
-deployment does not require committing its generated Worker configuration.
+Substitute `projectsSync` or `releasesSync` to preview the other databases.
 
-Confirm that recently active resolved and unresolved issues appear; project
-totals match the scoped issue set; current/prior seven-day buckets line up with
-Sentry; newest releases remain one row each with project context; and a
-successful health response without a matching release group clears prior
-metrics rather than retaining stale values or creating false zeroes.
+## Learn more
 
-## Customizing the default set
-
-To remove a database from a fork, delete its `worker.database(...)` and
-`worker.sync(...)` blocks from `src/index.ts`, then remove its schema module if
-unused. No environment flag is required. This stops future management but does
-not trash a database created by an earlier deployment; archive or trash that
-database manually in Notion after confirming its contents are no longer needed.
-
-### Safe extension contract
-
-Follow the complete path for every field or resource rather than editing only
-the visible schema:
-
-1. **Provider contract:** add the narrow response type and runtime parser in
-   `src/sentry.ts`. Build URLs from the validated Sentry base, validate provider
-   pagination with `nextCursorFromLink`, and route every request through
-   `fetchSentryJson` so timeout, redirect, authentication, rate-limit, and
-   response checks remain consistent. Retain only fields the database actually
-   uses.
-2. **Database contract:** update the schema and transform together in
-   `src/issues.ts`, `src/projects.ts`, or `src/releases.ts`. Every upsert must
-   emit every declared schema property; emit the empty property value (`[]`)
-   when an upstream nullable value disappears so Notion clears stale data. Use
-   an immutable provider ID as the primary key.
-3. **Lifecycle contract:** register a new database, sync, and schedule in
-   `src/index.ts`. Pin the time window and `SentryScope` for the full refresh,
-   validate cursor traversal with `nextCursorTraversal`, and enforce the
-   continuation limits in `src/sync-state.ts`. If state can grow before any
-   rows are emitted, prefer a small recoverable checkpoint like the projects
-   sync rather than stranding an oversized continuation.
-4. **Completeness contract:** exhaustive syncs must follow trusted pagination
-   until a terminal `hasMore: false`; never silently stop and call a partial
-   result complete. If a deliberately bounded snapshot is more useful, as with
-   the newest 100 releases, make the limit part of its membership definition
-   and document it.
-5. **Verification contract:** add complete, minimal, populated-to-missing,
-   explicit-zero, unknown-enum, privacy, cursor, rate-limit, and boundary tests
-   in `test.ts`. Then run the offline checks and exercise the changed endpoint
-   against a small real Sentry scope before deployment.
-
-Keep raw event data out of this base example. A webhook-driven fork can improve
-issue freshness while the full refresh remains reconciliation.
-
-## Official documentation
-
-- [List an organization's issues](https://docs.sentry.io/api/events/list-an-organizations-issues/)
-- [List an organization's projects](https://docs.sentry.io/api/organizations/list-an-organizations-projects/)
-- [List an organization's releases](https://docs.sentry.io/api/releases/list-an-organizations-releases/)
-- [Retrieve Release Health session statistics](https://docs.sentry.io/api/releases/retrieve-release-health-session-statistics/)
+- [Sentry issues API](https://docs.sentry.io/api/events/list-an-organizations-issues/)
+- [Sentry projects API](https://docs.sentry.io/api/organizations/list-an-organizations-projects/)
+- [Sentry releases API](https://docs.sentry.io/api/releases/list-an-organizations-releases/)
+- [Sentry Release Health API](https://docs.sentry.io/api/releases/retrieve-release-health-session-statistics/)
+- [Sentry authentication and permissions](https://docs.sentry.io/api/auth/)
 - [Sentry pagination](https://docs.sentry.io/api/pagination/)
 - [Sentry rate limits](https://docs.sentry.io/api/ratelimits/)
-- [Sentry authentication and permissions](https://docs.sentry.io/api/auth/)
-- [Sentry data scrubbing](https://docs.sentry.io/security-legal-pii/scrubbing/)
-- [Notion Workers overview](https://developers.notion.com/workers/get-started/overview)
-- [Workers SDK reference](https://developers.notion.com/workers/reference/sdk)
-- [Workers sync guide](https://developers.notion.com/workers/guides/syncs)
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Contributing guide](../../CONTRIBUTING.md)

--- a/workers/snowflake-query/README.md
+++ b/workers/snowflake-query/README.md
@@ -1,6 +1,6 @@
 # Worker tool: Snowflake query
 
-**TL;DR:** Connect a read-only slice of Snowflake to a Notion agent so it can
+**TL;DR:** Connect a read-only slice of Snowflake to a Notion Agent so it can
 discover warehouse tables, write SQL, and answer data questions in the
 conversation.
 

--- a/workers/sqlite-query/README.md
+++ b/workers/sqlite-query/README.md
@@ -1,6 +1,6 @@
 # Worker tool: SQLite query
 
-**TL;DR:** Give a Notion agent an instant, zero-configuration SQL sandbox with
+**TL;DR:** Give a Notion Agent an instant, zero-configuration SQL sandbox with
 sample sales data. It is ideal for demos, onboarding, and learning how agents
 discover tables and answer questions with SQLite.
 


### PR DESCRIPTION
## Summary

- align the Intercom, PagerDuty, and Sentry guides with the GitHub and HubSpot recipe structure and tone
- keep setup value-first, retain useful per-database field references, and link to external docs for deeper API behavior
- sharpen each What you can answer section around concrete decisions supported by synced fields
- replace manual Intercom conversation and ticket reconciliation with automatic daily full refreshes
- move the existing Quickstarts directly after What do you want to build and place the unchanged coding-agent guidance first
- standardize the Notion Agent product name across repository documentation
- update the Intercom manifest test and catalog summary for the new cadence

## Testing

- `npm run verify:all`
- `npm run lint:markdown`
- `npm run format:check`
- `npm run catalog:validate`
- `git diff --check`