### PR TITLE
Improve Zendesk sync data integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ and a **webhook** handles events from another service. See the complete
 | Sync accounts and opportunities                             | [Salesforce sync](workers/salesforce-sync/) | Salesforce |
 | Coordinate issue triage, service risk, and rollout health   | [Sentry sync](workers/sentry-sync/)         | Sentry     |
 | Sync the result of a warehouse query                        | [Snowflake sync](workers/snowflake-sync/)   | Snowflake  |
-| Sync tickets, users, organizations, and support metrics     | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
+| Sync related tickets, users, organizations, and metrics     | [Zendesk sync](workers/zendesk-sync/)       | Zendesk    |
 
 ### Add tools to a Notion Agent
 

--- a/catalog.json
+++ b/catalog.json
@@ -483,7 +483,7 @@
     {
       "id": "zendesk-sync",
       "title": "Zendesk sync",
-      "summary": "Sync Zendesk tickets, organizations, users, CSAT responses, ticket metrics, and SLA policies into managed Notion databases.",
+      "summary": "Sync Zendesk tickets, organizations, users, CSAT responses, ticket metrics, and SLA policies into related managed Notion databases with incremental updates and manual repair sweeps.",
       "path": "workers/zendesk-sync",
       "kind": "worker-sync",
       "status": "ready",

--- a/workers/README.md
+++ b/workers/README.md
@@ -1,7 +1,9 @@
 # Notion Worker examples
+
 [Notion Workers](https://developers.notion.com/docs/workers) are server-side extensions deployed to Notion. Each direct child of this directory is an independently executable and deployable Worker.
 
 There are 3 different type of Worker capabilties:
+
 - A **sync** imports external records into a managed Notion database on a
   schedule or on demand.
 - An **agent tool** lets a Notion Agent query context or execute a repeatable API workflow
@@ -24,7 +26,7 @@ For self-hosted integrations built directly with the Notion API, see the [API ex
 | [Salesforce sync](salesforce-sync/) | Salesforce accounts and opportunities, with related account context.                                                   |
 | [Sentry sync](sentry-sync/)         | Issue triage, project reliability trends, and recent release health for cross-functional follow-up.                    |
 | [Snowflake sync](snowflake-sync/)   | Rows returned by a configurable Snowflake query.                                                                       |
-| [Zendesk sync](zendesk-sync/)       | Tickets, organizations, users, CSAT responses, ticket metrics, and SLA policies.                                       |
+| [Zendesk sync](zendesk-sync/)       | Related tickets, organizations, users, CSAT responses, metrics, and SLA policies with manual repair sweeps.            |
 
 ## Agent tools
 

--- a/workers/zendesk-sync/README.md
+++ b/workers/zendesk-sync/README.md
@@ -339,6 +339,12 @@ a cross-capability lock to this Worker, so automatically overlapping a full
 sweep with a five-minute cursor would make deletion safety depend on
 undocumented scheduling behavior.
 
+Run the repair procedure below once immediately after upgrading an existing
+deployment. Notion preserves incremental sync state across deploys, so unchanged
+historical tickets and metrics will not otherwise revisit the new relation
+properties or nullable-field clearing behavior. New deployments populate those
+values during their initial backfill.
+
 Before a repair, pause both scheduled incremental capabilities and wait for any
 in-flight runs to finish. Then reset and trigger the replacement sweeps. Resume
 incremental updates only after both repairs report completion in `sync status`:

--- a/workers/zendesk-sync/README.md
+++ b/workers/zendesk-sync/README.md
@@ -2,8 +2,8 @@
 
 Bring your support operation into Notion so teams and agents can investigate
 queue health, customer feedback, response performance, and SLA targets without
-leaving the workspace. One deploy creates six managed databases and keeps them
-updated from Zendesk automatically.
+leaving the workspace. One deploy creates six connected managed databases and
+keeps them updated from Zendesk automatically.
 
 You do not need to build the Notion databases or supply a Notion API token. The
 worker declares their schemas, and Notion creates and manages them for you.
@@ -33,15 +33,19 @@ ntn workers env set ZENDESK_API_TOKEN=your-api-token
 ntn workers env set ZENDESK_API_USER_EMAIL=agent@example.com
 ```
 
-Preview the ticket sync without changing Notion, then run it:
+Preview the ticket sync without changing Notion. Then populate Organizations
+and Users before Tickets so the first ticket pass can resolve its relation
+targets:
 
 ```sh
 ntn workers sync trigger ticketsSync --preview
+ntn workers sync trigger organizationsSync
+ntn workers sync trigger usersSync
 ntn workers sync trigger ticketsSync
 ```
 
-The real run populates **Support Tickets**. The other five databases populate
-on their schedules, or you can [trigger them manually](#triggering-syncs-manually).
+The other three databases populate on their schedules, or you can
+[trigger them manually](#triggering-syncs-manually).
 
 These databases can contain ticket descriptions, organization notes, user
 emails and phone numbers, and CSAT feedback. Review their Notion sharing
@@ -62,48 +66,52 @@ settings before giving a broader audience access.
 
 ### Zendesk plan compatibility
 
-To run all six syncs as written, use Zendesk Support Professional or higher, or
-Zendesk Suite Growth or higher, with the updated CSAT experience enabled and an
-admin API user with API token access. Accounts that do not meet this
-configuration can still use the core ticket, organization, user, and
+To populate all six databases as written, use Zendesk Support Professional or
+higher, or Zendesk Suite Growth or higher, with the updated CSAT experience
+enabled and an admin API user with API token access. Accounts that do not meet
+this configuration can still use the core ticket, organization, user, and
 ticket-metric syncs after removing the CSAT and SLA sync registrations.
 
 ### Synced databases
 
-| Database                          | Zendesk resource           | Schedule    | Plan                                 |
-| --------------------------------- | -------------------------- | ----------- | ------------------------------------ |
-| **Support Tickets**               | Tickets                    | Every 5 min | All                                  |
-| **Zendesk Organizations**         | Organizations              | Every 5 min | All                                  |
-| **Zendesk Users**                 | Users (agents + end-users) | Every 5 min | All                                  |
-| **Zendesk CSAT Survey Responses** | CSAT Survey Responses      | Daily       | Support Professional / Suite Growth+ |
-| **Zendesk Ticket Metrics**        | Ticket Metrics             | Every 5 min | All                                  |
-| **Zendesk SLA Policies**          | SLA Policies               | Daily       | Support Professional / Suite Growth+ |
+| Database                          | Zendesk resource           | Schedule                    | Plan                                 |
+| --------------------------------- | -------------------------- | --------------------------- | ------------------------------------ |
+| **Support Tickets**               | Tickets                    | Every 5 min + manual repair | All                                  |
+| **Zendesk Organizations**         | Organizations              | Every 5 min                 | All                                  |
+| **Zendesk Users**                 | Users (agents + end-users) | Every 5 min                 | All                                  |
+| **Zendesk CSAT Survey Responses** | CSAT Survey Responses      | Daily                       | Support Professional / Suite Growth+ |
+| **Zendesk Ticket Metrics**        | Ticket Metrics             | Every 5 min + manual repair | All                                  |
+| **Zendesk SLA Policies**          | SLA Policies               | Daily                       | Support Professional / Suite Growth+ |
 
 #### Support Tickets
 
-| Notion property | Zendesk field             | Type        |
-| --------------- | ------------------------- | ----------- |
-| Subject         | `subject`                 | title       |
-| Status          | `status`                  | select      |
-| Priority        | `priority`                | select      |
-| Assignee        | agent name (resolved)     | richText    |
-| Group           | group name (resolved)     | richText    |
-| Ticket link     | clickable link to ticket  | url         |
-| Updated at      | `updated_at`              | date        |
-| Requester       | requester name (resolved) | richText    |
-| Organization    | org name (resolved)       | richText    |
-| Type            | `type`                    | select      |
-| Channel         | `via.channel`             | select      |
-| Tags            | `tags`                    | multiSelect |
-| Created at      | `created_at`              | date        |
-| Ticket ID       | `id`                      | richText    |
+| Notion property     | Zendesk field             | Type        |
+| ------------------- | ------------------------- | ----------- |
+| Subject             | `subject`                 | title       |
+| Status              | `status`                  | select      |
+| Priority            | `priority`                | select      |
+| Assignee            | agent name (resolved)     | richText    |
+| Assignee Record     | `assignee_id`             | relation    |
+| Group               | group name (resolved)     | richText    |
+| Ticket link         | clickable link to ticket  | url         |
+| Updated at          | `updated_at`              | date        |
+| Requester           | requester name (resolved) | richText    |
+| Requester Record    | `requester_id`            | relation    |
+| Organization        | org name (resolved)       | richText    |
+| Organization Record | `organization_id`         | relation    |
+| Type                | `type`                    | select      |
+| Channel             | `via.channel`             | select      |
+| Tags                | `tags`                    | multiSelect |
+| Created at          | `created_at`              | date        |
+| Ticket ID           | `id`                      | richText    |
 
 Each page body contains the ticket description. Assignee, requester, group,
 and organization show real names (resolved via Zendesk's
 [sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/),
-with no extra API calls). The incremental export includes archived tickets and
-uses `support_type_scope=all`, so both human-agent and AI-agent tickets are
-included.
+with no extra API calls). The matching relation columns link to stable User and
+Organization records without replacing the readable names. The incremental
+export includes archived tickets and uses `support_type_scope=all`, so both
+human-agent and AI-agent tickets are included.
 
 #### Zendesk Organizations
 
@@ -121,37 +129,40 @@ Page body contains the organization's `notes` field.
 
 #### Zendesk Users
 
-| Notion property | Zendesk field     | Type        |
-| --------------- | ----------------- | ----------- |
-| Name            | `name`            | title       |
-| Role            | `role`            | select      |
-| Email           | `email`           | email       |
-| Last login      | `last_login_at`   | date        |
-| Tags            | `tags`            | multiSelect |
-| Updated at      | `updated_at`      | date        |
-| Organization ID | `organization_id` | richText    |
-| Phone           | `phone`           | richText    |
-| Suspended       | `suspended`       | checkbox    |
-| User ID         | `id`              | richText    |
-| Created at      | `created_at`      | date        |
+| Notion property     | Zendesk field     | Type        |
+| ------------------- | ----------------- | ----------- |
+| Name                | `name`            | title       |
+| Role                | `role`            | select      |
+| Email               | `email`           | email       |
+| Last login          | `last_login_at`   | date        |
+| Tags                | `tags`            | multiSelect |
+| Updated at          | `updated_at`      | date        |
+| Organization ID     | `organization_id` | richText    |
+| Organization Record | `organization_id` | relation    |
+| Phone               | `phone`           | richText    |
+| Suspended           | `suspended`       | checkbox    |
+| User ID             | `id`              | richText    |
+| Created at          | `created_at`      | date        |
 
 #### Zendesk CSAT Survey Responses
 
-| Notion property | Zendesk field                               | Type     |
-| --------------- | ------------------------------------------- | -------- |
-| Response        | ticket ID or response ID (derived)          | title    |
-| Rating          | customer-satisfaction `rating_scale` answer | number   |
-| Rating category | `rating_category`                           | select   |
-| Feedback        | non-empty `open_ended` answers              | richText |
-| Subject         | `subjects[0].zrn`                           | richText |
-| Ticket ID       | ticket subject `id`                         | richText |
-| Responder ID    | `responder_id`                              | richText |
-| Survey ID       | `survey.id`                                 | richText |
-| Survey version  | `survey.version`                            | number   |
-| Survey state    | `survey.state`                              | select   |
-| Updated at      | latest answer `updated_at`                  | date     |
-| Expires at      | `expires_at`                                | date     |
-| Response ID     | `id`                                        | richText |
+| Notion property  | Zendesk field                               | Type     |
+| ---------------- | ------------------------------------------- | -------- |
+| Response         | ticket ID or response ID (derived)          | title    |
+| Rating           | customer-satisfaction `rating_scale` answer | number   |
+| Rating category  | `rating_category`                           | select   |
+| Feedback         | non-empty `open_ended` answers              | richText |
+| Subject          | `subjects[0].zrn`                           | richText |
+| Ticket ID        | ticket subject `id`                         | richText |
+| Ticket Record    | ticket subject `id`                         | relation |
+| Responder ID     | `responder_id`                              | richText |
+| Responder Record | `responder_id`                              | relation |
+| Survey ID        | `survey.id`                                 | richText |
+| Survey version   | `survey.version`                            | number   |
+| Survey state     | `survey.state`                              | select   |
+| Updated at       | latest answer `updated_at`                  | date     |
+| Expires at       | `expires_at`                                | date     |
+| Response ID      | `id`                                        | richText |
 
 This database uses Zendesk's current CSAT Survey Responses API. Open-ended
 feedback is also copied into the page body. It uses a daily replace sweep so
@@ -159,22 +170,23 @@ answers edited after the response was first offered are refreshed correctly.
 
 #### Zendesk Ticket Metrics
 
-| Notion property        | Zendesk field                         | Type   |
-| ---------------------- | ------------------------------------- | ------ |
-| Ticket ID              | `ticket_id`                           | title  |
-| First Reply (min)      | `reply_time_in_minutes.calendar`      | number |
-| Full Resolution (min)  | `full_resolution_time_in_minutes`     | number |
-| Reopens                | `reopens`                             | number |
-| Agents Touched         | `assignee_stations`                   | number |
-| Groups Touched         | `group_stations`                      | number |
-| Solved at              | `solved_at`                           | date   |
-| First Resolution (min) | `first_resolution_time_in_minutes`    | number |
-| Replies                | `replies`                             | number |
-| On Hold (min)          | `on_hold_time_in_minutes.calendar`    | number |
-| Agent Wait (min)       | `agent_wait_time_in_minutes.calendar` | number |
-| Requester Wait (min)   | `requester_wait_time_in_minutes`      | number |
-| Updated at             | `updated_at`                          | date   |
-| Created at             | `created_at`                          | date   |
+| Notion property        | Zendesk field                         | Type     |
+| ---------------------- | ------------------------------------- | -------- |
+| Ticket ID              | `ticket_id`                           | title    |
+| Ticket Record          | `ticket_id`                           | relation |
+| First Reply (min)      | `reply_time_in_minutes.calendar`      | number   |
+| Full Resolution (min)  | `full_resolution_time_in_minutes`     | number   |
+| Reopens                | `reopens`                             | number   |
+| Agents Touched         | `assignee_stations`                   | number   |
+| Groups Touched         | `group_stations`                      | number   |
+| Solved at              | `solved_at`                           | date     |
+| First Resolution (min) | `first_resolution_time_in_minutes`    | number   |
+| Replies                | `replies`                             | number   |
+| On Hold (min)          | `on_hold_time_in_minutes.calendar`    | number   |
+| Agent Wait (min)       | `agent_wait_time_in_minutes.calendar` | number   |
+| Requester Wait (min)   | `requester_wait_time_in_minutes`      | number   |
+| Updated at             | `updated_at`                          | date     |
+| Created at             | `created_at`                          | date     |
 
 Times use calendar minutes by default. To switch to business hours, change
 `.calendar` to `.business` in `src/ticket-metrics.ts`.
@@ -201,6 +213,29 @@ SLA targets are flattened from the `policy_metrics` array into individual
 columns by priority level, so managers can compare targets at a glance.
 Page body contains the policy description.
 
+### Connected records and clearing behavior
+
+Relations use immutable Zendesk IDs, while the existing name and ID columns
+remain available for search, export, and troubleshooting:
+
+- Tickets relate to their assignee and requester in **Zendesk Users**, and to
+  their organization in **Zendesk Organizations**.
+- Users relate to their organization.
+- CSAT responses relate to their ticket and responder.
+- Ticket metrics relate to their ticket.
+
+These are two-way relations. **Zendesk Users** receives **Assigned Tickets**,
+**Requested Tickets**, and **CSAT Responses** backlinks. **Zendesk
+Organizations** receives **Tickets** and **Users**, while **Support Tickets**
+receives **CSAT Responses** and **Ticket Metrics**. SLA policies remain
+standalone because the synced ticket payload does not provide a reliable policy
+foreign key.
+
+Every transform emits every declared property. When Zendesk changes a nullable
+field from populated to empty, the worker sends an explicit empty value so the
+old Notion value is cleared. The same rule applies to CSAT feedback in the page
+body.
+
 ### Project structure
 
 ```text
@@ -219,24 +254,38 @@ src/
 ### How it works
 
 1. Tickets and ticket metrics use Zendesk's cursor-based Incremental Ticket
-   Export. The first run starts at Unix time `1` to backfill retained history;
-   later runs continue from the persisted `after_cursor`.
-2. The export includes archived records. Deleted ticket records become explicit
-   Notion delete changes before their scrubbed fields are transformed.
-3. Organizations and users use cursor-paginated list endpoints with 100 records
+   Export every five minutes. The first run starts at Unix time `1` to backfill
+   retained history; later runs continue from the persisted `after_cursor`.
+2. The incremental export includes archived records. Deleted ticket records
+   become explicit Notion delete changes before their scrubbed fields are
+   transformed.
+3. On-demand replacement reconciliations use Zendesk Search Export, which
+   includes archived tickets and supports cursor pagination. One sweep refreshes
+   ticket rows and a second uses the `metric_sets` sideload to refresh ticket
+   metrics. These sweeps repair missed updates, expired deletion markers,
+   permission changes, stale nullable values, and missing relations.
+4. Each reconciliation pins a creation-time cutoff behind Zendesk's search
+   indexing delay. After Search Export reaches its last page, the same
+   replacement cycle starts a fresh Incremental Ticket Export at that cutoff
+   and follows it through `end_of_stream`. Only this tail phase can complete the
+   replacement, preventing records newer than the search snapshot from being
+   swept away.
+5. Organizations and users use cursor-paginated list endpoints with 100 records
    per page and `mode: "replace"`.
-4. CSAT survey responses use a cursor-paginated daily replace sweep. Zendesk
+6. CSAT survey responses use a cursor-paginated daily replace sweep. Zendesk
    exposes creation-time filters but no update-time cursor, so a full sweep
    safely catches submitted or edited answers.
-5. SLA policies use Zendesk's offset pagination and refresh daily.
-6. Every record uses its stable Zendesk ID as the Notion sync key, preventing
+7. SLA policies use Zendesk's offset pagination and refresh daily.
+8. Every record uses its stable Zendesk ID as the Notion sync key, preventing
    duplicates across pages and scheduled runs.
 
-General API calls share a 170-request/minute pacer, leaving headroom under the
-200-request Team-plan limit. Ticket and metric exports share a separate
-9-request/minute pacer because Zendesk caps incremental exports at 10/minute.
-If Zendesk still returns 429, the worker passes `Retry-After` to the Workers
-runtime for backoff.
+General API calls use a 70-request/minute pacer. Ticket and metric exports share
+a separate 9-request/minute pacer because Zendesk caps incremental exports at
+10/minute. The two Search Export sweeps share a 90-request/minute budget below
+that endpoint's 100-request/minute limit. Together the independent pacers allow
+at most 169 requests per minute, leaving headroom under the 200-request Team-plan
+limit. If Zendesk still returns 429, the worker passes `Retry-After` to the
+Workers runtime for backoff.
 
 ### Zendesk API token
 
@@ -271,16 +320,43 @@ automatically.
 ### Triggering syncs manually
 
 ```sh
-ntn workers sync trigger ticketsSync
 ntn workers sync trigger organizationsSync
 ntn workers sync trigger usersSync
+ntn workers sync trigger ticketsSync
 ntn workers sync trigger surveyResponsesSync
 ntn workers sync trigger ticketMetricsSync
 ntn workers sync trigger slaPoliciesSync
 ```
 
-SLA Policies refreshes daily, but it can also be triggered manually after a
-policy change.
+Run Organizations and Users before Tickets when populating a new deployment so
+the relation targets already exist. SLA Policies refreshes daily, but it can
+also be triggered manually after a policy change.
+
+The replacement reconciliations are deliberately manual. This follows Notion's
+recommended scheduled-delta plus manual-backfill pattern.
+Replace mode deletes keys unseen at completion, and the runtime does not expose
+a cross-capability lock to this Worker, so automatically overlapping a full
+sweep with a five-minute cursor would make deletion safety depend on
+undocumented scheduling behavior.
+
+Before a repair, pause both scheduled incremental capabilities and wait for any
+in-flight runs to finish. Then reset and trigger the replacement sweeps. Resume
+incremental updates only after both repairs report completion in `sync status`:
+
+```sh
+ntn workers sync pause ticketsSync
+ntn workers sync pause ticketMetricsSync
+ntn workers sync status
+
+ntn workers sync state reset ticketsReconciliationSync
+ntn workers sync state reset ticketMetricsReconciliationSync
+ntn workers sync trigger ticketsReconciliationSync
+ntn workers sync trigger ticketMetricsReconciliationSync
+ntn workers sync status
+
+ntn workers sync resume ticketsSync
+ntn workers sync resume ticketMetricsSync
+```
 
 ### Adapting the schema
 
@@ -303,7 +379,9 @@ To add a new Zendesk field to any resource:
 3. Add a `Builder.*` call in the transform function
 
 The `PRIMARY_KEY` property is used by the platform to match incoming data to
-existing pages — don't remove it.
+existing pages—don't remove it. Keep every schema property present in its
+transform and use `[]` for missing nullable values. Preserve the stable-ID
+relations when changing the user-facing name or ID columns.
 
 ### Incremental history and large instances
 
@@ -323,17 +401,44 @@ ntn workers sync state reset ticketsSync
 ntn workers sync state reset ticketMetricsSync
 ```
 
-Organizations, users, and CSAT survey responses still use full replace sweeps.
-For large collections, follow Notion's recommended two-sync pattern: a
-scheduled incremental delta plus a manual replace backfill against the same
-database and stable key space.
+The manual `ticketsReconciliationSync` and
+`ticketMetricsReconciliationSync` replacement sweeps use the same database
+handles and stable keys as their incremental partners. Search Export is used
+instead of restarting the incremental cursor: Zendesk recommends incremental
+cursors for ongoing changes rather than repeated full exports, while Search
+Export can include archived tickets and sideload their metric sets. Its cursors
+expire after one hour, so the worker bounds and validates continuation state and
+fails visibly rather than committing a known partial replacement.
+
+The search phase alone is not a complete replacement snapshot because search
+indexing is delayed. Each sweep therefore transitions into a fresh incremental
+tail from the pinned cutoff. Search and tail pages share one replacement cycle;
+only reaching the tail's `end_of_stream` allows mark-and-sweep deletion to
+commit.
+
+A ticket deleted after its Search page was emitted may already count as seen
+for that in-flight replacement. The five-minute incremental export normally
+removes it from its deletion marker; if that marker races the sweep, run the
+manual reconciliation again. Failed or incomplete replacement runs never
+commit mark-and-sweep deletions.
+
+At the recommended 100 rows per Search Export page, each reconciliation is
+bounded to 2,000 pages, or 200,000 searched tickets. Larger accounts should
+partition reconciliation by a stable creation-time range before enabling these
+repair capabilities; increasing the page size trades fewer requests for a
+greater risk of archived-ticket timeouts.
+
+Organizations, users, CSAT survey responses, and SLA policies continue to use
+full replace sweeps directly.
 
 ### Local testing
 
-Run offline tests (no Zendesk connection needed):
+Run deterministic checks without contacting Zendesk or Notion:
 
 ```sh
+npm run check
 npm test
+npm run build
 ```
 
 Test a specific sync locally against a real Zendesk instance:
@@ -347,6 +452,8 @@ ntn workers exec organizationsSync --local
 
 - [Notion Workers documentation](https://developers.notion.com/docs/workers)
 - [Zendesk API — Tickets](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/)
+- [Zendesk API — Search Export](https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/#export-search-results)
+- [Zendesk API — Side-loading](https://developer.zendesk.com/documentation/api-basics/working-with-data/side_loading/)
 - [Zendesk API — Organizations](https://developer.zendesk.com/api-reference/ticketing/organizations/organizations/)
 - [Zendesk API — Users](https://developer.zendesk.com/api-reference/ticketing/users/users/)
 - [Zendesk API — CSAT Survey Responses](https://developer.zendesk.com/api-reference/ticketing/ticket-management/csat_survey_responses/)

--- a/workers/zendesk-sync/README.md
+++ b/workers/zendesk-sync/README.md
@@ -2,8 +2,8 @@
 
 Bring your support operation into Notion so teams and agents can investigate
 queue health, customer feedback, response performance, and SLA targets without
-leaving the workspace. One deploy creates six connected managed databases and
-keeps them updated from Zendesk automatically.
+leaving the workspace. One deploy creates six managed databases and keeps them
+updated from Zendesk automatically.
 
 You do not need to build the Notion databases or supply a Notion API token. The
 worker declares their schemas, and Notion creates and manages them for you.
@@ -108,10 +108,9 @@ ticket-metric syncs after removing the CSAT and SLA sync registrations.
 Each page body contains the ticket description. Assignee, requester, group,
 and organization show real names (resolved via Zendesk's
 [sideloading](https://developer.zendesk.com/api-reference/introduction/side-loading/),
-with no extra API calls). The matching relation columns link to stable User and
-Organization records without replacing the readable names. The incremental
-export includes archived tickets and uses `support_type_scope=all`, so both
-human-agent and AI-agent tickets are included.
+with no extra API calls). The incremental export includes archived tickets and
+uses `support_type_scope=all`, so both human-agent and AI-agent tickets are
+included.
 
 #### Zendesk Organizations
 
@@ -213,28 +212,15 @@ SLA targets are flattened from the `policy_metrics` array into individual
 columns by priority level, so managers can compare targets at a glance.
 Page body contains the policy description.
 
-### Connected records and clearing behavior
+### Relations and clearing behavior
 
-Relations use immutable Zendesk IDs, while the existing name and ID columns
-remain available for search, export, and troubleshooting:
+Relations use immutable Zendesk IDs while keeping readable name and ID columns.
+Tickets link to users and organizations; users link to organizations; CSAT
+responses link to tickets and responders; and metrics link to tickets.
+Relations are two-way; SLA policies remain standalone.
 
-- Tickets relate to their assignee and requester in **Zendesk Users**, and to
-  their organization in **Zendesk Organizations**.
-- Users relate to their organization.
-- CSAT responses relate to their ticket and responder.
-- Ticket metrics relate to their ticket.
-
-These are two-way relations. **Zendesk Users** receives **Assigned Tickets**,
-**Requested Tickets**, and **CSAT Responses** backlinks. **Zendesk
-Organizations** receives **Tickets** and **Users**, while **Support Tickets**
-receives **CSAT Responses** and **Ticket Metrics**. SLA policies remain
-standalone because the synced ticket payload does not provide a reliable policy
-foreign key.
-
-Every transform emits every declared property. When Zendesk changes a nullable
-field from populated to empty, the worker sends an explicit empty value so the
-old Notion value is cleared. The same rule applies to CSAT feedback in the page
-body.
+Every transform emits every declared property. Missing nullable values are sent
+as explicit empty values so stale Notion properties and CSAT page content clear.
 
 ### Project structure
 
@@ -253,28 +239,20 @@ src/
 
 ### How it works
 
-1. Tickets and ticket metrics use Zendesk's cursor-based Incremental Ticket
-   Export every five minutes. The first run starts at Unix time `1` to backfill
-   retained history; later runs continue from the persisted `after_cursor`.
-2. The export includes archived records and turns deleted tickets into explicit
-   Notion deletes before their scrubbed fields are transformed.
-3. Manual repair sweeps use Search Export for archived tickets and their metric
-   sets, then run a fresh incremental tail from a pinned cutoff. Replacement
-   completes only after the tail reaches `end_of_stream`, so newer records are
-   not swept away.
-4. Organizations and users use cursor-paginated list endpoints with 100 records
+1. Tickets and ticket metrics sync incrementally every five minutes, including
+   archived records and explicit ticket deletions.
+2. Manual repairs combine Search Export with an incremental tail and complete
+   replacement only after the tail reaches `end_of_stream`.
+3. Organizations and users use cursor-paginated list endpoints with 100 records
    per page and `mode: "replace"`.
-5. CSAT survey responses use a cursor-paginated daily replace sweep. Zendesk
+4. CSAT survey responses use a cursor-paginated daily replace sweep. Zendesk
    exposes creation-time filters but no update-time cursor, so a full sweep
    safely catches submitted or edited answers.
-6. SLA policies use Zendesk's offset pagination and refresh daily.
-7. Every record uses its stable Zendesk ID as the Notion sync key, preventing
+5. SLA policies use Zendesk's offset pagination and refresh daily.
+6. Every record uses its stable Zendesk ID as the Notion sync key, preventing
    duplicates across pages and scheduled runs.
 
-Separate shared pacers keep general, incremental, and Search Export traffic
-within Zendesk's limits. Incremental exports are capped at 10 requests per
-minute and Search Export at 100; if Zendesk returns 429, the worker passes
-`Retry-After` to the Workers runtime for backoff.
+API families are paced separately, and 429 responses honor `Retry-After`.
 
 ### Zendesk API token
 
@@ -317,18 +295,14 @@ ntn workers sync trigger ticketMetricsSync
 ntn workers sync trigger slaPoliciesSync
 ```
 
-Run Organizations and Users before Tickets when populating a new deployment so
-the relation targets already exist. SLA Policies refreshes daily, but it can
-also be triggered manually after a policy change.
+SLA Policies refreshes daily, but it can also be triggered manually after a
+policy change.
 
-Replacement repairs are deliberately manual because replace mode deletes unseen
-keys at completion and must not overlap the five-minute incremental syncs.
-After upgrading an existing deployment, run this procedure once: Notion preserves
-incremental state, so unchanged rows otherwise retain their old property values.
-
-Pause both incremental syncs and wait for in-flight runs to finish. Then reset
-and trigger both repairs, and resume the incremental syncs only after
-`sync status` reports that both repairs completed:
+Repairs are manual because replace mode deletes unseen keys and must not overlap
+the incremental syncs. After upgrading, run this once to backfill relations and
+clear stale nullable values: pause both incrementals and wait for in-flight runs
+to finish, then reset and trigger both repairs. Resume only after `sync status`
+reports completion:
 
 ```sh
 ntn workers sync pause ticketsSync
@@ -365,10 +339,8 @@ To add a new Zendesk field to any resource:
 2. Add a property to the schema with the appropriate `Schema.*` type
 3. Add a `Builder.*` call in the transform function
 
-The `PRIMARY_KEY` property is used by the platform to match incoming data to
-existing pages—don't remove it. Keep every schema property present in its
-transform and use `[]` for missing nullable values. Preserve the stable-ID
-relations when changing the user-facing name or ID columns.
+Keep every schema property in its transform, using `[]` for missing nullable
+values. Do not remove `PRIMARY_KEY` or the stable-ID relations.
 
 ### Incremental history and repairs
 
@@ -388,13 +360,8 @@ ntn workers sync state reset ticketsSync
 ntn workers sync state reset ticketMetricsSync
 ```
 
-Search Export cursors expire after one hour. Failed or incomplete repairs do not
-commit mark-and-sweep deletions; reset and trigger the repair again. If a ticket
-deletion races a completed repair and remains visible, let the incremental sync
-resume and rerun the repair.
-
-Organizations, users, CSAT survey responses, and SLA policies continue to use
-full replace sweeps directly.
+Search Export cursors expire after one hour. Incomplete repairs do not commit
+replacement deletions; reset and trigger the repair again.
 
 ### Local testing
 
@@ -418,7 +385,6 @@ ntn workers exec organizationsSync --local
 - [Notion Workers documentation](https://developers.notion.com/docs/workers)
 - [Zendesk API — Tickets](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/)
 - [Zendesk API — Search Export](https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/#export-search-results)
-- [Zendesk API — Side-loading](https://developer.zendesk.com/documentation/api-basics/working-with-data/side_loading/)
 - [Zendesk API — Organizations](https://developer.zendesk.com/api-reference/ticketing/organizations/organizations/)
 - [Zendesk API — Users](https://developer.zendesk.com/api-reference/ticketing/users/users/)
 - [Zendesk API — CSAT Survey Responses](https://developer.zendesk.com/api-reference/ticketing/ticket-management/csat_survey_responses/)

--- a/workers/zendesk-sync/README.md
+++ b/workers/zendesk-sync/README.md
@@ -256,36 +256,25 @@ src/
 1. Tickets and ticket metrics use Zendesk's cursor-based Incremental Ticket
    Export every five minutes. The first run starts at Unix time `1` to backfill
    retained history; later runs continue from the persisted `after_cursor`.
-2. The incremental export includes archived records. Deleted ticket records
-   become explicit Notion delete changes before their scrubbed fields are
-   transformed.
-3. On-demand replacement reconciliations use Zendesk Search Export, which
-   includes archived tickets and supports cursor pagination. One sweep refreshes
-   ticket rows and a second uses the `metric_sets` sideload to refresh ticket
-   metrics. These sweeps repair missed updates, expired deletion markers,
-   permission changes, stale nullable values, and missing relations.
-4. Each reconciliation pins a creation-time cutoff behind Zendesk's search
-   indexing delay. After Search Export reaches its last page, the same
-   replacement cycle starts a fresh Incremental Ticket Export at that cutoff
-   and follows it through `end_of_stream`. Only this tail phase can complete the
-   replacement, preventing records newer than the search snapshot from being
-   swept away.
-5. Organizations and users use cursor-paginated list endpoints with 100 records
+2. The export includes archived records and turns deleted tickets into explicit
+   Notion deletes before their scrubbed fields are transformed.
+3. Manual repair sweeps use Search Export for archived tickets and their metric
+   sets, then run a fresh incremental tail from a pinned cutoff. Replacement
+   completes only after the tail reaches `end_of_stream`, so newer records are
+   not swept away.
+4. Organizations and users use cursor-paginated list endpoints with 100 records
    per page and `mode: "replace"`.
-6. CSAT survey responses use a cursor-paginated daily replace sweep. Zendesk
+5. CSAT survey responses use a cursor-paginated daily replace sweep. Zendesk
    exposes creation-time filters but no update-time cursor, so a full sweep
    safely catches submitted or edited answers.
-7. SLA policies use Zendesk's offset pagination and refresh daily.
-8. Every record uses its stable Zendesk ID as the Notion sync key, preventing
+6. SLA policies use Zendesk's offset pagination and refresh daily.
+7. Every record uses its stable Zendesk ID as the Notion sync key, preventing
    duplicates across pages and scheduled runs.
 
-General API calls use a 70-request/minute pacer. Ticket and metric exports share
-a separate 9-request/minute pacer because Zendesk caps incremental exports at
-10/minute. The two Search Export sweeps share a 90-request/minute budget below
-that endpoint's 100-request/minute limit. Together the independent pacers allow
-at most 169 requests per minute, leaving headroom under the 200-request Team-plan
-limit. If Zendesk still returns 429, the worker passes `Retry-After` to the
-Workers runtime for backoff.
+Separate shared pacers keep general, incremental, and Search Export traffic
+within Zendesk's limits. Incremental exports are capped at 10 requests per
+minute and Search Export at 100; if Zendesk returns 429, the worker passes
+`Retry-After` to the Workers runtime for backoff.
 
 ### Zendesk API token
 
@@ -332,22 +321,14 @@ Run Organizations and Users before Tickets when populating a new deployment so
 the relation targets already exist. SLA Policies refreshes daily, but it can
 also be triggered manually after a policy change.
 
-The replacement reconciliations are deliberately manual. This follows Notion's
-recommended scheduled-delta plus manual-backfill pattern.
-Replace mode deletes keys unseen at completion, and the runtime does not expose
-a cross-capability lock to this Worker, so automatically overlapping a full
-sweep with a five-minute cursor would make deletion safety depend on
-undocumented scheduling behavior.
+Replacement repairs are deliberately manual because replace mode deletes unseen
+keys at completion and must not overlap the five-minute incremental syncs.
+After upgrading an existing deployment, run this procedure once: Notion preserves
+incremental state, so unchanged rows otherwise retain their old property values.
 
-Run the repair procedure below once immediately after upgrading an existing
-deployment. Notion preserves incremental sync state across deploys, so unchanged
-historical tickets and metrics will not otherwise revisit the new relation
-properties or nullable-field clearing behavior. New deployments populate those
-values during their initial backfill.
-
-Before a repair, pause both scheduled incremental capabilities and wait for any
-in-flight runs to finish. Then reset and trigger the replacement sweeps. Resume
-incremental updates only after both repairs report completion in `sync status`:
+Pause both incremental syncs and wait for in-flight runs to finish. Then reset
+and trigger both repairs, and resume the incremental syncs only after
+`sync status` reports that both repairs completed:
 
 ```sh
 ntn workers sync pause ticketsSync
@@ -389,7 +370,7 @@ existing pages—don't remove it. Keep every schema property present in its
 transform and use `[]` for missing nullable values. Preserve the stable-ID
 relations when changing the user-facing name or ID columns.
 
-### Incremental history and large instances
+### Incremental history and repairs
 
 Tickets and ticket metrics already use Zendesk's cursor-based incremental
 export. The initial request sends `start_time=1` as Unix epoch seconds. Every
@@ -407,32 +388,10 @@ ntn workers sync state reset ticketsSync
 ntn workers sync state reset ticketMetricsSync
 ```
 
-The manual `ticketsReconciliationSync` and
-`ticketMetricsReconciliationSync` replacement sweeps use the same database
-handles and stable keys as their incremental partners. Search Export is used
-instead of restarting the incremental cursor: Zendesk recommends incremental
-cursors for ongoing changes rather than repeated full exports, while Search
-Export can include archived tickets and sideload their metric sets. Its cursors
-expire after one hour, so the worker bounds and validates continuation state and
-fails visibly rather than committing a known partial replacement.
-
-The search phase alone is not a complete replacement snapshot because search
-indexing is delayed. Each sweep therefore transitions into a fresh incremental
-tail from the pinned cutoff. Search and tail pages share one replacement cycle;
-only reaching the tail's `end_of_stream` allows mark-and-sweep deletion to
-commit.
-
-A ticket deleted after its Search page was emitted may already count as seen
-for that in-flight replacement. The five-minute incremental export normally
-removes it from its deletion marker; if that marker races the sweep, run the
-manual reconciliation again. Failed or incomplete replacement runs never
-commit mark-and-sweep deletions.
-
-At the recommended 100 rows per Search Export page, each reconciliation is
-bounded to 2,000 pages, or 200,000 searched tickets. Larger accounts should
-partition reconciliation by a stable creation-time range before enabling these
-repair capabilities; increasing the page size trades fewer requests for a
-greater risk of archived-ticket timeouts.
+Search Export cursors expire after one hour. Failed or incomplete repairs do not
+commit mark-and-sweep deletions; reset and trigger the repair again. If a ticket
+deletion races a completed repair and remains visible, let the incremental sync
+resume and rerun the repair.
 
 Organizations, users, CSAT survey responses, and SLA policies continue to use
 full replace sweeps directly.

--- a/workers/zendesk-sync/package.json
+++ b/workers/zendesk-sync/package.json
@@ -17,6 +17,6 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "@notionhq/workers": ">=0.0.0"
+    "@notionhq/workers": "^0.4.0"
   }
 }

--- a/workers/zendesk-sync/src/index.ts
+++ b/workers/zendesk-sync/src/index.ts
@@ -237,18 +237,10 @@ worker.sync("ticketsReconciliationSync", {
       reconciliation.cursor,
       reconciliationTailStart(reconciliation)
     )
-    const changes = page.tickets.flatMap((ticket) =>
+    const changes = page.tickets.map((ticket) =>
       isDeletedTicket(ticket)
-        ? []
-        : [
-            ticketToChange(
-              ticket,
-              subdomain,
-              page.users,
-              page.groups,
-              page.orgs
-            ),
-          ]
+        ? { type: "delete" as const, key: String(ticket.id) }
+        : ticketToChange(ticket, subdomain, page.users, page.groups, page.orgs)
     )
     return {
       changes,
@@ -414,9 +406,15 @@ worker.sync("ticketMetricsReconciliationSync", {
     )
     const deletedTicketIds = new Set(page.deletedTicketIds)
     return {
-      changes: page.metrics
-        .filter((metric) => !deletedTicketIds.has(metric.ticket_id))
-        .map(ticketMetricToChange),
+      changes: [
+        ...page.metrics
+          .filter((metric) => !deletedTicketIds.has(metric.ticket_id))
+          .map(ticketMetricToChange),
+        ...[...deletedTicketIds].map((ticketId) => ({
+          type: "delete" as const,
+          key: String(ticketId),
+        })),
+      ],
       hasMore: page.hasMore,
       nextState: page.hasMore
         ? nextReconciliationState(

--- a/workers/zendesk-sync/src/index.ts
+++ b/workers/zendesk-sync/src/index.ts
@@ -11,13 +11,11 @@ import { Worker } from "@notionhq/workers"
 import {
   fetchTicketsPage,
   fetchTicketsReconciliationPage,
-  fetchTicketsReconciliationTailPage,
   fetchOrganizationsPage,
   fetchUsersPage,
   fetchSurveyResponsesPage,
   fetchTicketMetricsPage,
   fetchTicketMetricsReconciliationPage,
-  fetchTicketMetricsReconciliationTailPage,
   fetchSlaPoliciesPage,
   isDeletedTicket,
   requireSubdomain,
@@ -65,46 +63,23 @@ type SyncState = {
 
 type ReconciliationState = {
   phase: "search" | "tail"
+  cutoff: string
   cursor?: string
-  createdBefore: string
-  tailStartTime: number
-  recentCursors: string[]
-  pageCount: number
 }
 
-const MAX_RECONCILIATION_CURSOR_HISTORY = 128
 const SEARCH_INDEX_BUFFER_MS = 5 * 60_000
-// Search Export cursors expire after one hour. At 100 rows per page, this
-// bound supports up to 200,000 records per replacement while ensuring two
-// concurrently scheduled sweeps can stay within the shared search pacer.
-const MAX_RECONCILIATION_SEARCH_PAGES = 2_000
-const MAX_RECONCILIATION_TAIL_PAGES = 2_000
 
 function reconciliationState(
   state: ReconciliationState | undefined,
-  resourceName: string,
-  now: () => Date = () => new Date()
+  resourceName: string
 ): ReconciliationState {
   if (!state) {
-    const value = now()
-    if (Number.isNaN(value.getTime())) {
-      throw new Error(`Zendesk ${resourceName} reconciliation clock is invalid`)
-    }
     // Zendesk documents that newly created records can take a few minutes to
     // enter Search. Keep the immutable creation boundary behind that lag; the
     // five-minute incremental capability owns the newer tail.
-    const createdBefore = new Date(
-      Math.max(0, value.getTime() - SEARCH_INDEX_BUFFER_MS)
-    ).toISOString()
     return {
       phase: "search",
-      createdBefore,
-      tailStartTime: Math.max(
-        1,
-        Math.floor(new Date(createdBefore).getTime() / 1_000)
-      ),
-      recentCursors: [],
-      pageCount: 0,
+      cutoff: new Date(Date.now() - SEARCH_INDEX_BUFFER_MS).toISOString(),
     }
   }
 
@@ -113,74 +88,20 @@ function reconciliationState(
       `Zendesk ${resourceName} reconciliation has an invalid phase`
     )
   }
-  if (typeof state.createdBefore !== "string" || !state.createdBefore.trim()) {
-    throw new Error(
-      `Zendesk ${resourceName} reconciliation has an invalid createdBefore cutoff`
-    )
-  }
-  const cutoff = new Date(state.createdBefore)
   if (
-    Number.isNaN(cutoff.getTime()) ||
-    cutoff.toISOString() !== state.createdBefore
+    typeof state.cutoff !== "string" ||
+    Number.isNaN(Date.parse(state.cutoff))
   ) {
     throw new Error(
-      `Zendesk ${resourceName} reconciliation has an invalid createdBefore cutoff`
-    )
-  }
-  const expectedTailStartTime = Math.max(
-    1,
-    Math.floor(cutoff.getTime() / 1_000)
-  )
-  if (
-    !Number.isSafeInteger(state.tailStartTime) ||
-    state.tailStartTime !== expectedTailStartTime
-  ) {
-    throw new Error(
-      `Zendesk ${resourceName} reconciliation has an invalid tail start_time`
+      `Zendesk ${resourceName} reconciliation has an invalid cutoff`
     )
   }
   if (
-    !Array.isArray(state.recentCursors) ||
-    state.recentCursors.length > MAX_RECONCILIATION_CURSOR_HISTORY ||
-    state.recentCursors.some(
-      (cursor) => typeof cursor !== "string" || !cursor.trim()
-    )
+    state.cursor !== undefined &&
+    (typeof state.cursor !== "string" || !state.cursor.trim())
   ) {
     throw new Error(
-      `Zendesk ${resourceName} reconciliation has invalid cursor history`
-    )
-  }
-  if (state.cursor !== undefined) {
-    if (
-      typeof state.cursor !== "string" ||
-      !state.cursor.trim() ||
-      state.recentCursors.length === 0 ||
-      !state.recentCursors.includes(state.cursor)
-    ) {
-      throw new Error(
-        `Zendesk ${resourceName} reconciliation has an invalid cursor`
-      )
-    }
-  } else if (
-    state.phase !== "tail" ||
-    state.recentCursors.length !== 0 ||
-    state.pageCount !== 0
-  ) {
-    throw new Error(
-      `Zendesk ${resourceName} reconciliation is missing its phase cursor`
-    )
-  }
-  const pageLimit =
-    state.phase === "search"
-      ? MAX_RECONCILIATION_SEARCH_PAGES
-      : MAX_RECONCILIATION_TAIL_PAGES
-  if (
-    !Number.isSafeInteger(state.pageCount) ||
-    state.pageCount < (state.cursor ? 1 : 0) ||
-    state.pageCount >= pageLimit
-  ) {
-    throw new Error(
-      `Zendesk ${resourceName} reconciliation is outside its page bound`
+      `Zendesk ${resourceName} reconciliation has an invalid cursor`
     )
   }
   return state
@@ -196,30 +117,9 @@ function nextReconciliationState(
       `Zendesk ${resourceName} reconciliation is missing its next cursor`
     )
   }
-  const recentCursors = new Set(state.recentCursors)
-  if (state.cursor) recentCursors.add(state.cursor)
-  if (recentCursors.has(nextCursor)) {
-    throw new Error(
-      `Zendesk ${resourceName} reconciliation repeated a recent cursor`
-    )
-  }
-
-  const pageCount = state.pageCount + 1
-  const pageLimit =
-    state.phase === "search"
-      ? MAX_RECONCILIATION_SEARCH_PAGES
-      : MAX_RECONCILIATION_TAIL_PAGES
-  if (pageCount >= pageLimit) {
-    throw new Error(
-      `Zendesk ${resourceName} reconciliation ${state.phase} phase exceeded ${pageLimit} pages`
-    )
-  }
-  recentCursors.add(nextCursor)
   return {
     ...state,
     cursor: nextCursor,
-    recentCursors: [...recentCursors].slice(-MAX_RECONCILIATION_CURSOR_HISTORY),
-    pageCount,
   }
 }
 
@@ -228,11 +128,12 @@ function tailReconciliationState(
 ): ReconciliationState {
   return {
     phase: "tail",
-    createdBefore: state.createdBefore,
-    tailStartTime: state.tailStartTime,
-    recentCursors: [],
-    pageCount: 0,
+    cutoff: state.cutoff,
   }
+}
+
+function reconciliationTailStart(state: ReconciliationState): number {
+  return Math.max(1, Math.floor(Date.parse(state.cutoff) / 1_000))
 }
 
 const worker = new Worker()
@@ -306,7 +207,7 @@ worker.sync("ticketsReconciliationSync", {
     if (reconciliation.phase === "search") {
       await searchExportPacer.wait()
       const page = await fetchTicketsReconciliationPage(
-        reconciliation.createdBefore,
+        reconciliation.cutoff,
         reconciliation.cursor
       )
       const changes = page.tickets.flatMap((ticket) =>
@@ -332,9 +233,9 @@ worker.sync("ticketsReconciliationSync", {
     }
 
     await incrementalExportPacer.wait()
-    const page = await fetchTicketsReconciliationTailPage(
-      reconciliation.tailStartTime,
-      reconciliation.cursor
+    const page = await fetchTicketsPage(
+      reconciliation.cursor,
+      reconciliationTailStart(reconciliation)
     )
     const changes = page.tickets.flatMap((ticket) =>
       isDeletedTicket(ticket)
@@ -490,7 +391,7 @@ worker.sync("ticketMetricsReconciliationSync", {
     if (reconciliation.phase === "search") {
       await searchExportPacer.wait()
       const page = await fetchTicketMetricsReconciliationPage(
-        reconciliation.createdBefore,
+        reconciliation.cutoff,
         reconciliation.cursor
       )
       return {
@@ -507,9 +408,9 @@ worker.sync("ticketMetricsReconciliationSync", {
     }
 
     await incrementalExportPacer.wait()
-    const page = await fetchTicketMetricsReconciliationTailPage(
-      reconciliation.tailStartTime,
-      reconciliation.cursor
+    const page = await fetchTicketMetricsPage(
+      reconciliation.cursor,
+      reconciliationTailStart(reconciliation)
     )
     const deletedTicketIds = new Set(page.deletedTicketIds)
     return {

--- a/workers/zendesk-sync/src/index.ts
+++ b/workers/zendesk-sync/src/index.ts
@@ -10,10 +10,14 @@ import { Worker } from "@notionhq/workers"
 
 import {
   fetchTicketsPage,
+  fetchTicketsReconciliationPage,
+  fetchTicketsReconciliationTailPage,
   fetchOrganizationsPage,
   fetchUsersPage,
   fetchSurveyResponsesPage,
   fetchTicketMetricsPage,
+  fetchTicketMetricsReconciliationPage,
+  fetchTicketMetricsReconciliationTailPage,
   fetchSlaPoliciesPage,
   isDeletedTicket,
   requireSubdomain,
@@ -59,12 +63,184 @@ type SyncState = {
   cursor: string
 }
 
+type ReconciliationState = {
+  phase: "search" | "tail"
+  cursor?: string
+  createdBefore: string
+  tailStartTime: number
+  recentCursors: string[]
+  pageCount: number
+}
+
+const MAX_RECONCILIATION_CURSOR_HISTORY = 128
+const SEARCH_INDEX_BUFFER_MS = 5 * 60_000
+// Search Export cursors expire after one hour. At 100 rows per page, this
+// bound supports up to 200,000 records per replacement while ensuring two
+// concurrently scheduled sweeps can stay within the shared search pacer.
+const MAX_RECONCILIATION_SEARCH_PAGES = 2_000
+const MAX_RECONCILIATION_TAIL_PAGES = 2_000
+
+function reconciliationState(
+  state: ReconciliationState | undefined,
+  resourceName: string,
+  now: () => Date = () => new Date()
+): ReconciliationState {
+  if (!state) {
+    const value = now()
+    if (Number.isNaN(value.getTime())) {
+      throw new Error(`Zendesk ${resourceName} reconciliation clock is invalid`)
+    }
+    // Zendesk documents that newly created records can take a few minutes to
+    // enter Search. Keep the immutable creation boundary behind that lag; the
+    // five-minute incremental capability owns the newer tail.
+    const createdBefore = new Date(
+      Math.max(0, value.getTime() - SEARCH_INDEX_BUFFER_MS)
+    ).toISOString()
+    return {
+      phase: "search",
+      createdBefore,
+      tailStartTime: Math.max(
+        1,
+        Math.floor(new Date(createdBefore).getTime() / 1_000)
+      ),
+      recentCursors: [],
+      pageCount: 0,
+    }
+  }
+
+  if (state.phase !== "search" && state.phase !== "tail") {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation has an invalid phase`
+    )
+  }
+  if (typeof state.createdBefore !== "string" || !state.createdBefore.trim()) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation has an invalid createdBefore cutoff`
+    )
+  }
+  const cutoff = new Date(state.createdBefore)
+  if (
+    Number.isNaN(cutoff.getTime()) ||
+    cutoff.toISOString() !== state.createdBefore
+  ) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation has an invalid createdBefore cutoff`
+    )
+  }
+  const expectedTailStartTime = Math.max(
+    1,
+    Math.floor(cutoff.getTime() / 1_000)
+  )
+  if (
+    !Number.isSafeInteger(state.tailStartTime) ||
+    state.tailStartTime !== expectedTailStartTime
+  ) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation has an invalid tail start_time`
+    )
+  }
+  if (
+    !Array.isArray(state.recentCursors) ||
+    state.recentCursors.length > MAX_RECONCILIATION_CURSOR_HISTORY ||
+    state.recentCursors.some(
+      (cursor) => typeof cursor !== "string" || !cursor.trim()
+    )
+  ) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation has invalid cursor history`
+    )
+  }
+  if (state.cursor !== undefined) {
+    if (
+      typeof state.cursor !== "string" ||
+      !state.cursor.trim() ||
+      state.recentCursors.length === 0 ||
+      !state.recentCursors.includes(state.cursor)
+    ) {
+      throw new Error(
+        `Zendesk ${resourceName} reconciliation has an invalid cursor`
+      )
+    }
+  } else if (
+    state.phase !== "tail" ||
+    state.recentCursors.length !== 0 ||
+    state.pageCount !== 0
+  ) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation is missing its phase cursor`
+    )
+  }
+  const pageLimit =
+    state.phase === "search"
+      ? MAX_RECONCILIATION_SEARCH_PAGES
+      : MAX_RECONCILIATION_TAIL_PAGES
+  if (
+    !Number.isSafeInteger(state.pageCount) ||
+    state.pageCount < (state.cursor ? 1 : 0) ||
+    state.pageCount >= pageLimit
+  ) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation is outside its page bound`
+    )
+  }
+  return state
+}
+
+function nextReconciliationState(
+  state: ReconciliationState,
+  nextCursor: string | undefined,
+  resourceName: string
+): ReconciliationState {
+  if (!nextCursor?.trim()) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation is missing its next cursor`
+    )
+  }
+  const recentCursors = new Set(state.recentCursors)
+  if (state.cursor) recentCursors.add(state.cursor)
+  if (recentCursors.has(nextCursor)) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation repeated a recent cursor`
+    )
+  }
+
+  const pageCount = state.pageCount + 1
+  const pageLimit =
+    state.phase === "search"
+      ? MAX_RECONCILIATION_SEARCH_PAGES
+      : MAX_RECONCILIATION_TAIL_PAGES
+  if (pageCount >= pageLimit) {
+    throw new Error(
+      `Zendesk ${resourceName} reconciliation ${state.phase} phase exceeded ${pageLimit} pages`
+    )
+  }
+  recentCursors.add(nextCursor)
+  return {
+    ...state,
+    cursor: nextCursor,
+    recentCursors: [...recentCursors].slice(-MAX_RECONCILIATION_CURSOR_HISTORY),
+    pageCount,
+  }
+}
+
+function tailReconciliationState(
+  state: ReconciliationState
+): ReconciliationState {
+  return {
+    phase: "tail",
+    createdBefore: state.createdBefore,
+    tailStartTime: state.tailStartTime,
+    recentCursors: [],
+    pageCount: 0,
+  }
+}
+
 const worker = new Worker()
 
-// Team accounts allow 200 Support API requests/minute. Keep aggregate general
-// traffic below that limit, with headroom for the incremental export pacer.
+// Team accounts allow 200 Support API requests/minute. These three independent
+// pacers sum to 169 requests/minute, leaving headroom for account activity.
 const generalPacer = worker.pacer("zendesk", {
-  allowedRequests: 170,
+  allowedRequests: 70,
   intervalMs: 60_000,
 })
 
@@ -72,6 +248,13 @@ const generalPacer = worker.pacer("zendesk", {
 // Tickets and metrics share this pacer so the limit applies collectively.
 const incrementalExportPacer = worker.pacer("zendeskIncrementalExports", {
   allowedRequests: 9,
+  intervalMs: 60_000,
+})
+
+// Search Export has a separate 100-request/minute account limit. Both manual
+// reconciliation capabilities share this pacer and leave provider headroom.
+const searchExportPacer = worker.pacer("zendeskSearchExports", {
+  allowedRequests: 90,
   intervalMs: 60_000,
 })
 
@@ -105,6 +288,73 @@ worker.sync("ticketsSync", {
       // Incremental mode persists this checkpoint across scheduled runs,
       // including when this page reaches end_of_stream.
       nextState: { cursor: page.nextCursor },
+    }
+  },
+})
+
+// Search Export includes archived tickets, unlike the ordinary List Tickets
+// endpoint. A pinned creation cutoff keeps membership fixed while its
+// short-lived cursor is paged; a fresh incremental tail then adds newer
+// tickets before replacement is allowed to complete.
+worker.sync("ticketsReconciliationSync", {
+  database: tickets,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state: ReconciliationState | undefined) => {
+    const reconciliation = reconciliationState(state, "ticket")
+    const subdomain = requireSubdomain()
+    if (reconciliation.phase === "search") {
+      await searchExportPacer.wait()
+      const page = await fetchTicketsReconciliationPage(
+        reconciliation.createdBefore,
+        reconciliation.cursor
+      )
+      const changes = page.tickets.flatMap((ticket) =>
+        isDeletedTicket(ticket)
+          ? []
+          : [
+              ticketToChange(
+                ticket,
+                subdomain,
+                page.users,
+                page.groups,
+                page.orgs
+              ),
+            ]
+      )
+      return {
+        changes,
+        hasMore: true as const,
+        nextState: page.hasMore
+          ? nextReconciliationState(reconciliation, page.nextCursor, "ticket")
+          : tailReconciliationState(reconciliation),
+      }
+    }
+
+    await incrementalExportPacer.wait()
+    const page = await fetchTicketsReconciliationTailPage(
+      reconciliation.tailStartTime,
+      reconciliation.cursor
+    )
+    const changes = page.tickets.flatMap((ticket) =>
+      isDeletedTicket(ticket)
+        ? []
+        : [
+            ticketToChange(
+              ticket,
+              subdomain,
+              page.users,
+              page.groups,
+              page.orgs
+            ),
+          ]
+    )
+    return {
+      changes,
+      hasMore: page.hasMore,
+      nextState: page.hasMore
+        ? nextReconciliationState(reconciliation, page.nextCursor, "ticket")
+        : undefined,
     }
   },
 })
@@ -224,6 +474,56 @@ worker.sync("ticketMetricsSync", {
       changes,
       hasMore: page.hasMore,
       nextState: { cursor: page.nextCursor },
+    }
+  },
+})
+
+// List Ticket Metrics excludes archived tickets, so this replacement also
+// uses Search Export with the documented tickets(metric_sets) sideload. This
+// preserves the historical keyspace populated by the incremental export.
+worker.sync("ticketMetricsReconciliationSync", {
+  database: ticketMetrics,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state: ReconciliationState | undefined) => {
+    const reconciliation = reconciliationState(state, "ticket metric")
+    if (reconciliation.phase === "search") {
+      await searchExportPacer.wait()
+      const page = await fetchTicketMetricsReconciliationPage(
+        reconciliation.createdBefore,
+        reconciliation.cursor
+      )
+      return {
+        changes: page.metrics.map(ticketMetricToChange),
+        hasMore: true as const,
+        nextState: page.hasMore
+          ? nextReconciliationState(
+              reconciliation,
+              page.nextCursor,
+              "ticket metric"
+            )
+          : tailReconciliationState(reconciliation),
+      }
+    }
+
+    await incrementalExportPacer.wait()
+    const page = await fetchTicketMetricsReconciliationTailPage(
+      reconciliation.tailStartTime,
+      reconciliation.cursor
+    )
+    const deletedTicketIds = new Set(page.deletedTicketIds)
+    return {
+      changes: page.metrics
+        .filter((metric) => !deletedTicketIds.has(metric.ticket_id))
+        .map(ticketMetricToChange),
+      hasMore: page.hasMore,
+      nextState: page.hasMore
+        ? nextReconciliationState(
+            reconciliation,
+            page.nextCursor,
+            "ticket metric"
+          )
+        : undefined,
     }
   },
 })

--- a/workers/zendesk-sync/src/organizations.ts
+++ b/workers/zendesk-sync/src/organizations.ts
@@ -3,14 +3,14 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import type { ZendeskOrganization } from "./zendesk.js"
 import { dateOnly } from "./formatters.js"
 
 export const INITIAL_TITLE = "Zendesk Organizations"
 export const PRIMARY_KEY = "Org ID"
 
-export const organizationSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const organizationSchema = {
   databaseIcon: notionIcon("briefcase"),
   properties: {
     Name: Schema.title(),
@@ -27,9 +27,11 @@ export const organizationSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Created at": Schema.date(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
-export function organizationToChange(org: ZendeskOrganization) {
+export function organizationToChange(
+  org: ZendeskOrganization
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof organizationSchema.properties> {
   return {
     type: "upsert" as const,
     key: String(org.id),
@@ -38,13 +40,12 @@ export function organizationToChange(org: ZendeskOrganization) {
     properties: {
       Name: Builder.title(org.name ?? ""),
       "Org ID": Builder.richText(String(org.id)),
-      ...(org.domain_names.length > 0
-        ? { Domains: Builder.richText(org.domain_names.join(", ")) }
-        : {}),
-      ...(org.tags.length > 0
-        ? { Tags: Builder.multiSelect(...org.tags) }
-        : {}),
-      ...(org.details ? { Details: Builder.richText(org.details) } : {}),
+      Domains:
+        org.domain_names.length > 0
+          ? Builder.richText(org.domain_names.join(", "))
+          : [],
+      Tags: org.tags.length > 0 ? Builder.multiSelect(...org.tags) : [],
+      Details: org.details ? Builder.richText(org.details) : [],
       "Created at": Builder.date(dateOnly(org.created_at)),
       "Updated at": Builder.date(dateOnly(org.updated_at)),
     },

--- a/workers/zendesk-sync/src/sla-policies.ts
+++ b/workers/zendesk-sync/src/sla-policies.ts
@@ -7,14 +7,14 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import type { ZendeskSlaPolicy, ZendeskSlaPolicyMetric } from "./zendesk.js"
 import { dateOnly } from "./formatters.js"
 
 export const INITIAL_TITLE = "Zendesk SLA Policies"
 export const PRIMARY_KEY = "Policy ID"
 
-export const slaPolicySchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const slaPolicySchema = {
   databaseIcon: notionIcon("shield"),
   properties: {
     Title: Schema.title(),
@@ -43,7 +43,7 @@ export const slaPolicySchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Created at": Schema.date(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 function findTarget(
   metrics: ZendeskSlaPolicyMetric[],
@@ -56,7 +56,9 @@ function findTarget(
   return match?.target
 }
 
-export function slaPolicyToChange(policy: ZendeskSlaPolicy) {
+export function slaPolicyToChange(
+  policy: ZendeskSlaPolicy
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof slaPolicySchema.properties> {
   const metrics = policy.policy_metrics ?? []
   const description = policy.description ?? ""
 
@@ -78,39 +80,26 @@ export function slaPolicyToChange(policy: ZendeskSlaPolicy) {
     properties: {
       Title: Builder.title(policy.title ?? ""),
       "Policy ID": Builder.richText(String(policy.id)),
-      ...(policy.position != null
-        ? { Position: Builder.number(policy.position) }
-        : {}),
-      ...(urgentReply != null
-        ? { "Urgent First Reply (min)": Builder.number(urgentReply) }
-        : {}),
-      ...(highReply != null
-        ? { "High First Reply (min)": Builder.number(highReply) }
-        : {}),
-      ...(normalReply != null
-        ? { "Normal First Reply (min)": Builder.number(normalReply) }
-        : {}),
-      ...(lowReply != null
-        ? { "Low First Reply (min)": Builder.number(lowReply) }
-        : {}),
-      ...(urgentRes != null
-        ? { "Urgent Resolution (min)": Builder.number(urgentRes) }
-        : {}),
-      ...(highRes != null
-        ? { "High Resolution (min)": Builder.number(highRes) }
-        : {}),
-      ...(normalRes != null
-        ? { "Normal Resolution (min)": Builder.number(normalRes) }
-        : {}),
-      ...(lowRes != null
-        ? { "Low Resolution (min)": Builder.number(lowRes) }
-        : {}),
-      ...(policy.created_at
-        ? { "Created at": Builder.date(dateOnly(policy.created_at)) }
-        : {}),
-      ...(policy.updated_at
-        ? { "Updated at": Builder.date(dateOnly(policy.updated_at)) }
-        : {}),
+      Position: policy.position != null ? Builder.number(policy.position) : [],
+      "Urgent First Reply (min)":
+        urgentReply != null ? Builder.number(urgentReply) : [],
+      "High First Reply (min)":
+        highReply != null ? Builder.number(highReply) : [],
+      "Normal First Reply (min)":
+        normalReply != null ? Builder.number(normalReply) : [],
+      "Low First Reply (min)": lowReply != null ? Builder.number(lowReply) : [],
+      "Urgent Resolution (min)":
+        urgentRes != null ? Builder.number(urgentRes) : [],
+      "High Resolution (min)": highRes != null ? Builder.number(highRes) : [],
+      "Normal Resolution (min)":
+        normalRes != null ? Builder.number(normalRes) : [],
+      "Low Resolution (min)": lowRes != null ? Builder.number(lowRes) : [],
+      "Created at": policy.created_at
+        ? Builder.date(dateOnly(policy.created_at))
+        : [],
+      "Updated at": policy.updated_at
+        ? Builder.date(dateOnly(policy.updated_at))
+        : [],
     },
   }
 }

--- a/workers/zendesk-sync/src/survey-responses.ts
+++ b/workers/zendesk-sync/src/survey-responses.ts
@@ -3,14 +3,14 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import type { ZendeskSurveyAnswer, ZendeskSurveyResponse } from "./zendesk.js"
 import { dateOnly, formatLabel } from "./formatters.js"
 
 export const INITIAL_TITLE = "Zendesk CSAT Survey Responses"
 export const PRIMARY_KEY = "Response ID"
 
-export const surveyResponseSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const surveyResponseSchema = {
   databaseIcon: notionIcon("thumbs-up"),
   properties: {
     Response: Schema.title(),
@@ -29,7 +29,17 @@ export const surveyResponseSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Ticket ID": Schema.richText(),
 
+    "Ticket Record": Schema.relation("tickets", {
+      twoWay: true,
+      relatedPropertyName: "CSAT Responses",
+    }),
+
     "Responder ID": Schema.richText(),
+
+    "Responder Record": Schema.relation("users", {
+      twoWay: true,
+      relatedPropertyName: "CSAT Responses",
+    }),
 
     "Survey ID": Schema.richText(),
 
@@ -43,7 +53,7 @@ export const surveyResponseSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Response ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 function latestAnswerUpdate(
   answers: ZendeskSurveyAnswer[]
@@ -56,7 +66,12 @@ function latestAnswerUpdate(
   return latest
 }
 
-export function surveyResponseToChange(response: ZendeskSurveyResponse) {
+export function surveyResponseToChange(
+  response: ZendeskSurveyResponse
+): SyncChangeUpsert<
+  typeof PRIMARY_KEY,
+  typeof surveyResponseSchema.properties
+> {
   const answers = response.answers ?? []
   const ratingAnswer = answers.find(
     (answer) =>
@@ -83,39 +98,35 @@ export function surveyResponseToChange(response: ZendeskSurveyResponse) {
     type: "upsert" as const,
     key: response.id,
     ...(updatedAt ? { upstreamUpdatedAt: updatedAt } : {}),
-    ...(feedback ? { pageContentMarkdown: feedback } : {}),
+    pageContentMarkdown: feedback,
     properties: {
       Response: Builder.title(title),
       "Response ID": Builder.richText(response.id),
       "Responder ID": Builder.richText(String(response.responder_id)),
-      ...(ratingAnswer?.rating != null
-        ? { Rating: Builder.number(ratingAnswer.rating) }
-        : {}),
-      ...(ratingAnswer?.rating_category
-        ? {
-            "Rating category": Builder.select(
-              formatLabel(ratingAnswer.rating_category)
-            ),
-          }
-        : {}),
-      ...(feedback ? { Feedback: Builder.richText(feedback) } : {}),
-      ...(subject ? { Subject: Builder.richText(subject.zrn) } : {}),
-      ...(ticketId ? { "Ticket ID": Builder.richText(ticketId) } : {}),
-      ...(response.survey?.id
-        ? { "Survey ID": Builder.richText(response.survey.id) }
-        : {}),
-      ...(response.survey?.version != null
-        ? { "Survey version": Builder.number(response.survey.version) }
-        : {}),
-      ...(response.survey?.state
-        ? {
-            "Survey state": Builder.select(formatLabel(response.survey.state)),
-          }
-        : {}),
-      ...(updatedAt ? { "Updated at": Builder.date(dateOnly(updatedAt)) } : {}),
-      ...(response.expires_at
-        ? { "Expires at": Builder.date(dateOnly(response.expires_at)) }
-        : {}),
+      "Responder Record": [Builder.relation(String(response.responder_id))],
+      Rating:
+        ratingAnswer?.rating != null ? Builder.number(ratingAnswer.rating) : [],
+      "Rating category": ratingAnswer?.rating_category
+        ? Builder.select(formatLabel(ratingAnswer.rating_category))
+        : [],
+      Feedback: feedback ? Builder.richText(feedback) : [],
+      Subject: subject ? Builder.richText(subject.zrn) : [],
+      "Ticket ID": ticketId ? Builder.richText(ticketId) : [],
+      "Ticket Record": ticketId ? [Builder.relation(ticketId)] : [],
+      "Survey ID": response.survey?.id
+        ? Builder.richText(response.survey.id)
+        : [],
+      "Survey version":
+        response.survey?.version != null
+          ? Builder.number(response.survey.version)
+          : [],
+      "Survey state": response.survey?.state
+        ? Builder.select(formatLabel(response.survey.state))
+        : [],
+      "Updated at": updatedAt ? Builder.date(dateOnly(updatedAt)) : [],
+      "Expires at": response.expires_at
+        ? Builder.date(dateOnly(response.expires_at))
+        : [],
     },
   }
 }

--- a/workers/zendesk-sync/src/ticket-metrics.ts
+++ b/workers/zendesk-sync/src/ticket-metrics.ts
@@ -7,17 +7,22 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import type { ZendeskTicketMetric } from "./zendesk.js"
 import { dateOnly } from "./formatters.js"
 
 export const INITIAL_TITLE = "Zendesk Ticket Metrics"
 export const PRIMARY_KEY = "Ticket ID"
 
-export const ticketMetricSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const ticketMetricSchema = {
   databaseIcon: notionIcon("stopwatch"),
   properties: {
     "Ticket ID": Schema.title(),
+
+    "Ticket Record": Schema.relation("tickets", {
+      twoWay: true,
+      relatedPropertyName: "Ticket Metrics",
+    }),
 
     "First Reply (min)": Schema.number(),
 
@@ -45,7 +50,7 @@ export const ticketMetricSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Created at": Schema.date(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 function calendarMinutes(
   metric: ZendeskTicketMetric["reply_time_in_minutes"]
@@ -53,7 +58,9 @@ function calendarMinutes(
   return metric?.calendar ?? null
 }
 
-export function ticketMetricToChange(metric: ZendeskTicketMetric) {
+export function ticketMetricToChange(
+  metric: ZendeskTicketMetric
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof ticketMetricSchema.properties> {
   const firstReply = calendarMinutes(metric.reply_time_in_minutes)
   const firstResolution = calendarMinutes(
     metric.first_resolution_time_in_minutes
@@ -69,43 +76,35 @@ export function ticketMetricToChange(metric: ZendeskTicketMetric) {
     ...(metric.updated_at ? { upstreamUpdatedAt: metric.updated_at } : {}),
     properties: {
       "Ticket ID": Builder.title(String(metric.ticket_id)),
-      ...(firstReply != null
-        ? { "First Reply (min)": Builder.number(firstReply) }
-        : {}),
-      ...(firstResolution != null
-        ? { "First Resolution (min)": Builder.number(firstResolution) }
-        : {}),
-      ...(fullResolution != null
-        ? { "Full Resolution (min)": Builder.number(fullResolution) }
-        : {}),
-      ...(agentWait != null
-        ? { "Agent Wait (min)": Builder.number(agentWait) }
-        : {}),
-      ...(requesterWait != null
-        ? { "Requester Wait (min)": Builder.number(requesterWait) }
-        : {}),
-      ...(metric.reopens != null
-        ? { Reopens: Builder.number(metric.reopens) }
-        : {}),
-      ...(metric.assignee_stations != null
-        ? { "Agents Touched": Builder.number(metric.assignee_stations) }
-        : {}),
-      ...(metric.group_stations != null
-        ? { "Groups Touched": Builder.number(metric.group_stations) }
-        : {}),
-      ...(metric.solved_at
-        ? { "Solved at": Builder.date(dateOnly(metric.solved_at)) }
-        : {}),
-      ...(metric.replies != null
-        ? { Replies: Builder.number(metric.replies) }
-        : {}),
-      ...(onHold != null ? { "On Hold (min)": Builder.number(onHold) } : {}),
-      ...(metric.updated_at
-        ? { "Updated at": Builder.date(dateOnly(metric.updated_at)) }
-        : {}),
-      ...(metric.created_at
-        ? { "Created at": Builder.date(dateOnly(metric.created_at)) }
-        : {}),
+      "Ticket Record": [Builder.relation(String(metric.ticket_id))],
+      "First Reply (min)": firstReply != null ? Builder.number(firstReply) : [],
+      "First Resolution (min)":
+        firstResolution != null ? Builder.number(firstResolution) : [],
+      "Full Resolution (min)":
+        fullResolution != null ? Builder.number(fullResolution) : [],
+      "Agent Wait (min)": agentWait != null ? Builder.number(agentWait) : [],
+      "Requester Wait (min)":
+        requesterWait != null ? Builder.number(requesterWait) : [],
+      Reopens: metric.reopens != null ? Builder.number(metric.reopens) : [],
+      "Agents Touched":
+        metric.assignee_stations != null
+          ? Builder.number(metric.assignee_stations)
+          : [],
+      "Groups Touched":
+        metric.group_stations != null
+          ? Builder.number(metric.group_stations)
+          : [],
+      "Solved at": metric.solved_at
+        ? Builder.date(dateOnly(metric.solved_at))
+        : [],
+      Replies: metric.replies != null ? Builder.number(metric.replies) : [],
+      "On Hold (min)": onHold != null ? Builder.number(onHold) : [],
+      "Updated at": metric.updated_at
+        ? Builder.date(dateOnly(metric.updated_at))
+        : [],
+      "Created at": metric.created_at
+        ? Builder.date(dateOnly(metric.created_at))
+        : [],
     },
   }
 }

--- a/workers/zendesk-sync/src/tickets.ts
+++ b/workers/zendesk-sync/src/tickets.ts
@@ -22,7 +22,7 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import type {
   ZendeskTicket,
   UserLookup,
@@ -38,7 +38,7 @@ export const INITIAL_TITLE =
 // this property to decide whether to create or update a page.
 export const PRIMARY_KEY = "Ticket ID"
 
-export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const ticketSchema = {
   databaseIcon: notionIcon("ticket"),
   properties: {
     Subject: Schema.title(),
@@ -61,6 +61,11 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Assignee: Schema.richText(),
 
+    "Assignee Record": Schema.relation("users", {
+      twoWay: true,
+      relatedPropertyName: "Assigned Tickets",
+    }),
+
     Group: Schema.richText(),
 
     "Ticket link": Schema.url(),
@@ -69,7 +74,17 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     Requester: Schema.richText(),
 
+    "Requester Record": Schema.relation("users", {
+      twoWay: true,
+      relatedPropertyName: "Requested Tickets",
+    }),
+
     Organization: Schema.richText(),
+
+    "Organization Record": Schema.relation("organizations", {
+      twoWay: true,
+      relatedPropertyName: "Tickets",
+    }),
 
     Type: Schema.select([
       { name: "Problem" },
@@ -96,7 +111,7 @@ export const ticketSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Ticket ID": Schema.richText(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 // Use explicit labels when Zendesk's raw values need product-specific casing.
 const CHANNEL_LABELS: Record<string, string> = {
@@ -107,14 +122,16 @@ const CHANNEL_LABELS: Record<string, string> = {
   mobile: "Mobile",
 }
 
-// Nullable fields are omitted instead of writing empty values into Notion.
+// Empty arrays explicitly clear nullable fields when an upstream value disappears.
 export function ticketToChange(
   ticket: ZendeskTicket,
   subdomain: string,
   users: UserLookup,
   groups: GroupLookup,
   orgs: OrgLookup
-) {
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof ticketSchema.properties> & {
+  pageContentMarkdown: string
+} {
   const assigneeName = ticket.assignee_id
     ? (users.get(ticket.assignee_id)?.name ?? String(ticket.assignee_id))
     : null
@@ -124,7 +141,7 @@ export function ticketToChange(
     ? (groups.get(ticket.group_id)?.name ?? String(ticket.group_id))
     : null
   const orgName = ticket.organization_id
-    ? (orgs.get(ticket.organization_id)?.name ?? null)
+    ? (orgs.get(ticket.organization_id)?.name ?? String(ticket.organization_id))
     : null
 
   return {
@@ -135,25 +152,30 @@ export function ticketToChange(
     properties: {
       Subject: Builder.title(ticket.subject ?? ""),
       Status: Builder.select(formatLabel(ticket.status ?? "new")),
-      ...(ticket.priority
-        ? { Priority: Builder.select(formatLabel(ticket.priority)) }
-        : {}),
-      ...(assigneeName ? { Assignee: Builder.richText(assigneeName) } : {}),
-      ...(groupName ? { Group: Builder.richText(groupName) } : {}),
+      Priority: ticket.priority
+        ? Builder.select(formatLabel(ticket.priority))
+        : [],
+      Assignee: assigneeName ? Builder.richText(assigneeName) : [],
+      "Assignee Record":
+        ticket.assignee_id != null
+          ? [Builder.relation(String(ticket.assignee_id))]
+          : [],
+      Group: groupName ? Builder.richText(groupName) : [],
       "Ticket link": Builder.url(ticketUrl(subdomain, ticket.id)),
       "Updated at": Builder.date(dateOnly(ticket.updated_at)),
       Requester: Builder.richText(requesterName),
-      ...(orgName ? { Organization: Builder.richText(orgName) } : {}),
-      ...(ticket.type
-        ? { Type: Builder.select(formatLabel(ticket.type)) }
-        : {}),
+      "Requester Record": [Builder.relation(String(ticket.requester_id))],
+      Organization: orgName ? Builder.richText(orgName) : [],
+      "Organization Record":
+        ticket.organization_id != null
+          ? [Builder.relation(String(ticket.organization_id))]
+          : [],
+      Type: ticket.type ? Builder.select(formatLabel(ticket.type)) : [],
       Channel: Builder.select(
         CHANNEL_LABELS[ticket.via?.channel ?? "web"] ??
           formatLabel(ticket.via?.channel ?? "web")
       ),
-      ...(ticket.tags.length > 0
-        ? { Tags: Builder.multiSelect(...ticket.tags) }
-        : {}),
+      Tags: ticket.tags.length > 0 ? Builder.multiSelect(...ticket.tags) : [],
       "Created at": Builder.date(dateOnly(ticket.created_at)),
       "Ticket ID": Builder.richText(String(ticket.id)),
     },

--- a/workers/zendesk-sync/src/users.ts
+++ b/workers/zendesk-sync/src/users.ts
@@ -4,14 +4,14 @@
 
 import * as Schema from "@notionhq/workers/schema"
 import * as Builder from "@notionhq/workers/builder"
-import { notionIcon } from "@notionhq/workers"
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import type { ZendeskFullUser } from "./zendesk.js"
 import { formatLabel, dateOnly } from "./formatters.js"
 
 export const INITIAL_TITLE = "Zendesk Users"
 export const PRIMARY_KEY = "User ID"
 
-export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
+export const userSchema = {
   databaseIcon: notionIcon("people"),
   properties: {
     Name: Schema.title(),
@@ -32,6 +32,11 @@ export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Organization ID": Schema.richText(),
 
+    "Organization Record": Schema.relation("organizations", {
+      twoWay: true,
+      relatedPropertyName: "Users",
+    }),
+
     Phone: Schema.richText(),
 
     Suspended: Schema.checkbox(),
@@ -40,7 +45,7 @@ export const userSchema: Schema.Schema<typeof PRIMARY_KEY> = {
 
     "Created at": Schema.date(),
   },
-}
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
 
 const ROLE_LABELS: Record<string, string> = {
   "end-user": "End-user",
@@ -48,7 +53,9 @@ const ROLE_LABELS: Record<string, string> = {
   admin: "Admin",
 }
 
-export function userToChange(user: ZendeskFullUser) {
+export function userToChange(
+  user: ZendeskFullUser
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof userSchema.properties> {
   return {
     type: "upsert" as const,
     key: String(user.id),
@@ -56,21 +63,24 @@ export function userToChange(user: ZendeskFullUser) {
     properties: {
       Name: Builder.title(user.name ?? ""),
       "User ID": Builder.richText(String(user.id)),
-      ...(user.email ? { Email: Builder.email(user.email) } : {}),
+      Email: user.email ? Builder.email(user.email) : [],
       Role: Builder.select(
         ROLE_LABELS[user.role] ?? formatLabel(user.role ?? "end-user")
       ),
-      ...(user.organization_id
-        ? { "Organization ID": Builder.richText(String(user.organization_id)) }
-        : {}),
-      ...(user.phone ? { Phone: Builder.richText(user.phone) } : {}),
-      ...(user.tags.length > 0
-        ? { Tags: Builder.multiSelect(...user.tags) }
-        : {}),
+      "Organization ID":
+        user.organization_id != null
+          ? Builder.richText(String(user.organization_id))
+          : [],
+      "Organization Record":
+        user.organization_id != null
+          ? [Builder.relation(String(user.organization_id))]
+          : [],
+      Phone: user.phone ? Builder.richText(user.phone) : [],
+      Tags: user.tags.length > 0 ? Builder.multiSelect(...user.tags) : [],
       Suspended: Builder.checkbox(user.suspended),
-      ...(user.last_login_at
-        ? { "Last login": Builder.date(dateOnly(user.last_login_at)) }
-        : {}),
+      "Last login": user.last_login_at
+        ? Builder.date(dateOnly(user.last_login_at))
+        : [],
       "Created at": Builder.date(dateOnly(user.created_at)),
       "Updated at": Builder.date(dateOnly(user.updated_at)),
     },

--- a/workers/zendesk-sync/src/zendesk.ts
+++ b/workers/zendesk-sync/src/zendesk.ts
@@ -297,11 +297,9 @@ async function fetchSearchExportTicketsPage(
   if (page.meta.has_more && nextCursor === cursor) {
     throw new Error("Zendesk ticket search export repeated its cursor")
   }
-  if (page.meta.has_more && page.results.length === 0) {
-    throw new Error(
-      "Zendesk ticket search export returned a cursor without results"
-    )
-  }
+  // Search Export can return an empty page with has_more and a new cursor.
+  // Continue through it; the cursor-loop and page-count guards still fail
+  // closed if pagination stops making progress.
   if (includes.includes("metric_sets") && !Array.isArray(page.metric_sets)) {
     // A missing sideload must not be mistaken for an empty metrics keyspace;
     // completing replace mode in that case would delete valid metric pages.

--- a/workers/zendesk-sync/src/zendesk.ts
+++ b/workers/zendesk-sync/src/zendesk.ts
@@ -298,8 +298,8 @@ async function fetchSearchExportTicketsPage(
     throw new Error("Zendesk ticket search export repeated its cursor")
   }
   // Search Export can return an empty page with has_more and a new cursor.
-  // Continue through it; the cursor-loop and page-count guards still fail
-  // closed if pagination stops making progress.
+  // Continue through it; missing or immediately repeated cursors still fail
+  // closed.
   if (includes.includes("metric_sets") && !Array.isArray(page.metric_sets)) {
     // A missing sideload must not be mistaken for an empty metrics keyspace;
     // completing replace mode in that case would delete valid metric pages.
@@ -321,7 +321,10 @@ async function fetchSearchExportTicketsPage(
 
 // Sideloading embeds related objects in the ticket response so we can
 // resolve IDs to names without extra API calls.
-export async function fetchTicketsPage(cursor?: string): Promise<{
+export async function fetchTicketsPage(
+  cursor?: string,
+  startTime: number = INITIAL_EXPORT_START_TIME
+): Promise<{
   tickets: ZendeskExportTicket[]
   users: UserLookup
   groups: GroupLookup
@@ -331,7 +334,8 @@ export async function fetchTicketsPage(cursor?: string): Promise<{
 }> {
   const page = await fetchIncrementalTicketsPage(
     ["users", "groups", "organizations"],
-    cursor
+    cursor,
+    startTime
   )
 
   return {
@@ -367,32 +371,6 @@ export async function fetchTicketsReconciliationPage(
     orgs: page.orgs,
     hasMore: page.hasMore,
     nextCursor: page.nextCursor,
-  }
-}
-
-export async function fetchTicketsReconciliationTailPage(
-  startTime: number,
-  cursor?: string
-): Promise<{
-  tickets: ZendeskExportTicket[]
-  users: UserLookup
-  groups: GroupLookup
-  orgs: OrgLookup
-  hasMore: boolean
-  nextCursor: string
-}> {
-  const page = await fetchIncrementalTicketsPage(
-    ["users", "groups", "organizations"],
-    cursor,
-    startTime
-  )
-  return {
-    tickets: page.tickets,
-    users: userLookup(page.users),
-    groups: groupLookup(page.groups),
-    orgs: organizationLookup(page.organizations),
-    hasMore: !page.end_of_stream,
-    nextCursor: page.after_cursor,
   }
 }
 
@@ -561,13 +539,20 @@ export type ZendeskMinuteMetric = {
   business?: number | null
 }
 
-export async function fetchTicketMetricsPage(cursor?: string): Promise<{
+export async function fetchTicketMetricsPage(
+  cursor?: string,
+  startTime: number = INITIAL_EXPORT_START_TIME
+): Promise<{
   metrics: ZendeskTicketMetric[]
   deletedTicketIds: number[]
   hasMore: boolean
   nextCursor: string
 }> {
-  const page = await fetchIncrementalTicketsPage(["metric_sets"], cursor)
+  const page = await fetchIncrementalTicketsPage(
+    ["metric_sets"],
+    cursor,
+    startTime
+  )
   const deletedTicketIds = page.tickets
     .filter(isDeletedTicket)
     .map((ticket) => ticket.id)
@@ -604,30 +589,6 @@ export async function fetchTicketMetricsReconciliationPage(
     ),
     hasMore: page.hasMore,
     nextCursor: page.nextCursor,
-  }
-}
-
-export async function fetchTicketMetricsReconciliationTailPage(
-  startTime: number,
-  cursor?: string
-): Promise<{
-  metrics: ZendeskTicketMetric[]
-  deletedTicketIds: number[]
-  hasMore: boolean
-  nextCursor: string
-}> {
-  const page = await fetchIncrementalTicketsPage(
-    ["metric_sets"],
-    cursor,
-    startTime
-  )
-  return {
-    metrics: page.metric_sets ?? [],
-    deletedTicketIds: page.tickets
-      .filter(isDeletedTicket)
-      .map((ticket) => ticket.id),
-    hasMore: !page.end_of_stream,
-    nextCursor: page.after_cursor,
   }
 }
 

--- a/workers/zendesk-sync/src/zendesk.ts
+++ b/workers/zendesk-sync/src/zendesk.ts
@@ -175,10 +175,42 @@ type IncrementalTicketsResponse = {
   end_of_stream: boolean
 }
 
+type SearchExportTicket = ZendeskExportTicket & {
+  result_type?: string
+}
+
+type SearchExportTicketsResponse = {
+  results: SearchExportTicket[]
+  users?: ZendeskUser[]
+  groups?: ZendeskGroup[]
+  organizations?: ZendeskOrganizationRef[]
+  metric_sets?: ZendeskTicketMetric[]
+  meta: {
+    has_more: boolean
+    after_cursor?: string | null
+  }
+}
+
+type SearchExportTicketsPage = {
+  tickets: ZendeskExportTicket[]
+  users: UserLookup
+  groups: GroupLookup
+  orgs: OrgLookup
+  metrics: ZendeskTicketMetric[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}
+
 async function fetchIncrementalTicketsPage(
   includes: string[],
-  cursor?: string
+  cursor?: string,
+  startTime: number = INITIAL_EXPORT_START_TIME
 ): Promise<IncrementalTicketsResponse> {
+  if (!Number.isSafeInteger(startTime) || startTime < 1) {
+    throw new Error(
+      "Zendesk incremental export start_time must be a positive Unix timestamp"
+    )
+  }
   const subdomain = requireSubdomain()
   const url = new URL(
     `https://${subdomain}.zendesk.com/api/v2/incremental/tickets/cursor`
@@ -191,7 +223,7 @@ async function fetchIncrementalTicketsPage(
   if (cursor) {
     url.searchParams.set("cursor", cursor)
   } else {
-    url.searchParams.set("start_time", String(INITIAL_EXPORT_START_TIME))
+    url.searchParams.set("start_time", String(startTime))
   }
 
   const page = await fetchJson<IncrementalTicketsResponse>(url.toString())
@@ -201,7 +233,92 @@ async function fetchIncrementalTicketsPage(
   if (!page.end_of_stream && page.after_cursor === cursor) {
     throw new Error("Zendesk incremental export repeated its cursor")
   }
+  if (includes.includes("metric_sets") && !Array.isArray(page.metric_sets)) {
+    throw new Error(
+      "Zendesk incremental export is missing its metric_sets sideload"
+    )
+  }
   return page
+}
+
+function userLookup(users: ZendeskUser[] | undefined): UserLookup {
+  return new Map((users ?? []).map((user) => [user.id, user]))
+}
+
+function groupLookup(groups: ZendeskGroup[] | undefined): GroupLookup {
+  return new Map((groups ?? []).map((group) => [group.id, group]))
+}
+
+function organizationLookup(
+  organizations: ZendeskOrganizationRef[] | undefined
+): OrgLookup {
+  return new Map((organizations ?? []).map((org) => [org.id, org]))
+}
+
+async function fetchSearchExportTicketsPage(
+  createdBefore: string,
+  includes: string[],
+  cursor?: string
+): Promise<SearchExportTicketsPage> {
+  const subdomain = requireSubdomain()
+  const url = new URL(`https://${subdomain}.zendesk.com/api/v2/search/export`)
+  url.searchParams.set("filter[type]", "ticket")
+  url.searchParams.set("query", `created<=${createdBefore}`)
+  // Zendesk allows up to 1,000 Search Export results but recommends 100 when
+  // archived tickets are present because larger responses may time out.
+  url.searchParams.set("page[size]", String(PAGE_SIZE))
+  url.searchParams.set("include", `tickets(${includes.join(",")})`)
+  if (cursor) {
+    url.searchParams.set("page[after]", cursor)
+  }
+
+  const page = await fetchJson<SearchExportTicketsResponse>(url.toString())
+  if (
+    !Array.isArray(page.results) ||
+    typeof page.meta?.has_more !== "boolean"
+  ) {
+    throw new Error("Zendesk ticket search export returned an invalid page")
+  }
+  if (
+    page.results.some(
+      (result) =>
+        result.result_type !== undefined && result.result_type !== "ticket"
+    )
+  ) {
+    throw new Error("Zendesk ticket search export returned a non-ticket result")
+  }
+
+  const nextCursor = page.meta.has_more
+    ? (page.meta.after_cursor ?? undefined)
+    : undefined
+  if (page.meta.has_more && !nextCursor) {
+    throw new Error("Zendesk ticket search export is missing its after_cursor")
+  }
+  if (page.meta.has_more && nextCursor === cursor) {
+    throw new Error("Zendesk ticket search export repeated its cursor")
+  }
+  if (page.meta.has_more && page.results.length === 0) {
+    throw new Error(
+      "Zendesk ticket search export returned a cursor without results"
+    )
+  }
+  if (includes.includes("metric_sets") && !Array.isArray(page.metric_sets)) {
+    // A missing sideload must not be mistaken for an empty metrics keyspace;
+    // completing replace mode in that case would delete valid metric pages.
+    throw new Error(
+      "Zendesk ticket search export is missing its metric_sets sideload"
+    )
+  }
+
+  return {
+    tickets: page.results,
+    users: userLookup(page.users),
+    groups: groupLookup(page.groups),
+    orgs: organizationLookup(page.organizations),
+    metrics: page.metric_sets ?? [],
+    hasMore: page.meta.has_more,
+    nextCursor,
+  }
 }
 
 // Sideloading embeds related objects in the ticket response so we can
@@ -219,26 +336,63 @@ export async function fetchTicketsPage(cursor?: string): Promise<{
     cursor
   )
 
-  const users: UserLookup = new Map()
-  for (const user of page.users ?? []) {
-    users.set(user.id, user)
-  }
-
-  const groups: GroupLookup = new Map()
-  for (const group of page.groups ?? []) {
-    groups.set(group.id, group)
-  }
-
-  const orgs: OrgLookup = new Map()
-  for (const org of page.organizations ?? []) {
-    orgs.set(org.id, org)
-  }
-
   return {
     tickets: page.tickets,
-    users,
-    groups,
-    orgs,
+    users: userLookup(page.users),
+    groups: groupLookup(page.groups),
+    orgs: organizationLookup(page.organizations),
+    hasMore: !page.end_of_stream,
+    nextCursor: page.after_cursor,
+  }
+}
+
+export async function fetchTicketsReconciliationPage(
+  createdBefore: string,
+  cursor?: string
+): Promise<{
+  tickets: ZendeskExportTicket[]
+  users: UserLookup
+  groups: GroupLookup
+  orgs: OrgLookup
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const page = await fetchSearchExportTicketsPage(
+    createdBefore,
+    ["users", "groups", "organizations"],
+    cursor
+  )
+  return {
+    tickets: page.tickets,
+    users: page.users,
+    groups: page.groups,
+    orgs: page.orgs,
+    hasMore: page.hasMore,
+    nextCursor: page.nextCursor,
+  }
+}
+
+export async function fetchTicketsReconciliationTailPage(
+  startTime: number,
+  cursor?: string
+): Promise<{
+  tickets: ZendeskExportTicket[]
+  users: UserLookup
+  groups: GroupLookup
+  orgs: OrgLookup
+  hasMore: boolean
+  nextCursor: string
+}> {
+  const page = await fetchIncrementalTicketsPage(
+    ["users", "groups", "organizations"],
+    cursor,
+    startTime
+  )
+  return {
+    tickets: page.tickets,
+    users: userLookup(page.users),
+    groups: groupLookup(page.groups),
+    orgs: organizationLookup(page.organizations),
     hasMore: !page.end_of_stream,
     nextCursor: page.after_cursor,
   }
@@ -423,6 +577,57 @@ export async function fetchTicketMetricsPage(cursor?: string): Promise<{
   return {
     metrics: page.metric_sets ?? [],
     deletedTicketIds,
+    hasMore: !page.end_of_stream,
+    nextCursor: page.after_cursor,
+  }
+}
+
+export async function fetchTicketMetricsReconciliationPage(
+  createdBefore: string,
+  cursor?: string
+): Promise<{
+  metrics: ZendeskTicketMetric[]
+  hasMore: boolean
+  nextCursor: string | undefined
+}> {
+  const page = await fetchSearchExportTicketsPage(
+    createdBefore,
+    ["metric_sets"],
+    cursor
+  )
+  const liveTicketIds = new Set(
+    page.tickets
+      .filter((ticket) => !isDeletedTicket(ticket))
+      .map((ticket) => ticket.id)
+  )
+  return {
+    metrics: page.metrics.filter((metric) =>
+      liveTicketIds.has(metric.ticket_id)
+    ),
+    hasMore: page.hasMore,
+    nextCursor: page.nextCursor,
+  }
+}
+
+export async function fetchTicketMetricsReconciliationTailPage(
+  startTime: number,
+  cursor?: string
+): Promise<{
+  metrics: ZendeskTicketMetric[]
+  deletedTicketIds: number[]
+  hasMore: boolean
+  nextCursor: string
+}> {
+  const page = await fetchIncrementalTicketsPage(
+    ["metric_sets"],
+    cursor,
+    startTime
+  )
+  return {
+    metrics: page.metric_sets ?? [],
+    deletedTicketIds: page.tickets
+      .filter(isDeletedTicket)
+      .map((ticket) => ticket.id),
     hasMore: !page.end_of_stream,
     nextCursor: page.after_cursor,
   }

--- a/workers/zendesk-sync/test.ts
+++ b/workers/zendesk-sync/test.ts
@@ -734,6 +734,20 @@ async function testZendeskClient() {
         })
       }
 
+      if (cursor === "empty-continuation") {
+        return Response.json({
+          results: [],
+          users: metrics ? undefined : [],
+          groups: metrics ? undefined : [],
+          organizations: metrics ? undefined : [],
+          metric_sets: metrics ? [] : undefined,
+          meta: {
+            has_more: true,
+            after_cursor: "empty-continuation-next",
+          },
+        })
+      }
+
       if (cursor === "cycle-a") {
         return Response.json({
           results: [{ ...standardTicket, result_type: "ticket" }],
@@ -817,6 +831,16 @@ async function testZendeskClient() {
     )
     const firstMetricReconciliation =
       await fetchTicketMetricsReconciliationPage(reconciliationCutoff)
+    const emptyTicketReconciliationContinuation =
+      await fetchTicketsReconciliationPage(
+        reconciliationCutoff,
+        "empty-continuation"
+      )
+    const emptyMetricReconciliationContinuation =
+      await fetchTicketMetricsReconciliationPage(
+        reconciliationCutoff,
+        "empty-continuation"
+      )
     const reconciliationTailStart = Math.floor(
       new Date(reconciliationCutoff).getTime() / 1_000
     )
@@ -1147,6 +1171,17 @@ async function testZendeskClient() {
         capabilityTicketTailUrl != null &&
         continuedTicketSearchUrl?.searchParams.get("query") ===
           `created<=${ticketReconciliationRun.nextUserContext?.createdBefore}`
+    )
+    ok(
+      "empty Search Export pages advance with their continuation cursor",
+      emptyTicketReconciliationContinuation.tickets.length === 0 &&
+        emptyTicketReconciliationContinuation.hasMore &&
+        emptyTicketReconciliationContinuation.nextCursor ===
+          "empty-continuation-next" &&
+        emptyMetricReconciliationContinuation.metrics.length === 0 &&
+        emptyMetricReconciliationContinuation.hasMore &&
+        emptyMetricReconciliationContinuation.nextCursor ===
+          "empty-continuation-next"
     )
     ok(
       "Search Export cursor loops fail closed",

--- a/workers/zendesk-sync/test.ts
+++ b/workers/zendesk-sync/test.ts
@@ -695,7 +695,9 @@ async function testZendeskClient() {
         return Response.json({
           tickets: [
             { id: 404, status: "deleted" },
-            ...(isReconciliationTail ? [tailOnlyTicket] : []),
+            ...(isReconciliationTail
+              ? [tailOnlyTicket, { id: 42, status: "deleted" as const }]
+              : []),
           ],
           metric_sets: [
             partialMetric,
@@ -716,8 +718,9 @@ async function testZendeskClient() {
 
       return Response.json({
         tickets: [
-          standardTicket,
-          ...(isReconciliationTail ? [tailOnlyTicket] : []),
+          ...(isReconciliationTail
+            ? [tailOnlyTicket, { id: 42, status: "deleted" as const }]
+            : [standardTicket]),
           { id: 404, status: "deleted" },
         ],
         users: [...users.values()],
@@ -1070,6 +1073,27 @@ async function testZendeskClient() {
         ) &&
         !ticketReconciliationFinalRun.hasMore &&
         capabilityTicketTailUrl != null
+    )
+    ok(
+      "reconciliation tails delete keys previously seen during Search",
+      ticketReconciliationRun.changes.some(
+        (change) => change.type === "upsert" && change.key === "42"
+      ) &&
+        ticketReconciliationTailRun.changes.some(
+          (change) => change.type === "delete" && change.key === "42"
+        ) &&
+        !ticketReconciliationTailRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "42"
+        ) &&
+        metricReconciliationRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "42"
+        ) &&
+        metricReconciliationFinalRun.changes.some(
+          (change) => change.type === "delete" && change.key === "42"
+        ) &&
+        !metricReconciliationFinalRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "42"
+        )
     )
     ok(
       "empty Search Export pages advance with their continuation cursor",

--- a/workers/zendesk-sync/test.ts
+++ b/workers/zendesk-sync/test.ts
@@ -17,10 +17,8 @@ import {
   fetchSurveyResponsesPage,
   fetchTicketMetricsPage,
   fetchTicketMetricsReconciliationPage,
-  fetchTicketMetricsReconciliationTailPage,
   fetchTicketsPage,
   fetchTicketsReconciliationPage,
-  fetchTicketsReconciliationTailPage,
   getAuthorizationHeader,
   isDeletedTicket,
 } from "./src/zendesk.js"
@@ -47,6 +45,15 @@ function ok(name: string, cond: boolean) {
     failed++
     console.log(`  FAIL ${name}`)
   }
+}
+
+async function captureError(action: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await action()
+  } catch (error) {
+    return error
+  }
+  return undefined
 }
 
 function isEmptyProperty(value: unknown): boolean {
@@ -734,6 +741,17 @@ async function testZendeskClient() {
         })
       }
 
+      if (cursor === "missing-cursor") {
+        return Response.json({
+          results: [],
+          meta: { has_more: true, after_cursor: null },
+        })
+      }
+
+      if (cursor === "malformed-page") {
+        return Response.json({ results: null, meta: { has_more: "yes" } })
+      }
+
       if (cursor === "empty-continuation") {
         return Response.json({
           results: [],
@@ -745,16 +763,6 @@ async function testZendeskClient() {
             has_more: true,
             after_cursor: "empty-continuation-next",
           },
-        })
-      }
-
-      if (cursor === "cycle-a") {
-        return Response.json({
-          results: [{ ...standardTicket, result_type: "ticket" }],
-          users: [...users.values()],
-          groups: [...groups.values()],
-          organizations: [...orgs.values()],
-          meta: { has_more: true, after_cursor: "cycle-b" },
         })
       }
 
@@ -823,14 +831,6 @@ async function testZendeskClient() {
     const finalTicketsPage = await fetchTicketsPage("ticket-cursor-1")
     const metricsPage = await fetchTicketMetricsPage("metric-cursor-1")
     const reconciliationCutoff = "2024-06-30T00:00:00.000Z"
-    const firstTicketReconciliation =
-      await fetchTicketsReconciliationPage(reconciliationCutoff)
-    const finalTicketReconciliation = await fetchTicketsReconciliationPage(
-      reconciliationCutoff,
-      firstTicketReconciliation.nextCursor
-    )
-    const firstMetricReconciliation =
-      await fetchTicketMetricsReconciliationPage(reconciliationCutoff)
     const emptyTicketReconciliationContinuation =
       await fetchTicketsReconciliationPage(
         reconciliationCutoff,
@@ -844,15 +844,6 @@ async function testZendeskClient() {
     const reconciliationTailStart = Math.floor(
       new Date(reconciliationCutoff).getTime() / 1_000
     )
-    const firstTicketReconciliationTail =
-      await fetchTicketsReconciliationTailPage(reconciliationTailStart)
-    const finalTicketReconciliationTail =
-      await fetchTicketsReconciliationTailPage(
-        reconciliationTailStart,
-        firstTicketReconciliationTail.nextCursor
-      )
-    const metricReconciliationTail =
-      await fetchTicketMetricsReconciliationTailPage(reconciliationTailStart)
     const firstSurveyPage = await fetchSurveyResponsesPage()
     const finalSurveyPage = await fetchSurveyResponsesPage(
       firstSurveyPage.nextCursor
@@ -865,133 +856,71 @@ async function testZendeskClient() {
       nextUserContext?: {
         phase?: "search" | "tail"
         cursor?: string
-        createdBefore?: string
-        tailStartTime?: number
-        recentCursors?: string[]
-        pageCount?: number
+        cutoff?: string
       }
     }
-    const initialTicketRun = (await worker.run(
-      "ticketsSync",
-      {},
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const finalTicketRun = (await worker.run(
-      "ticketsSync",
-      { state: { cursor: "ticket-cursor-1" } },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const metricRun = (await worker.run(
-      "ticketMetricsSync",
-      { state: { cursor: "metric-cursor-1" } },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const ticketReconciliationRun = (await worker.run(
-      "ticketsReconciliationSync",
-      {},
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const ticketReconciliationTailTransitionRun = (await worker.run(
-      "ticketsReconciliationSync",
-      { state: ticketReconciliationRun.nextUserContext },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const ticketReconciliationTailRun = (await worker.run(
-      "ticketsReconciliationSync",
-      { state: ticketReconciliationTailTransitionRun.nextUserContext },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const ticketReconciliationFinalRun = (await worker.run(
-      "ticketsReconciliationSync",
-      { state: ticketReconciliationTailRun.nextUserContext },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const metricReconciliationRun = (await worker.run(
-      "ticketMetricsReconciliationSync",
-      {},
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const metricReconciliationTailTransitionRun = (await worker.run(
-      "ticketMetricsReconciliationSync",
-      { state: metricReconciliationRun.nextUserContext },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const metricReconciliationFinalRun = (await worker.run(
-      "ticketMetricsReconciliationSync",
-      { state: metricReconciliationTailTransitionRun.nextUserContext },
-      { concreteOutput: true }
-    )) as SyncRunResult
-    const surveyRun = (await worker.run(
-      "surveyResponsesSync",
-      {},
-      { concreteOutput: true }
-    )) as SyncRunResult
+    type TestSyncKey =
+      | "ticketsSync"
+      | "ticketMetricsSync"
+      | "ticketsReconciliationSync"
+      | "ticketMetricsReconciliationSync"
+      | "surveyResponsesSync"
+    const runSync = async (key: TestSyncKey, state?: unknown) =>
+      (await worker.run(key, state === undefined ? {} : { state }, {
+        concreteOutput: true,
+      })) as SyncRunResult
 
-    let rateLimitError: unknown
-    try {
-      await fetchPage("acme", "/api/v2/organizations.json")
-    } catch (error) {
-      rateLimitError = error
-    }
-    let rateLimitWithoutHeader: unknown
-    try {
-      await fetchPage("acme", "/api/v2/users.json")
-    } catch (error) {
-      rateLimitWithoutHeader = error
-    }
-    let repeatedSearchCursorError: unknown
-    try {
-      await fetchTicketsReconciliationPage(reconciliationCutoff, "repeat")
-    } catch (error) {
-      repeatedSearchCursorError = error
-    }
-    let missingMetricSideloadError: unknown
-    try {
-      await fetchTicketMetricsReconciliationTailPage(
-        reconciliationTailStart,
-        "missing-metric-sideload"
-      )
-    } catch (error) {
-      missingMetricSideloadError = error
-    }
-    let reconciliationPageBoundError: unknown
-    try {
-      await worker.run(
-        "ticketsReconciliationSync",
-        {
-          state: {
-            phase: "tail",
-            cursor: "bound-cursor",
-            createdBefore: reconciliationCutoff,
-            tailStartTime: reconciliationTailStart,
-            recentCursors: ["bound-cursor"],
-            pageCount: 2_000,
-          },
-        },
-        { concreteOutput: true }
-      )
-    } catch (error) {
-      reconciliationPageBoundError = error
-    }
-    let nonImmediateCursorCycleError: unknown
-    try {
-      await worker.run(
-        "ticketsReconciliationSync",
-        {
-          state: {
-            phase: "search",
-            cursor: "cycle-a",
-            createdBefore: reconciliationCutoff,
-            tailStartTime: reconciliationTailStart,
-            recentCursors: ["cycle-b", "cycle-a"],
-            pageCount: 2,
-          },
-        },
-        { concreteOutput: true }
-      )
-    } catch (error) {
-      nonImmediateCursorCycleError = error
-    }
+    const initialTicketRun = await runSync("ticketsSync")
+    const finalTicketRun = await runSync("ticketsSync", {
+      cursor: "ticket-cursor-1",
+    })
+    const metricRun = await runSync("ticketMetricsSync", {
+      cursor: "metric-cursor-1",
+    })
+    const ticketReconciliationRun = await runSync("ticketsReconciliationSync")
+    const ticketReconciliationTailTransitionRun = await runSync(
+      "ticketsReconciliationSync",
+      ticketReconciliationRun.nextUserContext
+    )
+    const ticketReconciliationTailRun = await runSync(
+      "ticketsReconciliationSync",
+      ticketReconciliationTailTransitionRun.nextUserContext
+    )
+    const ticketReconciliationFinalRun = await runSync(
+      "ticketsReconciliationSync",
+      ticketReconciliationTailRun.nextUserContext
+    )
+    const metricReconciliationRun = await runSync(
+      "ticketMetricsReconciliationSync"
+    )
+    const metricReconciliationTailTransitionRun = await runSync(
+      "ticketMetricsReconciliationSync",
+      metricReconciliationRun.nextUserContext
+    )
+    const metricReconciliationFinalRun = await runSync(
+      "ticketMetricsReconciliationSync",
+      metricReconciliationTailTransitionRun.nextUserContext
+    )
+    const surveyRun = await runSync("surveyResponsesSync")
+
+    const rateLimitError = await captureError(() =>
+      fetchPage("acme", "/api/v2/organizations.json")
+    )
+    const rateLimitWithoutHeader = await captureError(() =>
+      fetchPage("acme", "/api/v2/users.json")
+    )
+    const repeatedSearchCursorError = await captureError(() =>
+      fetchTicketsReconciliationPage(reconciliationCutoff, "repeat")
+    )
+    const missingSearchCursorError = await captureError(() =>
+      fetchTicketsReconciliationPage(reconciliationCutoff, "missing-cursor")
+    )
+    const malformedSearchPageError = await captureError(() =>
+      fetchTicketsReconciliationPage(reconciliationCutoff, "malformed-page")
+    )
+    const missingMetricSideloadError = await captureError(() =>
+      fetchTicketMetricsPage("missing-metric-sideload", reconciliationTailStart)
+    )
 
     const initialTicketUrl = requestedUrls.find(
       (url) =>
@@ -1070,64 +999,38 @@ async function testZendeskClient() {
         url.searchParams.get("include") === "tickets(metric_sets)" &&
         !url.searchParams.has("page[after]")
     )
+    const ticketCutoff = ticketReconciliationRun.nextUserContext?.cutoff
+    const metricCutoff = metricReconciliationRun.nextUserContext?.cutoff
+    const tailStart = ticketCutoff
+      ? Math.floor(Date.parse(ticketCutoff) / 1_000)
+      : undefined
     const continuedTicketSearchUrl = requestedUrls.find(
       (url) =>
         url.pathname === "/api/v2/search/export" &&
-        url.searchParams.get("page[after]") === "ticket-search-cursor" &&
-        url.searchParams.get("query") ===
-          `created<=${ticketReconciliationRun.nextUserContext?.createdBefore}`
-    )
-    const directTicketTailUrl = requestedUrls.find(
-      (url) =>
-        url.pathname === "/api/v2/incremental/tickets/cursor" &&
-        url.searchParams.get("include") === "users,groups,organizations" &&
-        url.searchParams.get("start_time") === String(reconciliationTailStart)
-    )
-    const directMetricTailUrl = requestedUrls.find(
-      (url) =>
-        url.pathname === "/api/v2/incremental/tickets/cursor" &&
-        url.searchParams.get("include") === "metric_sets" &&
-        url.searchParams.get("start_time") === String(reconciliationTailStart)
+        url.searchParams.get("page[after]") === "ticket-search-cursor"
     )
     const capabilityTicketTailUrl = requestedUrls.find(
       (url) =>
         url.pathname === "/api/v2/incremental/tickets/cursor" &&
         url.searchParams.get("include") === "users,groups,organizations" &&
-        url.searchParams.get("start_time") ===
-          String(
-            ticketReconciliationTailTransitionRun.nextUserContext?.tailStartTime
-          )
+        url.searchParams.get("start_time") === String(tailStart)
     )
     ok(
       "ticket reconciliation uses a pinned archived-ticket Search Export",
-      firstTicketReconciliation.tickets[0]?.id === standardTicket.id &&
-        firstTicketReconciliation.hasMore &&
-        !finalTicketReconciliation.hasMore &&
-        ticketSearchUrl?.searchParams.get("filter[type]") === "ticket" &&
+      ticketSearchUrl?.searchParams.get("filter[type]") === "ticket" &&
         ticketSearchUrl.searchParams.get("query") ===
-          `created<=${reconciliationCutoff}` &&
-        ticketSearchUrl.searchParams.get("page[size]") === "100"
+          `created<=${ticketCutoff}` &&
+        ticketSearchUrl.searchParams.get("page[size]") === "100" &&
+        continuedTicketSearchUrl?.searchParams.get("query") ===
+          `created<=${ticketCutoff}`
     )
     ok(
       "metric reconciliation uses archived ticket metric sideloads",
-      firstMetricReconciliation.metrics[0]?.ticket_id === 42 &&
-        firstMetricReconciliation.hasMore &&
-        metricSearchUrl?.searchParams.get("query") ===
-          `created<=${reconciliationCutoff}`
-    )
-    ok(
-      "reconciliation tails cover new records through incremental end_of_stream",
-      firstTicketReconciliationTail.hasMore &&
-        firstTicketReconciliationTail.tickets.some(
-          (ticket) => ticket.id === tailOnlyTicket.id
-        ) &&
-        !finalTicketReconciliationTail.hasMore &&
-        metricReconciliationTail.metrics.some(
-          (metric) => metric.ticket_id === tailOnlyMetric.ticket_id
-        ) &&
-        metricReconciliationTail.deletedTicketIds.join(",") === "404" &&
-        directTicketTailUrl != null &&
-        directMetricTailUrl != null
+      metricSearchUrl?.searchParams.get("query") ===
+        `created<=${metricCutoff}` &&
+        metricReconciliationRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "42"
+        )
     )
     ok(
       "manual reconciliation capabilities preserve cutoff state and finish only after the tail",
@@ -1137,22 +1040,21 @@ async function testZendeskClient() {
         !ticketReconciliationRun.changes.some(
           (change) => change.key === "777"
         ) &&
-        metricReconciliationRun.changes.some(
-          (change) => change.type === "upsert" && change.key === "42"
-        ) &&
         !metricReconciliationRun.changes.some(
           (change) => change.key === "777"
         ) &&
         ticketReconciliationRun.nextUserContext?.phase === "search" &&
-        ticketReconciliationRun.nextUserContext?.createdBefore != null &&
-        ticketReconciliationRun.nextUserContext?.pageCount === 1 &&
+        ticketCutoff != null &&
+        Object.keys(ticketReconciliationRun.nextUserContext)
+          .sort()
+          .join(",") === "cursor,cutoff,phase" &&
         ticketReconciliationTailTransitionRun.hasMore &&
         ticketReconciliationTailTransitionRun.nextUserContext?.phase ===
           "tail" &&
         ticketReconciliationTailTransitionRun.nextUserContext?.cursor ===
           undefined &&
-        ticketReconciliationTailTransitionRun.nextUserContext?.pageCount ===
-          0 &&
+        ticketReconciliationTailTransitionRun.nextUserContext?.cutoff ===
+          ticketCutoff &&
         ticketReconciliationTailRun.hasMore &&
         ticketReconciliationTailRun.nextUserContext?.phase === "tail" &&
         ticketReconciliationTailRun.nextUserContext?.cursor ===
@@ -1160,7 +1062,6 @@ async function testZendeskClient() {
         ticketReconciliationTailRun.changes.some(
           (change) => change.type === "upsert" && change.key === "777"
         ) &&
-        metricReconciliationRun.nextUserContext?.createdBefore != null &&
         metricReconciliationTailTransitionRun.nextUserContext?.phase ===
           "tail" &&
         !metricReconciliationFinalRun.hasMore &&
@@ -1168,9 +1069,7 @@ async function testZendeskClient() {
           (change) => change.type === "upsert" && change.key === "777"
         ) &&
         !ticketReconciliationFinalRun.hasMore &&
-        capabilityTicketTailUrl != null &&
-        continuedTicketSearchUrl?.searchParams.get("query") ===
-          `created<=${ticketReconciliationRun.nextUserContext?.createdBefore}`
+        capabilityTicketTailUrl != null
     )
     ok(
       "empty Search Export pages advance with their continuation cursor",
@@ -1184,21 +1083,19 @@ async function testZendeskClient() {
           "empty-continuation-next"
     )
     ok(
-      "Search Export cursor loops fail closed",
+      "malformed Search Export pages and cursors fail closed",
       repeatedSearchCursorError instanceof Error &&
-        repeatedSearchCursorError.message.includes("repeated its cursor")
+        repeatedSearchCursorError.message.includes("repeated its cursor") &&
+        missingSearchCursorError instanceof Error &&
+        missingSearchCursorError.message.includes("missing its after_cursor") &&
+        malformedSearchPageError instanceof Error &&
+        malformedSearchPageError.message.includes("returned an invalid page")
     )
     ok(
-      "reconciliation rejects missing metric sideloads and unsafe state",
+      "reconciliation rejects missing metric sideloads",
       missingMetricSideloadError instanceof Error &&
         missingMetricSideloadError.message.includes(
           "missing its metric_sets sideload"
-        ) &&
-        reconciliationPageBoundError instanceof Error &&
-        reconciliationPageBoundError.message.includes("page bound") &&
-        nonImmediateCursorCycleError instanceof Error &&
-        nonImmediateCursorCycleError.message.includes(
-          "repeated a recent cursor"
         )
     )
     const finalSurveyUrl = requestedUrls.find(

--- a/workers/zendesk-sync/test.ts
+++ b/workers/zendesk-sync/test.ts
@@ -7,6 +7,7 @@ import worker from "./src/index.js"
 import { ticketToChange, ticketUrl } from "./src/tickets.js"
 import { formatLabel, dateOnly } from "./src/formatters.js"
 import { userToChange } from "./src/users.js"
+import { organizationToChange } from "./src/organizations.js"
 import { ticketMetricToChange } from "./src/ticket-metrics.js"
 import { slaPolicyToChange } from "./src/sla-policies.js"
 import { surveyResponseToChange } from "./src/survey-responses.js"
@@ -15,12 +16,17 @@ import {
   fetchSlaPoliciesPage,
   fetchSurveyResponsesPage,
   fetchTicketMetricsPage,
+  fetchTicketMetricsReconciliationPage,
+  fetchTicketMetricsReconciliationTailPage,
   fetchTicketsPage,
+  fetchTicketsReconciliationPage,
+  fetchTicketsReconciliationTailPage,
   getAuthorizationHeader,
   isDeletedTicket,
 } from "./src/zendesk.js"
 import type {
   ZendeskFullUser,
+  ZendeskOrganization,
   ZendeskTicket,
   ZendeskTicketMetric,
   ZendeskSlaPolicy,
@@ -41,6 +47,10 @@ function ok(name: string, cond: boolean) {
     failed++
     console.log(`  FAIL ${name}`)
   }
+}
+
+function isEmptyProperty(value: unknown): boolean {
+  return Array.isArray(value) && value.length === 0
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +88,13 @@ const standardTicket: ZendeskTicket = {
   via: { channel: "email" },
   created_at: "2024-06-15T10:30:00Z",
   updated_at: "2024-06-16T14:00:00Z",
+}
+
+const tailOnlyTicket: ZendeskTicket = {
+  ...standardTicket,
+  id: 777,
+  subject: "Created after the reconciliation search cutoff",
+  updated_at: "2024-06-30T00:02:00Z",
 }
 
 const change = ticketToChange(standardTicket, SUBDOMAIN, users, groups, orgs)
@@ -125,6 +142,10 @@ ok(
   JSON.stringify(change.properties.Assignee).includes("Jane Smith")
 )
 ok(
+  "Assignee relation uses the stable user id",
+  JSON.stringify(change.properties["Assignee Record"]).includes("1001")
+)
+ok(
   "Group resolved to name",
   JSON.stringify(change.properties.Group).includes("Billing Support")
 )
@@ -133,8 +154,16 @@ ok(
   JSON.stringify(change.properties.Requester).includes("Bob Customer")
 )
 ok(
+  "Requester relation uses the stable user id",
+  JSON.stringify(change.properties["Requester Record"]).includes("2001")
+)
+ok(
   "Organization resolved to name",
   JSON.stringify(change.properties.Organization).includes("Acme Corp")
+)
+ok(
+  "Organization relation uses the stable organization id",
+  JSON.stringify(change.properties["Organization Record"]).includes("500")
 )
 ok(
   "Created at contains date",
@@ -185,20 +214,25 @@ const minimalChange = ticketToChange(
 )
 
 ok("key is ticket id", minimalChange.key === "99")
-ok("null type omits Type", minimalChange.properties.Type === undefined)
+ok("null type clears Type", isEmptyProperty(minimalChange.properties.Type))
 ok(
-  "null priority omits Priority",
-  minimalChange.properties.Priority === undefined
+  "null priority clears Priority",
+  isEmptyProperty(minimalChange.properties.Priority)
 )
-ok("empty tags omits Tags", minimalChange.properties.Tags === undefined)
+ok("empty tags clears Tags", isEmptyProperty(minimalChange.properties.Tags))
 ok(
-  "null assignee_id omits Assignee",
-  minimalChange.properties.Assignee === undefined
+  "null assignee_id clears Assignee and its relation",
+  isEmptyProperty(minimalChange.properties.Assignee) &&
+    isEmptyProperty(minimalChange.properties["Assignee Record"])
 )
-ok("null group_id omits Group", minimalChange.properties.Group === undefined)
 ok(
-  "null organization_id omits Organization",
-  minimalChange.properties.Organization === undefined
+  "null group_id clears Group",
+  isEmptyProperty(minimalChange.properties.Group)
+)
+ok(
+  "null organization_id clears Organization and its relation",
+  isEmptyProperty(minimalChange.properties.Organization) &&
+    isEmptyProperty(minimalChange.properties["Organization Record"])
 )
 ok(
   "requester resolved to name",
@@ -235,8 +269,11 @@ ok(
   JSON.stringify(fallbackChange.properties.Group).includes("100")
 )
 ok(
-  "unknown org omits Organization",
-  fallbackChange.properties.Organization === undefined
+  "unknown org falls back to its id and preserves the stable relation",
+  JSON.stringify(fallbackChange.properties.Organization).includes("500") &&
+    JSON.stringify(fallbackChange.properties["Organization Record"]).includes(
+      "500"
+    )
 )
 
 // ---------------------------------------------------------------------------
@@ -299,17 +336,64 @@ ok(
   JSON.stringify(endUserChange.properties.Role).includes("End-user") &&
     !JSON.stringify(endUserChange.properties.Role).includes("End-User")
 )
+ok(
+  "missing user fields explicitly clear stale values",
+  isEmptyProperty(endUserChange.properties.Email) === false &&
+    isEmptyProperty(endUserChange.properties["Organization ID"]) &&
+    isEmptyProperty(endUserChange.properties["Organization Record"]) &&
+    isEmptyProperty(endUserChange.properties.Phone) &&
+    isEmptyProperty(endUserChange.properties.Tags) &&
+    isEmptyProperty(endUserChange.properties["Last login"])
+)
+const organizationUserChange = userToChange({
+  ...endUser,
+  organization_id: 500,
+})
+ok(
+  "user organization relation uses the stable organization id",
+  JSON.stringify(
+    organizationUserChange.properties["Organization Record"]
+  ).includes("500")
+)
+
+const organization: ZendeskOrganization = {
+  id: 500,
+  name: "Acme Corp",
+  domain_names: [],
+  details: null,
+  notes: null,
+  tags: [],
+  group_id: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-02T00:00:00Z",
+}
+const organizationChange = organizationToChange(organization)
+ok(
+  "missing organization fields and page content explicitly clear",
+  isEmptyProperty(organizationChange.properties.Domains) &&
+    isEmptyProperty(organizationChange.properties.Tags) &&
+    isEmptyProperty(organizationChange.properties.Details) &&
+    organizationChange.pageContentMarkdown === ""
+)
 
 const partialMetric: ZendeskTicketMetric = {
   id: 8001,
   ticket_id: 42,
 }
+const tailOnlyMetric: ZendeskTicketMetric = {
+  id: 8002,
+  ticket_id: 777,
+  updated_at: "2024-06-30T00:02:00Z",
+}
 const partialMetricChange = ticketMetricToChange(partialMetric)
 ok(
-  "optional ticket metrics do not crash or emit invalid numbers",
-  partialMetricChange.properties["First Reply (min)"] === undefined &&
-    partialMetricChange.properties["Full Resolution (min)"] === undefined &&
-    partialMetricChange.properties.Reopens === undefined
+  "optional ticket metrics clear stale values and retain their ticket relation",
+  isEmptyProperty(partialMetricChange.properties["First Reply (min)"]) &&
+    isEmptyProperty(partialMetricChange.properties["Full Resolution (min)"]) &&
+    isEmptyProperty(partialMetricChange.properties.Reopens) &&
+    JSON.stringify(partialMetricChange.properties["Ticket Record"]).includes(
+      "42"
+    )
 )
 
 const surveyResponse: ZendeskSurveyResponse = {
@@ -359,7 +443,15 @@ ok(
     JSON.stringify(surveyResponseChange.properties.Feedback).includes(
       "Fast and helpful."
     ) &&
-    JSON.stringify(surveyResponseChange.properties["Ticket ID"]).includes("99")
+    JSON.stringify(surveyResponseChange.properties["Ticket ID"]).includes(
+      "99"
+    ) &&
+    JSON.stringify(surveyResponseChange.properties["Ticket Record"]).includes(
+      "99"
+    ) &&
+    JSON.stringify(
+      surveyResponseChange.properties["Responder Record"]
+    ).includes("4398080151295")
 )
 ok(
   "survey response uses the latest answer update as its checkpoint",
@@ -371,9 +463,11 @@ const minimalSurveyResponse = surveyResponseToChange({
   responder_id: 123,
 })
 ok(
-  "optional survey response fields do not emit invalid values",
-  minimalSurveyResponse.properties.Rating === undefined &&
-    minimalSurveyResponse.properties.Feedback === undefined &&
+  "optional survey response fields and page content explicitly clear",
+  isEmptyProperty(minimalSurveyResponse.properties.Rating) &&
+    isEmptyProperty(minimalSurveyResponse.properties.Feedback) &&
+    isEmptyProperty(minimalSurveyResponse.properties["Ticket Record"]) &&
+    minimalSurveyResponse.pageContentMarkdown === "" &&
     minimalSurveyResponse.upstreamUpdatedAt === undefined
 )
 
@@ -385,10 +479,10 @@ const minimalSlaPolicy: ZendeskSlaPolicy = {
 }
 const minimalSlaChange = slaPolicyToChange(minimalSlaPolicy)
 ok(
-  "optional SLA fields do not crash or emit invalid values",
-  minimalSlaChange.properties.Position === undefined &&
-    minimalSlaChange.properties["Created at"] === undefined &&
-    minimalSlaChange.properties["Updated at"] === undefined &&
+  "optional SLA fields explicitly clear stale values",
+  isEmptyProperty(minimalSlaChange.properties.Position) &&
+    isEmptyProperty(minimalSlaChange.properties["Created at"]) &&
+    isEmptyProperty(minimalSlaChange.properties["Updated at"]) &&
     minimalSlaChange.upstreamUpdatedAt === undefined
 )
 
@@ -409,8 +503,30 @@ function syncConfig(key: string): SyncManifestConfig {
   return capability.config as SyncManifestConfig
 }
 
+function hasRelation(
+  databaseKey: string,
+  propertyName: string,
+  relatedDatabaseKey: string,
+  relatedPropertyName: string
+): boolean {
+  const database = worker.manifest.databases.find(
+    (candidate) => candidate.key === databaseKey
+  )
+  const property = database?.config.schema.properties[propertyName]
+  return (
+    property?.type === "relation" &&
+    property.relatedDatabaseKey === relatedDatabaseKey &&
+    property.config.twoWay &&
+    property.config.relatedPropertyName === relatedPropertyName
+  )
+}
+
 const ticketsConfig = syncConfig("ticketsSync")
+const ticketsReconciliationConfig = syncConfig("ticketsReconciliationSync")
 const metricsConfig = syncConfig("ticketMetricsSync")
+const metricsReconciliationConfig = syncConfig(
+  "ticketMetricsReconciliationSync"
+)
 const surveyResponsesConfig = syncConfig("surveyResponsesSync")
 const slaConfig = syncConfig("slaPoliciesSync")
 ok(
@@ -420,6 +536,13 @@ ok(
     ticketsConfig.schedule.intervalMs === 5 * 60_000
 )
 ok("ticket metrics use incremental mode", metricsConfig.mode === "incremental")
+ok(
+  "tickets and ticket metrics expose manual replacement repair sweeps",
+  ticketsReconciliationConfig.mode === "replace" &&
+    ticketsReconciliationConfig.schedule?.type === "manual" &&
+    metricsReconciliationConfig.mode === "replace" &&
+    metricsReconciliationConfig.schedule?.type === "manual"
+)
 ok(
   "current CSAT survey responses replace daily",
   surveyResponsesConfig.mode === "replace" &&
@@ -439,6 +562,44 @@ ok(
       pacer.config.allowedRequests === 9 &&
       pacer.config.intervalMs === 60_000
   )
+)
+ok(
+  "independent pacers leave aggregate Zendesk account headroom",
+  worker.manifest.pacers.some(
+    (pacer) =>
+      pacer.key === "zendesk" &&
+      pacer.config.allowedRequests === 70 &&
+      pacer.config.intervalMs === 60_000
+  )
+)
+ok(
+  "manual repair sweeps share a bounded Search Export pacer",
+  worker.manifest.pacers.some(
+    (pacer) =>
+      pacer.key === "zendeskSearchExports" &&
+      pacer.config.allowedRequests === 90 &&
+      pacer.config.intervalMs === 60_000
+  )
+)
+ok(
+  "managed databases expose stable cross-resource relations",
+  hasRelation("tickets", "Assignee Record", "users", "Assigned Tickets") &&
+    hasRelation("tickets", "Requester Record", "users", "Requested Tickets") &&
+    hasRelation("tickets", "Organization Record", "organizations", "Tickets") &&
+    hasRelation("users", "Organization Record", "organizations", "Users") &&
+    hasRelation(
+      "surveyResponses",
+      "Ticket Record",
+      "tickets",
+      "CSAT Responses"
+    ) &&
+    hasRelation(
+      "surveyResponses",
+      "Responder Record",
+      "users",
+      "CSAT Responses"
+    ) &&
+    hasRelation("ticketMetrics", "Ticket Record", "tickets", "Ticket Metrics")
 )
 
 // ---------------------------------------------------------------------------
@@ -514,10 +675,25 @@ async function testZendeskClient() {
 
     if (url.pathname === "/api/v2/incremental/tickets/cursor") {
       const include = url.searchParams.get("include")
+      const startTime = url.searchParams.get("start_time")
+      const isReconciliationTail = startTime != null && startTime !== "1"
       if (include === "metric_sets") {
+        if (url.searchParams.get("cursor") === "missing-metric-sideload") {
+          return Response.json({
+            tickets: [],
+            after_cursor: "missing-metric-sideload-end",
+            end_of_stream: true,
+          })
+        }
         return Response.json({
-          tickets: [{ id: 404, status: "deleted" }],
-          metric_sets: [{ id: 8001, ticket_id: 42 }],
+          tickets: [
+            { id: 404, status: "deleted" },
+            ...(isReconciliationTail ? [tailOnlyTicket] : []),
+          ],
+          metric_sets: [
+            partialMetric,
+            ...(isReconciliationTail ? [tailOnlyMetric] : []),
+          ],
           after_cursor: "metric-cursor-2",
           end_of_stream: true,
         })
@@ -532,12 +708,65 @@ async function testZendeskClient() {
       }
 
       return Response.json({
-        tickets: [standardTicket, { id: 404, status: "deleted" }],
+        tickets: [
+          standardTicket,
+          ...(isReconciliationTail ? [tailOnlyTicket] : []),
+          { id: 404, status: "deleted" },
+        ],
         users: [...users.values()],
         groups: [...groups.values()],
         organizations: [...orgs.values()],
         after_cursor: "ticket-cursor-1",
         end_of_stream: false,
+      })
+    }
+
+    if (url.pathname === "/api/v2/search/export") {
+      const include = url.searchParams.get("include") ?? ""
+      const cursor = url.searchParams.get("page[after]")
+      const metrics = include === "tickets(metric_sets)"
+
+      if (cursor === "repeat") {
+        return Response.json({
+          results: [],
+          metric_sets: metrics ? [] : undefined,
+          meta: { has_more: true, after_cursor: "repeat" },
+        })
+      }
+
+      if (cursor === "cycle-a") {
+        return Response.json({
+          results: [{ ...standardTicket, result_type: "ticket" }],
+          users: [...users.values()],
+          groups: [...groups.values()],
+          organizations: [...orgs.values()],
+          meta: { has_more: true, after_cursor: "cycle-b" },
+        })
+      }
+
+      if (cursor) {
+        return Response.json({
+          results: [],
+          users: metrics ? undefined : [],
+          groups: metrics ? undefined : [],
+          organizations: metrics ? undefined : [],
+          metric_sets: metrics ? [] : undefined,
+          meta: { has_more: false, after_cursor: null },
+        })
+      }
+
+      return Response.json({
+        results: [{ ...standardTicket, result_type: "ticket" }],
+        users: metrics ? undefined : [...users.values()],
+        groups: metrics ? undefined : [...groups.values()],
+        organizations: metrics ? undefined : [...orgs.values()],
+        metric_sets: metrics ? [partialMetric] : undefined,
+        meta: {
+          has_more: true,
+          after_cursor: metrics
+            ? "metric-search-cursor"
+            : "ticket-search-cursor",
+        },
       })
     }
 
@@ -579,6 +808,27 @@ async function testZendeskClient() {
     const firstTicketsPage = await fetchTicketsPage()
     const finalTicketsPage = await fetchTicketsPage("ticket-cursor-1")
     const metricsPage = await fetchTicketMetricsPage("metric-cursor-1")
+    const reconciliationCutoff = "2024-06-30T00:00:00.000Z"
+    const firstTicketReconciliation =
+      await fetchTicketsReconciliationPage(reconciliationCutoff)
+    const finalTicketReconciliation = await fetchTicketsReconciliationPage(
+      reconciliationCutoff,
+      firstTicketReconciliation.nextCursor
+    )
+    const firstMetricReconciliation =
+      await fetchTicketMetricsReconciliationPage(reconciliationCutoff)
+    const reconciliationTailStart = Math.floor(
+      new Date(reconciliationCutoff).getTime() / 1_000
+    )
+    const firstTicketReconciliationTail =
+      await fetchTicketsReconciliationTailPage(reconciliationTailStart)
+    const finalTicketReconciliationTail =
+      await fetchTicketsReconciliationTailPage(
+        reconciliationTailStart,
+        firstTicketReconciliationTail.nextCursor
+      )
+    const metricReconciliationTail =
+      await fetchTicketMetricsReconciliationTailPage(reconciliationTailStart)
     const firstSurveyPage = await fetchSurveyResponsesPage()
     const finalSurveyPage = await fetchSurveyResponsesPage(
       firstSurveyPage.nextCursor
@@ -588,7 +838,14 @@ async function testZendeskClient() {
     type SyncRunResult = {
       changes: { type: string; key: string }[]
       hasMore: boolean
-      nextUserContext?: { cursor: string }
+      nextUserContext?: {
+        phase?: "search" | "tail"
+        cursor?: string
+        createdBefore?: string
+        tailStartTime?: number
+        recentCursors?: string[]
+        pageCount?: number
+      }
     }
     const initialTicketRun = (await worker.run(
       "ticketsSync",
@@ -603,6 +860,41 @@ async function testZendeskClient() {
     const metricRun = (await worker.run(
       "ticketMetricsSync",
       { state: { cursor: "metric-cursor-1" } },
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const ticketReconciliationRun = (await worker.run(
+      "ticketsReconciliationSync",
+      {},
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const ticketReconciliationTailTransitionRun = (await worker.run(
+      "ticketsReconciliationSync",
+      { state: ticketReconciliationRun.nextUserContext },
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const ticketReconciliationTailRun = (await worker.run(
+      "ticketsReconciliationSync",
+      { state: ticketReconciliationTailTransitionRun.nextUserContext },
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const ticketReconciliationFinalRun = (await worker.run(
+      "ticketsReconciliationSync",
+      { state: ticketReconciliationTailRun.nextUserContext },
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const metricReconciliationRun = (await worker.run(
+      "ticketMetricsReconciliationSync",
+      {},
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const metricReconciliationTailTransitionRun = (await worker.run(
+      "ticketMetricsReconciliationSync",
+      { state: metricReconciliationRun.nextUserContext },
+      { concreteOutput: true }
+    )) as SyncRunResult
+    const metricReconciliationFinalRun = (await worker.run(
+      "ticketMetricsReconciliationSync",
+      { state: metricReconciliationTailTransitionRun.nextUserContext },
       { concreteOutput: true }
     )) as SyncRunResult
     const surveyRun = (await worker.run(
@@ -622,6 +914,59 @@ async function testZendeskClient() {
       await fetchPage("acme", "/api/v2/users.json")
     } catch (error) {
       rateLimitWithoutHeader = error
+    }
+    let repeatedSearchCursorError: unknown
+    try {
+      await fetchTicketsReconciliationPage(reconciliationCutoff, "repeat")
+    } catch (error) {
+      repeatedSearchCursorError = error
+    }
+    let missingMetricSideloadError: unknown
+    try {
+      await fetchTicketMetricsReconciliationTailPage(
+        reconciliationTailStart,
+        "missing-metric-sideload"
+      )
+    } catch (error) {
+      missingMetricSideloadError = error
+    }
+    let reconciliationPageBoundError: unknown
+    try {
+      await worker.run(
+        "ticketsReconciliationSync",
+        {
+          state: {
+            phase: "tail",
+            cursor: "bound-cursor",
+            createdBefore: reconciliationCutoff,
+            tailStartTime: reconciliationTailStart,
+            recentCursors: ["bound-cursor"],
+            pageCount: 2_000,
+          },
+        },
+        { concreteOutput: true }
+      )
+    } catch (error) {
+      reconciliationPageBoundError = error
+    }
+    let nonImmediateCursorCycleError: unknown
+    try {
+      await worker.run(
+        "ticketsReconciliationSync",
+        {
+          state: {
+            phase: "search",
+            cursor: "cycle-a",
+            createdBefore: reconciliationCutoff,
+            tailStartTime: reconciliationTailStart,
+            recentCursors: ["cycle-b", "cycle-a"],
+            pageCount: 2,
+          },
+        },
+        { concreteOutput: true }
+      )
+    } catch (error) {
+      nonImmediateCursorCycleError = error
     }
 
     const initialTicketUrl = requestedUrls.find(
@@ -686,6 +1031,139 @@ async function testZendeskClient() {
       ) &&
         metricRun.changes.some(
           (change) => change.type === "delete" && change.key === "404"
+        )
+    )
+    const ticketSearchUrl = requestedUrls.find(
+      (url) =>
+        url.pathname === "/api/v2/search/export" &&
+        url.searchParams.get("include") ===
+          "tickets(users,groups,organizations)" &&
+        !url.searchParams.has("page[after]")
+    )
+    const metricSearchUrl = requestedUrls.find(
+      (url) =>
+        url.pathname === "/api/v2/search/export" &&
+        url.searchParams.get("include") === "tickets(metric_sets)" &&
+        !url.searchParams.has("page[after]")
+    )
+    const continuedTicketSearchUrl = requestedUrls.find(
+      (url) =>
+        url.pathname === "/api/v2/search/export" &&
+        url.searchParams.get("page[after]") === "ticket-search-cursor" &&
+        url.searchParams.get("query") ===
+          `created<=${ticketReconciliationRun.nextUserContext?.createdBefore}`
+    )
+    const directTicketTailUrl = requestedUrls.find(
+      (url) =>
+        url.pathname === "/api/v2/incremental/tickets/cursor" &&
+        url.searchParams.get("include") === "users,groups,organizations" &&
+        url.searchParams.get("start_time") === String(reconciliationTailStart)
+    )
+    const directMetricTailUrl = requestedUrls.find(
+      (url) =>
+        url.pathname === "/api/v2/incremental/tickets/cursor" &&
+        url.searchParams.get("include") === "metric_sets" &&
+        url.searchParams.get("start_time") === String(reconciliationTailStart)
+    )
+    const capabilityTicketTailUrl = requestedUrls.find(
+      (url) =>
+        url.pathname === "/api/v2/incremental/tickets/cursor" &&
+        url.searchParams.get("include") === "users,groups,organizations" &&
+        url.searchParams.get("start_time") ===
+          String(
+            ticketReconciliationTailTransitionRun.nextUserContext?.tailStartTime
+          )
+    )
+    ok(
+      "ticket reconciliation uses a pinned archived-ticket Search Export",
+      firstTicketReconciliation.tickets[0]?.id === standardTicket.id &&
+        firstTicketReconciliation.hasMore &&
+        !finalTicketReconciliation.hasMore &&
+        ticketSearchUrl?.searchParams.get("filter[type]") === "ticket" &&
+        ticketSearchUrl.searchParams.get("query") ===
+          `created<=${reconciliationCutoff}` &&
+        ticketSearchUrl.searchParams.get("page[size]") === "100"
+    )
+    ok(
+      "metric reconciliation uses archived ticket metric sideloads",
+      firstMetricReconciliation.metrics[0]?.ticket_id === 42 &&
+        firstMetricReconciliation.hasMore &&
+        metricSearchUrl?.searchParams.get("query") ===
+          `created<=${reconciliationCutoff}`
+    )
+    ok(
+      "reconciliation tails cover new records through incremental end_of_stream",
+      firstTicketReconciliationTail.hasMore &&
+        firstTicketReconciliationTail.tickets.some(
+          (ticket) => ticket.id === tailOnlyTicket.id
+        ) &&
+        !finalTicketReconciliationTail.hasMore &&
+        metricReconciliationTail.metrics.some(
+          (metric) => metric.ticket_id === tailOnlyMetric.ticket_id
+        ) &&
+        metricReconciliationTail.deletedTicketIds.join(",") === "404" &&
+        directTicketTailUrl != null &&
+        directMetricTailUrl != null
+    )
+    ok(
+      "manual reconciliation capabilities preserve cutoff state and finish only after the tail",
+      ticketReconciliationRun.changes.some(
+        (change) => change.type === "upsert" && change.key === "42"
+      ) &&
+        !ticketReconciliationRun.changes.some(
+          (change) => change.key === "777"
+        ) &&
+        metricReconciliationRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "42"
+        ) &&
+        !metricReconciliationRun.changes.some(
+          (change) => change.key === "777"
+        ) &&
+        ticketReconciliationRun.nextUserContext?.phase === "search" &&
+        ticketReconciliationRun.nextUserContext?.createdBefore != null &&
+        ticketReconciliationRun.nextUserContext?.pageCount === 1 &&
+        ticketReconciliationTailTransitionRun.hasMore &&
+        ticketReconciliationTailTransitionRun.nextUserContext?.phase ===
+          "tail" &&
+        ticketReconciliationTailTransitionRun.nextUserContext?.cursor ===
+          undefined &&
+        ticketReconciliationTailTransitionRun.nextUserContext?.pageCount ===
+          0 &&
+        ticketReconciliationTailRun.hasMore &&
+        ticketReconciliationTailRun.nextUserContext?.phase === "tail" &&
+        ticketReconciliationTailRun.nextUserContext?.cursor ===
+          "ticket-cursor-1" &&
+        ticketReconciliationTailRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "777"
+        ) &&
+        metricReconciliationRun.nextUserContext?.createdBefore != null &&
+        metricReconciliationTailTransitionRun.nextUserContext?.phase ===
+          "tail" &&
+        !metricReconciliationFinalRun.hasMore &&
+        metricReconciliationFinalRun.changes.some(
+          (change) => change.type === "upsert" && change.key === "777"
+        ) &&
+        !ticketReconciliationFinalRun.hasMore &&
+        capabilityTicketTailUrl != null &&
+        continuedTicketSearchUrl?.searchParams.get("query") ===
+          `created<=${ticketReconciliationRun.nextUserContext?.createdBefore}`
+    )
+    ok(
+      "Search Export cursor loops fail closed",
+      repeatedSearchCursorError instanceof Error &&
+        repeatedSearchCursorError.message.includes("repeated its cursor")
+    )
+    ok(
+      "reconciliation rejects missing metric sideloads and unsafe state",
+      missingMetricSideloadError instanceof Error &&
+        missingMetricSideloadError.message.includes(
+          "missing its metric_sets sideload"
+        ) &&
+        reconciliationPageBoundError instanceof Error &&
+        reconciliationPageBoundError.message.includes("page bound") &&
+        nonImmediateCursorCycleError instanceof Error &&
+        nonImmediateCursorCycleError.message.includes(
+          "repeated a recent cursor"
         )
     )
     const finalSurveyUrl = requestedUrls.find(


### PR DESCRIPTION
## Summary

- connect Zendesk tickets, users, organizations, CSAT responses, and ticket metrics with stable two-way relations
- explicitly clear nullable Notion properties when Zendesk values disappear
- add manual replacement repairs for tickets and ticket metrics, followed by a fresh incremental tail
- preserve explicit ticket and metric deletions when records were already seen during replacement
- keep reconciliation state to phase, cutoff, and cursor while reusing the existing incremental export client
- document the safe pause, repair, and resume workflow and update catalog metadata

## Validation

- npm run check (workers/zendesk-sync)
- npm test (workers/zendesk-sync): 84 passed
- npm run build (workers/zendesk-sync)
- npm run verify:all (repository root)