### PR TITLE
Add Raindrop.io research library Worker sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,24 +111,24 @@ and a **webhook** handles events from another service. See the complete
 
 ### Sync external data into Notion
 
-| Task                                                                 | Worker                                                     | Source      |
-| -------------------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
-| Learn the sync pattern with seeded, in-memory data                   | [DuckDB sync](workers/duckdb-sync/)                        | DuckDB      |
-| Turn starred repositories into a research library                    | [GitHub stars sync](workers/github-stars-sync/)            | GitHub      |
-| Sync issues and pull requests                                        | [GitHub sync](workers/github-sync/)                        | GitHub      |
-| Sync contacts, deals, and companies                                  | [HubSpot sync](workers/hubspot-sync/)                      | HubSpot     |
-| Sync companies, contacts, conversations, and tickets                 | [Intercom sync](workers/intercom-sync/)                    | Intercom    |
-| Sync issues, sprints, analytics, and projects                        | [Jira sync](workers/jira-sync/)                            | Jira Cloud  |
-| Sync projects, issues, and initiatives                               | [Linear sync](workers/linear-sync/)                        | Linear      |
-| Monitor PagerDuty incidents and service readiness in Notion          | [PagerDuty sync](workers/pagerduty-sync/)                  | PagerDuty   |
-| Archive bookmarks and highlights in a connected library              | [Raindrop.io reading library sync](workers/raindrop-sync/) | Raindrop.io |
-| Build a related reading library and highlight knowledge base         | [Readwise and Reader sync](workers/readwise-sync/)         | Readwise    |
-| Sync accounts and opportunities                                      | [Salesforce sync](workers/salesforce-sync/)                | Salesforce  |
-| Coordinate issue triage, service risk, and rollout health            | [Sentry sync](workers/sentry-sync/)                        | Sentry      |
-| Sync the result of a warehouse query                                 | [Snowflake sync](workers/snowflake-sync/)                  | Snowflake   |
-| Sync open tasks and project summaries with recent completion context | [Todoist sync](workers/todoist-sync/)                      | Todoist     |
-| Sync an employee-facing directory                                    | [Workday employee directory sync](workers/workday-sync/)   | Workday     |
-| Sync related tickets, users, organizations, and metrics              | [Zendesk sync](workers/zendesk-sync/)                      | Zendesk     |
+| Task                                                                 | Worker                                                      | Source      |
+| -------------------------------------------------------------------- | ----------------------------------------------------------- | ----------- |
+| Learn the sync pattern with seeded, in-memory data                   | [DuckDB sync](workers/duckdb-sync/)                         | DuckDB      |
+| Turn starred repositories into a research library                    | [GitHub stars sync](workers/github-stars-sync/)             | GitHub      |
+| Sync issues and pull requests                                        | [GitHub sync](workers/github-sync/)                         | GitHub      |
+| Sync contacts, deals, and companies                                  | [HubSpot sync](workers/hubspot-sync/)                       | HubSpot     |
+| Sync companies, contacts, conversations, and tickets                 | [Intercom sync](workers/intercom-sync/)                     | Intercom    |
+| Sync issues, sprints, analytics, and projects                        | [Jira sync](workers/jira-sync/)                             | Jira Cloud  |
+| Sync projects, issues, and initiatives                               | [Linear sync](workers/linear-sync/)                         | Linear      |
+| Monitor PagerDuty incidents and service readiness in Notion          | [PagerDuty sync](workers/pagerduty-sync/)                   | PagerDuty   |
+| Turn saved sources and highlights into project evidence              | [Raindrop.io research library sync](workers/raindrop-sync/) | Raindrop.io |
+| Build a related reading library and highlight knowledge base         | [Readwise and Reader sync](workers/readwise-sync/)          | Readwise    |
+| Sync accounts and opportunities                                      | [Salesforce sync](workers/salesforce-sync/)                 | Salesforce  |
+| Coordinate issue triage, service risk, and rollout health            | [Sentry sync](workers/sentry-sync/)                         | Sentry      |
+| Sync the result of a warehouse query                                 | [Snowflake sync](workers/snowflake-sync/)                   | Snowflake   |
+| Sync open tasks and project summaries with recent completion context | [Todoist sync](workers/todoist-sync/)                       | Todoist     |
+| Sync an employee-facing directory                                    | [Workday employee directory sync](workers/workday-sync/)    | Workday     |
+| Sync related tickets, users, organizations, and metrics              | [Zendesk sync](workers/zendesk-sync/)                       | Zendesk     |
 
 ### Add tools to a Notion Agent
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ directory.
   [GitHub stars](workers/github-stars-sync/), [HubSpot](workers/hubspot-sync/),
   [Intercom](workers/intercom-sync/), [Jira](workers/jira-sync/),
   [Linear](workers/linear-sync/), [PagerDuty](workers/pagerduty-sync/),
+  [Raindrop.io](workers/raindrop-sync/),
   [Readwise and Reader](workers/readwise-sync/),
   [Salesforce](workers/salesforce-sync/), [Sentry](workers/sentry-sync/),
   [Todoist](workers/todoist-sync/),
   [Workday](workers/workday-sync/), [Zendesk](workers/zendesk-sync/) and more.
 - **Give a Notion Agent a reliable new capability:** execute a repeatable API
-  workflow in one tool call, or connect to [Airflow](workers/airflow/), [Vega-lite charts](workers/chart-generator/), 
+  workflow in one tool call, or connect to [Airflow](workers/airflow/), [Vega-lite charts](workers/chart-generator/),
   [CloudWatch Logs](workers/cloudwatch-logs/),
   [Postgres](workers/postgres-query/), [Snowflake query](workers/snowflake-query/), [PowerPoint creator](workers/powerpoint-creator/), [Vercel](workers/vercel-production-deployment-tools/), and more.
 - **React to external events:** receive and verify
@@ -110,23 +111,24 @@ and a **webhook** handles events from another service. See the complete
 
 ### Sync external data into Notion
 
-| Task                                                                 | Worker                                                   | Source     |
-| -------------------------------------------------------------------- | -------------------------------------------------------- | ---------- |
-| Learn the sync pattern with seeded, in-memory data                   | [DuckDB sync](workers/duckdb-sync/)                      | DuckDB     |
-| Turn starred repositories into a research library                    | [GitHub stars sync](workers/github-stars-sync/)          | GitHub     |
-| Sync issues and pull requests                                        | [GitHub sync](workers/github-sync/)                      | GitHub     |
-| Sync contacts, deals, and companies                                  | [HubSpot sync](workers/hubspot-sync/)                    | HubSpot    |
-| Sync companies, contacts, conversations, and tickets                 | [Intercom sync](workers/intercom-sync/)                  | Intercom   |
-| Sync issues, sprints, analytics, and projects                        | [Jira sync](workers/jira-sync/)                          | Jira Cloud |
-| Sync projects, issues, and initiatives                               | [Linear sync](workers/linear-sync/)                      | Linear     |
-| Monitor PagerDuty incidents and service readiness in Notion          | [PagerDuty sync](workers/pagerduty-sync/)                | PagerDuty  |
-| Build a related reading library and highlight knowledge base         | [Readwise and Reader sync](workers/readwise-sync/)       | Readwise   |
-| Sync accounts and opportunities                                      | [Salesforce sync](workers/salesforce-sync/)              | Salesforce |
-| Coordinate issue triage, service risk, and rollout health            | [Sentry sync](workers/sentry-sync/)                      | Sentry     |
-| Sync the result of a warehouse query                                 | [Snowflake sync](workers/snowflake-sync/)                | Snowflake  |
-| Sync open tasks and project summaries with recent completion context | [Todoist sync](workers/todoist-sync/)                    | Todoist    |
-| Sync an employee-facing directory                                    | [Workday employee directory sync](workers/workday-sync/) | Workday    |
-| Sync related tickets, users, organizations, and metrics              | [Zendesk sync](workers/zendesk-sync/)                    | Zendesk    |
+| Task                                                                 | Worker                                                     | Source      |
+| -------------------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
+| Learn the sync pattern with seeded, in-memory data                   | [DuckDB sync](workers/duckdb-sync/)                        | DuckDB      |
+| Turn starred repositories into a research library                    | [GitHub stars sync](workers/github-stars-sync/)            | GitHub      |
+| Sync issues and pull requests                                        | [GitHub sync](workers/github-sync/)                        | GitHub      |
+| Sync contacts, deals, and companies                                  | [HubSpot sync](workers/hubspot-sync/)                      | HubSpot     |
+| Sync companies, contacts, conversations, and tickets                 | [Intercom sync](workers/intercom-sync/)                    | Intercom    |
+| Sync issues, sprints, analytics, and projects                        | [Jira sync](workers/jira-sync/)                            | Jira Cloud  |
+| Sync projects, issues, and initiatives                               | [Linear sync](workers/linear-sync/)                        | Linear      |
+| Monitor PagerDuty incidents and service readiness in Notion          | [PagerDuty sync](workers/pagerduty-sync/)                  | PagerDuty   |
+| Archive bookmarks and highlights in a connected library              | [Raindrop.io reading library sync](workers/raindrop-sync/) | Raindrop.io |
+| Build a related reading library and highlight knowledge base         | [Readwise and Reader sync](workers/readwise-sync/)         | Readwise    |
+| Sync accounts and opportunities                                      | [Salesforce sync](workers/salesforce-sync/)                | Salesforce  |
+| Coordinate issue triage, service risk, and rollout health            | [Sentry sync](workers/sentry-sync/)                        | Sentry      |
+| Sync the result of a warehouse query                                 | [Snowflake sync](workers/snowflake-sync/)                  | Snowflake   |
+| Sync open tasks and project summaries with recent completion context | [Todoist sync](workers/todoist-sync/)                      | Todoist     |
+| Sync an employee-facing directory                                    | [Workday employee directory sync](workers/workday-sync/)   | Workday     |
+| Sync related tickets, users, organizations, and metrics              | [Zendesk sync](workers/zendesk-sync/)                      | Zendesk     |
 
 ### Add tools to a Notion Agent
 

--- a/catalog.json
+++ b/catalog.json
@@ -406,8 +406,8 @@
     },
     {
       "id": "raindrop-sync",
-      "title": "Raindrop.io reading library sync",
-      "summary": "Maintain a non-destructive, connected archive of Raindrop.io collections, bookmarks, Trash, and highlights in Notion.",
+      "title": "Raindrop.io research library sync",
+      "summary": "Sync Raindrop.io sources and exact passages into a connected research library for project evidence and downstream work.",
       "path": "workers/raindrop-sync",
       "kind": "worker-sync",
       "status": "ready",

--- a/catalog.json
+++ b/catalog.json
@@ -405,6 +405,25 @@
       }
     },
     {
+      "id": "raindrop-sync",
+      "title": "Raindrop.io reading library sync",
+      "summary": "Maintain a non-destructive, connected archive of Raindrop.io collections, bookmarks, Trash, and highlights in Notion.",
+      "path": "workers/raindrop-sync",
+      "kind": "worker-sync",
+      "status": "ready",
+      "language": "typescript",
+      "runtime": "node",
+      "integrations": ["notion-workers", "raindrop"],
+      "entrypoints": ["src/index.ts"],
+      "commands": {
+        "install": "npm install",
+        "check": "npm run check",
+        "test": "npm test",
+        "build": "npm run build",
+        "deploy": "ntn workers deploy --name raindrop-sync"
+      }
+    },
+    {
       "id": "readwise-sync",
       "title": "Readwise and Reader sync",
       "summary": "Archive a Reader library and Readwise highlights in related Notion databases without deleting pages when items disappear upstream.",

--- a/workers/README.md
+++ b/workers/README.md
@@ -14,24 +14,24 @@ For self-hosted integrations built directly with the Notion API, see the [API ex
 
 ## Syncs
 
-| Worker                                             | What it maintains                                                                                                                    |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [DuckDB sync](duckdb-sync/)                        | A self-contained managed database populated from seeded, in-memory DuckDB data; useful for learning the sync contract.               |
-| [GitHub stars sync](github-stars-sync/)            | The authenticated user's starred repositories as a current research and evaluation library.                                          |
-| [GitHub sync](github-sync/)                        | Issues, all pull requests, and open pull requests with review and CI status.                                                         |
-| [HubSpot sync](hubspot-sync/)                      | CRM contacts, deals, and companies.                                                                                                  |
-| [Intercom sync](intercom-sync/)                    | Companies, contacts, conversations, and tickets linked for support operations and customer context.                                  |
-| [Jira sync](jira-sync/)                            | Jira Cloud issues, current sprints, sprint analytics, and projects.                                                                  |
-| [Linear sync](linear-sync/)                        | Linear projects, issues, and initiatives.                                                                                            |
-| [PagerDuty sync](pagerduty-sync/)                  | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.                   |
-| [Raindrop.io reading library sync](raindrop-sync/) | A non-destructive archive of collections, active and trashed bookmarks, and highlights connected as a personal research library.     |
-| [Readwise and Reader sync](readwise-sync/)         | A Reader library and Readwise highlights linked into a durable archive that preserves Notion pages.                                  |
-| [Salesforce sync](salesforce-sync/)                | Salesforce accounts and opportunities, with related account context.                                                                 |
-| [Sentry sync](sentry-sync/)                        | Issue triage, project reliability trends, and recent release health for cross-functional follow-up.                                  |
-| [Snowflake sync](snowflake-sync/)                  | Rows returned by a configurable Snowflake query.                                                                                     |
-| [Todoist sync](todoist-sync/)                      | Open tasks and project summaries with recent completion context.                                                                     |
-| [Workday employee directory sync](workday-sync/)   | A daily employee-facing directory of people, work email, Notion People references, supervisory organizations, and manager relations. |
-| [Zendesk sync](zendesk-sync/)                      | Related tickets, organizations, users, CSAT responses, metrics, and SLA policies with manual repair sweeps.                          |
+| Worker                                              | What it maintains                                                                                                                    |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [DuckDB sync](duckdb-sync/)                         | A self-contained managed database populated from seeded, in-memory DuckDB data; useful for learning the sync contract.               |
+| [GitHub stars sync](github-stars-sync/)             | The authenticated user's starred repositories as a current research and evaluation library.                                          |
+| [GitHub sync](github-sync/)                         | Issues, all pull requests, and open pull requests with review and CI status.                                                         |
+| [HubSpot sync](hubspot-sync/)                       | CRM contacts, deals, and companies.                                                                                                  |
+| [Intercom sync](intercom-sync/)                     | Companies, contacts, conversations, and tickets linked for support operations and customer context.                                  |
+| [Jira sync](jira-sync/)                             | Jira Cloud issues, current sprints, sprint analytics, and projects.                                                                  |
+| [Linear sync](linear-sync/)                         | Linear projects, issues, and initiatives.                                                                                            |
+| [PagerDuty sync](pagerduty-sync/)                   | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.                   |
+| [Raindrop.io research library sync](raindrop-sync/) | Sources and exact passages linked to their collections and ready to connect to projects, decisions, and downstream work.             |
+| [Readwise and Reader sync](readwise-sync/)          | A Reader library and Readwise highlights linked into a durable archive that preserves Notion pages.                                  |
+| [Salesforce sync](salesforce-sync/)                 | Salesforce accounts and opportunities, with related account context.                                                                 |
+| [Sentry sync](sentry-sync/)                         | Issue triage, project reliability trends, and recent release health for cross-functional follow-up.                                  |
+| [Snowflake sync](snowflake-sync/)                   | Rows returned by a configurable Snowflake query.                                                                                     |
+| [Todoist sync](todoist-sync/)                       | Open tasks and project summaries with recent completion context.                                                                     |
+| [Workday employee directory sync](workday-sync/)    | A daily employee-facing directory of people, work email, Notion People references, supervisory organizations, and manager relations. |
+| [Zendesk sync](zendesk-sync/)                       | Related tickets, organizations, users, CSAT responses, metrics, and SLA policies with manual repair sweeps.                          |
 
 ## Agent tools
 

--- a/workers/README.md
+++ b/workers/README.md
@@ -14,23 +14,24 @@ For self-hosted integrations built directly with the Notion API, see the [API ex
 
 ## Syncs
 
-| Worker                                           | What it maintains                                                                                                                    |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [DuckDB sync](duckdb-sync/)                      | A self-contained managed database populated from seeded, in-memory DuckDB data; useful for learning the sync contract.               |
-| [GitHub stars sync](github-stars-sync/)          | The authenticated user's starred repositories as a current research and evaluation library.                                          |
-| [GitHub sync](github-sync/)                      | Issues, all pull requests, and open pull requests with review and CI status.                                                         |
-| [HubSpot sync](hubspot-sync/)                    | CRM contacts, deals, and companies.                                                                                                  |
-| [Intercom sync](intercom-sync/)                  | Companies, contacts, conversations, and tickets linked for support operations and customer context.                                  |
-| [Jira sync](jira-sync/)                          | Jira Cloud issues, current sprints, sprint analytics, and projects.                                                                  |
-| [Linear sync](linear-sync/)                      | Linear projects, issues, and initiatives.                                                                                            |
-| [PagerDuty sync](pagerduty-sync/)                | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.                   |
-| [Readwise and Reader sync](readwise-sync/)       | A Reader library and Readwise highlights linked into a durable archive that preserves Notion pages.                                  |
-| [Salesforce sync](salesforce-sync/)              | Salesforce accounts and opportunities, with related account context.                                                                 |
-| [Sentry sync](sentry-sync/)                      | Issue triage, project reliability trends, and recent release health for cross-functional follow-up.                                  |
-| [Snowflake sync](snowflake-sync/)                | Rows returned by a configurable Snowflake query.                                                                                     |
-| [Todoist sync](todoist-sync/)                    | Open tasks and project summaries with recent completion context.                                                                     |
-| [Workday employee directory sync](workday-sync/) | A daily employee-facing directory of people, work email, Notion People references, supervisory organizations, and manager relations. |
-| [Zendesk sync](zendesk-sync/)                    | Related tickets, organizations, users, CSAT responses, metrics, and SLA policies with manual repair sweeps.                          |
+| Worker                                             | What it maintains                                                                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [DuckDB sync](duckdb-sync/)                        | A self-contained managed database populated from seeded, in-memory DuckDB data; useful for learning the sync contract.               |
+| [GitHub stars sync](github-stars-sync/)            | The authenticated user's starred repositories as a current research and evaluation library.                                          |
+| [GitHub sync](github-sync/)                        | Issues, all pull requests, and open pull requests with review and CI status.                                                         |
+| [HubSpot sync](hubspot-sync/)                      | CRM contacts, deals, and companies.                                                                                                  |
+| [Intercom sync](intercom-sync/)                    | Companies, contacts, conversations, and tickets linked for support operations and customer context.                                  |
+| [Jira sync](jira-sync/)                            | Jira Cloud issues, current sprints, sprint analytics, and projects.                                                                  |
+| [Linear sync](linear-sync/)                        | Linear projects, issues, and initiatives.                                                                                            |
+| [PagerDuty sync](pagerduty-sync/)                  | Active and recent incidents linked to service readiness, current on-call coverage, ownership, and routing context.                   |
+| [Raindrop.io reading library sync](raindrop-sync/) | A non-destructive archive of collections, active and trashed bookmarks, and highlights connected as a personal research library.     |
+| [Readwise and Reader sync](readwise-sync/)         | A Reader library and Readwise highlights linked into a durable archive that preserves Notion pages.                                  |
+| [Salesforce sync](salesforce-sync/)                | Salesforce accounts and opportunities, with related account context.                                                                 |
+| [Sentry sync](sentry-sync/)                        | Issue triage, project reliability trends, and recent release health for cross-functional follow-up.                                  |
+| [Snowflake sync](snowflake-sync/)                  | Rows returned by a configurable Snowflake query.                                                                                     |
+| [Todoist sync](todoist-sync/)                      | Open tasks and project summaries with recent completion context.                                                                     |
+| [Workday employee directory sync](workday-sync/)   | A daily employee-facing directory of people, work email, Notion People references, supervisory organizations, and manager relations. |
+| [Zendesk sync](zendesk-sync/)                      | Related tickets, organizations, users, CSAT responses, metrics, and SLA policies with manual repair sweeps.                          |
 
 ## Agent tools
 

--- a/workers/raindrop-sync/.env.example
+++ b/workers/raindrop-sync/.env.example
@@ -1,0 +1,3 @@
+# Create an app at https://app.raindrop.io/settings/integrations, then copy its
+# test token. A test token is intended for syncing only your own account.
+RAINDROP_ACCESS_TOKEN=replace-with-your-raindrop-test-token

--- a/workers/raindrop-sync/.env.example
+++ b/workers/raindrop-sync/.env.example
@@ -1,3 +1,4 @@
 # Create an app at https://app.raindrop.io/settings/integrations, then copy its
-# test token. A test token is intended for syncing only your own account.
+# test token. Use the authenticated User endpoint to copy user._id.
 RAINDROP_ACCESS_TOKEN=replace-with-your-raindrop-test-token
+RAINDROP_ACCOUNT_ID=replace-with-your-raindrop-user-id

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -1,52 +1,34 @@
 # Worker sync: Raindrop.io reading library
 
-Turn saved links and highlights into a connected, non-destructive Notion
-research archive. This Worker creates managed databases for Raindrop.io
-collections, bookmarks, and highlights, then scans the account every hour.
+Bring saved links, collections, and highlights into a connected Notion research
+archive. One deployment creates three related managed databases and refreshes
+them every hour.
 
-The sync is read-only. Keep organizing and highlighting in Raindrop.io; use
+The Worker is read-only. Keep organizing and highlighting in Raindrop.io; use
 Notion to connect what you save to projects, topics, reading queues, and notes.
-Account-scoped source keys update the same pages on every run. User-added Notion
-properties and page bodies remain untouched, even when a source record later
-disappears from Raindrop.io.
-
-This is deliberately an archive, not an exact mirror. Raindrop.io does not
-provide reliable tombstones for hard-deleted bookmarks, deleted collections, or
-removed highlights, so the Worker never automatically deletes managed pages.
+This is deliberately an archive rather than an exact mirror: Raindrop.io does
+not expose reliable deletion tombstones, so missing source records are retained
+instead of risking the loss of Notion context.
 
 ## Quickstart
 
-You need:
-
-- Node.js 22 or newer and npm 10.9.2 or newer;
-- access to deploy Notion Workers;
-- a Raindrop.io account; and
-- a Raindrop.io test token for your own account.
-
-Create an app in [Raindrop.io App Management][raindrop-apps], open its
-settings, and copy the **Test token**. Raindrop.io recommends this simpler token
-when an integration only accesses its creator's account. This recipe uses one
-personal account token at a time; it does not implement OAuth for other users.
+You need Node.js 22+, npm 10.9.2+, access to deploy Notion Workers, a
+Raindrop.io account, and a personal test token. Create an app in
+[Raindrop.io App Management][raindrop-apps], open its settings, and copy the
+**Test token**.
 
 From the repository root:
 
 ```sh
-npm install --global ntn@latest
+npm install --global ntn
 cd workers/raindrop-sync
 npm install
-npm run check
-npm test
 ntn login
 ntn workers deploy --name raindrop-sync
-```
-
-Store the token as a Worker secret. Do not add it to source control.
-
-```sh
 ntn workers env set RAINDROP_ACCESS_TOKEN=replace-with-your-test-token
 ```
 
-Preview each database in dependency order:
+Preview the databases in dependency order:
 
 ```sh
 ntn workers sync trigger collectionsSync --preview
@@ -54,39 +36,47 @@ ntn workers sync trigger bookmarksSync --preview
 ntn workers sync trigger highlightsSync --preview
 ```
 
-Previews can print private collection names, bookmark titles, URLs, notes, and
-highlights. Protect terminal output. When the previews look right, run the
-initial imports:
+Previews can contain private collection names, URLs, notes, and highlights.
+Protect terminal output. When the previews look right, run the initial imports:
 
 ```sh
 ntn workers sync trigger collectionsSync
 ntn workers sync trigger bookmarksSync
 ntn workers sync trigger highlightsSync
-ntn workers sync status
 ```
 
-The three syncs then scan hourly without a recurring CLI command. The Worker
-does not need a Notion API token.
+The three syncs then run hourly without recurring CLI commands. Notion creates
+the databases from the Worker schemas; no Notion API token is needed.
 
-## What you get
+## What you can answer
 
-| Managed database            | What it is useful for                                                                                  |
-| --------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **Raindrop.io Collections** | Browse the observed source hierarchy and relate collections to other Notion work.                      |
-| **Raindrop.io Bookmarks**   | Build reading queues, project libraries, and views by collection, tag, type, favorite, or Trash state. |
-| **Raindrop.io Highlights**  | Review quotes and annotations independently while retaining a relation to the source bookmark.         |
+| Managed database            | Questions it helps answer                                                                                   |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Raindrop.io Collections** | How is my source library organized? Which collections have grown, and how do they connect to current work?  |
+| **Raindrop.io Bookmarks**   | What should I read next? What have I saved by project, collection, tag, type, favorite, or Trash state?     |
+| **Raindrop.io Highlights**  | Which quotes and annotations are relevant to a topic or project, and which saved source did each come from? |
 
-The Worker creates two-way relations from Bookmarks to Collections and from
-Highlights to Bookmarks. Trigger Collections before Bookmarks, and Bookmarks
-before Highlights, on the first import so every relation target already exists.
+Bookmarks relate to Collections, and Highlights relate to Bookmarks. You can
+add your own reading status, project relations, review dates, and notes without
+a later sync overwriting them.
 
-Every primary key includes the authenticated Raindrop account ID, resource type,
-and raw provider ID. For example, bookmark `42` in account `321` uses
-`raindrop:321:bookmark:42`. Rotating a token for the same account updates the
-same rows. A token for a different account creates a separate set of rows and
-cannot overwrite the earlier account's archive.
+## Reference
 
-### Collections
+### Synced databases and schedules
+
+| Managed database            | Raindrop.io source                           | Schedule |
+| --------------------------- | -------------------------------------------- | -------- |
+| **Raindrop.io Collections** | Root, child, Unsorted, and Trash collections | Hourly   |
+| **Raindrop.io Bookmarks**   | Active bookmarks followed by Trash           | Hourly   |
+| **Raindrop.io Highlights**  | Account highlights                           | Hourly   |
+
+Trigger Collections before Bookmarks and Bookmarks before Highlights on the
+first import so every relation target exists. Each primary key includes the
+authenticated account ID, resource type, and provider ID. Rotating a token for
+the same account updates the same rows; a different account gets a separate
+namespace.
+
+#### Raindrop.io Collections
 
 | Notion property     | Raindrop.io field or meaning              | Type                   |
 | ------------------- | ----------------------------------------- | ---------------------- |
@@ -104,11 +94,11 @@ cannot overwrite the earlier account's archive.
 | Synced Bookmarks    | Reciprocal of each bookmark's Collection  | reciprocal relation    |
 
 Raindrop.io omits system collections from its collection endpoints. The Worker
-adds account-scoped **Unsorted** (`-1`) and **Trash** (`-99`) relation targets.
-Their bookmark counts are left blank because the collection responses do not
-provide them.
+adds **Unsorted** (`-1`) and **Trash** (`-99`) as account-scoped relation
+targets; their bookmark counts remain empty because the API does not provide
+them.
 
-### Bookmarks
+#### Raindrop.io Bookmarks
 
 | Notion property     | Raindrop.io field or meaning                 | Type                    |
 | ------------------- | -------------------------------------------- | ----------------------- |
@@ -134,12 +124,11 @@ provide them.
 | Bookmark Key        | Account-scoped source identity               | rich text, primary key  |
 | Synced Highlights   | Reciprocal of each highlight's Bookmark      | reciprocal relation     |
 
-Each bookmark scan reads active items and then Trash. Moving a bookmark to
-Trash updates the same Notion page to **In Trash = checked** and relates it to
-the synthetic Trash collection. Restoring it updates that page to
-**In Trash = unchecked** and restores its observed collection relation.
+Moving a bookmark to Trash updates the same Notion page, checks **In Trash**,
+and relates it to the synthetic Trash collection. Restoring it clears the
+checkbox and restores its observed collection relation.
 
-### Highlights
+#### Raindrop.io Highlights
 
 | Notion property     | Raindrop.io field or meaning              | Type                   |
 | ------------------- | ----------------------------------------- | ---------------------- |
@@ -159,227 +148,107 @@ the synthetic Trash collection. Restoring it updates that page to
 | Raindrop Account ID | Authenticated user `_id`                  | rich text              |
 | Highlight Key       | Account-scoped source identity            | rich text, primary key |
 
-Notion rich-text properties are bounded to 2,000 Unicode characters in this
-reference recipe. When a source Note, Excerpt, highlight Text, or highlight Note
-is longer, the Worker adds an ellipsis and checks **Truncated** instead of
-failing the entire library. The complete values remain in Raindrop.io while the
-source record exists. Page bodies are deliberately not managed, so you can
-write longer summaries and project-specific notes there without a later scan
-overwriting them.
+Rich-text values are bounded to 2,000 Unicode characters. Longer values receive
+an ellipsis and set **Truncated** rather than failing the page. Links above
+[Notion's 2,000-character URL limit][notion-request-limits] leave **URL** empty
+and set **URL Omitted**. The complete source values remain in Raindrop.io.
 
-[Notion URL properties accept at most 2,000 characters][notion-request-limits].
-When a bookmark or highlight link is longer, the Worker leaves **URL** empty and
-checks **URL Omitted** instead of failing that page and blocking the rest of the
-scan. The complete link remains in Raindrop.io.
+Tags are trimmed, whitespace-normalized, and deduplicated case-insensitively.
+Commas become visually similar full-width commas (`，`) because the current
+multi-select wire format uses commas as separators. Otherwise-distinct tags
+that map to the same option receive a stable suffix. Records with more than 100
+resulting options fail explicitly instead of silently dropping values.
 
-Source timestamps are normalized to UTC before they are written to Notion date
-properties.
+### How it works
 
-Tag names are trimmed, whitespace-normalized, and deduplicated
-case-insensitively. Because the Worker multi-select wire format uses commas as
-separators, a comma inside one Raindrop.io tag becomes a visually similar
-full-width comma (`，`). If otherwise-distinct tags map to the same Notion
-option, the Worker adds a stable suffix to preserve both. More than 100
-resulting options on one record fails the page instead of silently dropping
-values.
-
-## Archive and refresh semantics
-
-Raindrop.io's documented REST API provides stable IDs and page-number
-pagination, but not a change feed, snapshot cursor, or reliable deletion feed.
-Each capability therefore uses `mode: "incremental"` for a complete,
-non-destructive scan:
-
-1. The Worker fetches the authenticated user's stable account ID.
+1. Each sync authenticates the token and scopes stable keys to that account.
 2. Collections read both collection endpoints and add Unsorted and Trash.
-3. Bookmarks read all active items in ascending creation order, then all Trash
-   items, 50 at a time.
-4. Highlights read the global highlights endpoint, 50 at a time.
+3. Bookmarks scan active items in ascending creation order, then Trash, 50 at a
+   time.
+4. Highlights scan the account's highlights 50 at a time.
 5. Every observed record is upserted and advances **Last Seen**. Unobserved
-   records are left untouched with their earlier timestamp.
+   records remain untouched with their earlier timestamp.
 
-This means:
+Raindrop.io provides page-number pagination but no change feed, snapshot cursor,
+or reliable deletion tombstones. The Worker therefore never emits deletes. A
+hard-deleted bookmark, collection, or highlight remains as its last-known
+Notion record; an older **Last Seen** value is a review signal, not proof of
+deletion. A record moved during a scan can be refreshed on the next hourly run.
 
-- A moved or restored Trash item is updated explicitly through **In Trash**.
-- A hard-deleted bookmark remains as its last-known Notion record and retains
-  its earlier **Last Seen** value.
-- A deleted collection remains as its last-known Notion record and retains its
-  earlier **Last Seen** value.
-- A removed or hard-deleted highlight remains as its last-known Notion record
-  and retains its earlier **Last Seen** value.
-- The API does not provide enough information to label those last three cases
-  as deleted reliably. Treat them as archive records, not confirmed live data.
+Raindrop.io remains the source of truth for managed fields. The Worker owns only
+the properties above and never writes page bodies, so user-added properties and
+page content remain intact.
 
-This non-destructive behavior is intentional. With page-number pagination, a
-save or deletion during a long scan can move another item across a page
-boundary. A missed item is refreshed on a later scan, but its Notion page and
-user-owned annotations are never deleted merely because one scan did not see
-it.
+Each active-bookmark, Trash, or highlight scan stops above 10,000 records.
+Partition larger libraries by collection instead of only raising the limit.
+Requests share a conservative 100-per-minute pacer beneath Raindrop.io's
+documented 120-per-minute limit.
 
-The reference Worker stops above 10,000 active Bookmarks, 10,000 Trash
-Bookmarks, or 10,000 Highlights instead of accepting an unbounded run.
-Partition larger libraries by collection. Collection responses are also capped
-at 10,000 records.
+Paginated state pins the authenticated account. If a token changes to a
+different account mid-scan, restore the original token or reset the bookmark
+and highlight sync state before importing the new account in dependency order.
 
-Each execution captures one token and uses it for both the authenticated-user
-lookup and its following data request. Every paginated continuation also stores
-the authenticated account ID. If the token changes to another account during a
-scan, the capability fails before reading the next data page. Restore the
-original token or reset that capability's state before intentionally continuing
-with the other account.
+### Raindrop.io access and credentials
 
-All requests share a Worker pacer set to 100 requests per minute, below
-Raindrop.io's documented limit of 120 authenticated requests per minute. HTTP
-429 responses become Worker rate-limit signals. Requests time out after 30
-seconds, reject redirects, and cap decoded response bodies at 10 MiB.
+This recipe uses one personal test token and does not implement multi-user
+OAuth. The token can read private collection names, URLs, notes, Trash, and
+highlights, although this Worker issues only documented `GET` requests.
 
-## Source of truth and editing
+Store `RAINDROP_ACCESS_TOKEN` as a Worker secret, use a dedicated Raindrop.io
+app, and share the managed databases only with their intended audience. Anyone
+with database access can see the synced values even when the source collection
+is private. Review the [Raindrop.io API terms][raindrop-terms] before adapting
+the recipe for multiple users or commercial use.
 
-This is a one-way refresh and archive. Change managed fields, collection
-membership, tags, notes, and highlights in Raindrop.io. Observed records update
-on the next complete scan.
-
-In Notion, you can safely add properties such as:
-
-- Reading status
-- Project or topic relations
-- Why it matters
-- Review date
-- Shared with
-
-The Worker schema owns only the properties listed above and does not write page
-bodies. Because it never emits deletes, source disappearance does not remove a
-managed page or its user-added values. Use **Last Seen** to find records that
-have not been observed recently, then verify them in Raindrop.io before taking
-destructive action. Absence from one scan is not proof of deletion.
-
-## Privacy and access
-
-The token can read private URLs, notes, tags, collection names, Trash, and
-highlights. The Worker sends those selected fields to managed Notion databases.
-Anyone who can access those databases can see the synced values, even when the
-original Raindrop.io collection is private or the bookmark is in Trash.
-
-- Use a dedicated Raindrop.io app and its test token; do not reuse credentials
-  from another integration.
-- Share the managed databases only with the intended audience.
-- Never commit `.env`, tokens, preview output, or generated `workers.json`
-  state.
-- Review the [Raindrop.io API terms][raindrop-terms] before adapting this into a
-  multi-user or commercial product.
-
-Although a Raindrop.io bearer token can authorize writes, this Worker only
-issues documented `GET` requests.
-
-## Project structure
+### Project structure
 
 ```text
 src/
-├── index.ts        — registers databases, schedules, and the shared pacer
+├── index.ts        — databases, schedules, and shared request pacing
 ├── raindrop.ts     — authenticated REST client and response validation
-├── sync-state.ts   — account-pinned active, Trash, and highlight scan state
-├── keys.ts         — account- and resource-scoped stable identities
-├── collections.ts  — Collections schema and transform
-├── bookmarks.ts    — Bookmarks schema and transform
-├── highlights.ts   — Highlights schema and transform
-└── format.ts       — labels, titles, and disclosed text bounds
+├── sync-state.ts   — account-pinned pagination state
+├── keys.ts         — account- and resource-scoped identities
+├── collections.ts  — Collection schema and transform
+├── bookmarks.ts    — Bookmark schema and transform
+├── highlights.ts   — Highlight schema and transform
+└── format.ts       — bounded text, titles, and tag options
 test.ts             — offline transforms, paging, auth, and failure tests
 ```
 
-## Adapt the recipe
+### Adapting the sync
 
-Common extensions:
+- **Add a source field:** extend the validated API type, schema, transform,
+  property table, and transform tests together.
+- **Sync one collection:** replace collection ID `0` in `src/raindrop.ts`, then
+  decide whether nested collections and Trash history remain in scope.
+- **Partition a large library:** register one managed database and incremental
+  scan per collection so each capability stays below 10,000 records.
+- **Add retention:** require a reviewed user action or provider-backed deletion
+  signal; never translate one missing page-number scan into deletion.
+- **Serve multiple users:** implement Raindrop.io OAuth and refresh-token
+  handling while retaining account-scoped keys.
 
-1. **Sync one collection.** Replace collection ID `0` in `src/raindrop.ts` with
-   a configured collection ID and document whether nested collections are
-   included. Decide separately whether its Trash history is still required.
-2. **Partition a large library.** Declare one managed database and incremental
-   full scan per collection so each capability remains below 10,000 records.
-3. **Add an explicit retention workflow.** If stale archive records must be
-   removed, require a reviewed user action or a provider-backed deletion signal;
-   do not translate one missing page-number scan into deletion.
-4. **Change the cadence.** Adjust the three `schedule` values in `src/index.ts`.
-   Keep complete scans affordable for the library size.
-5. **Add source fields.** Extend the validated API type, its schema, its
-   transform, and the property table in this README together.
-6. **Serve multiple users.** Replace the personal test-token setup with a
-   reviewed OAuth design using Raindrop.io's authorization and refresh-token
-   flow. Keep account-scoped keys; do not share one user's token between
-   deployments.
+### Local testing
 
-## Verify locally
-
-The checks use fixtures and mocked HTTP responses; they do not call
-Raindrop.io or require credentials.
+Offline checks use mocked HTTP responses and need no Raindrop.io credentials.
+From the repository root:
 
 ```sh
+cd workers/raindrop-sync
 npm install
 npm run check
 npm test
 npm run build
 ```
 
-To inspect a live response without writing managed databases after deployment:
+After deployment, inspect a live read without writing to Notion:
 
 ```sh
 ntn workers sync trigger bookmarksSync --preview
 ```
 
-## Troubleshooting
+## Learn more
 
-### The Worker reports an invalid token
-
-Open the app in [Raindrop.io App Management][raindrop-apps], replace its test
-token in Worker secrets, and preview again:
-
-```sh
-ntn workers env set RAINDROP_ACCESS_TOKEN=replace-with-your-test-token
-ntn workers sync trigger collectionsSync --preview
-```
-
-### The account changed during a scan
-
-If the token was changed accidentally, restore the original account's token. To
-intentionally continue with a different account, reset only the in-flight
-paginated capabilities, then trigger the imports in dependency order:
-
-```sh
-ntn workers sync state reset bookmarksSync
-ntn workers sync state reset highlightsSync
-ntn workers sync trigger collectionsSync
-ntn workers sync trigger bookmarksSync
-ntn workers sync trigger highlightsSync
-```
-
-The previous account's rows remain as an archive. New rows use a different
-account namespace.
-
-### Relations are empty
-
-Run the initial imports in dependency order: Collections, Bookmarks, then
-Highlights. The hourly scans keep using the same account-scoped keys.
-
-### A deleted source record still appears
-
-This is expected archive behavior. Raindrop.io does not expose reliable
-tombstones for hard-deleted bookmarks, deleted collections, or removed
-highlights. The Worker preserves last-known rows so an ambiguous absence cannot
-destroy Notion notes or user-added properties.
-
-### A moved bookmark has the wrong Trash state temporarily
-
-Check that the latest bookmark scan completed. Page-number APIs cannot freeze a
-changing library; the next complete active-and-Trash scan refreshes the same
-account-scoped bookmark key.
-
-### The sync exceeds 10,000 records
-
-Partition it by collection. Do not only raise the limit: larger full scans
-increase runtime, rate-limit pressure, and the window for page movement.
-
-## API references
-
-- [Notion request limits][notion-request-limits]
 - [Raindrop.io API overview and rate limits][raindrop-overview]
 - [Authentication and personal test tokens][raindrop-token]
 - [Authenticated user identity][raindrop-user]
@@ -387,9 +256,11 @@ increase runtime, rate-limit pressure, and the window for page movement.
 - [Bookmark fields][raindrop-fields]
 - [Paginated bookmark reads][raindrop-bookmarks]
 - [Highlights][raindrop-highlights]
+- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Contributing guide](../../CONTRIBUTING.md)
 
-[raindrop-apps]: https://app.raindrop.io/settings/integrations
 [notion-request-limits]: https://developers.notion.com/reference/request-limits
+[raindrop-apps]: https://app.raindrop.io/settings/integrations
 [raindrop-bookmarks]: https://developer.raindrop.io/v1/raindrops/multiple
 [raindrop-collections]: https://developer.raindrop.io/v1/collections/methods
 [raindrop-fields]: https://developer.raindrop.io/v1/raindrops

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -1,13 +1,13 @@
-# Worker sync: Raindrop.io reading library
+# Worker sync: Raindrop.io research library
 
-Turn your Raindrop.io bookmarks and highlights into a connected Notion
-research library. Use it to review what you save, connect sources and evidence
-to projects, and preserve the notes you develop in Notion.
+Turn your Raindrop.io bookmarks and highlights into evidence you can connect to
+projects, claims, decisions, and finished work in Notion. Follow every passage
+back to its source while Raindrop.io remains the place to capture and organize.
 
 One deploy creates three related managed databases and refreshes them every
 hour. The Worker is read-only and never deletes a Notion page. Raindrop.io
-remains the place to collect and organize; Notion becomes the project and
-knowledge layer.
+remains the source of truth; Notion connects what you save to the work it
+informs.
 
 ## Quickstart
 
@@ -82,48 +82,60 @@ Worker and databases for a different account.
 
 ## What you can answer
 
-| Managed database            | Questions it helps answer                                                                                    |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Raindrop.io Collections** | How is my library organized? Which collections contain the most saved links?                                 |
-| **Raindrop.io Bookmarks**   | What deserves review? What have I favorited, tagged, broken, or moved to Trash?                              |
-| **Raindrop.io Highlights**  | Which quotes and annotations support this project? Which bookmark and collection supplied the original idea? |
+| Question                                                                                  | Start here                 | How to answer it                                                                                                                                                                                             |
+| ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Which sources and exact passages support this project, claim, or decision?                | **Raindrop.io Highlights** | Add and filter by a `Project`, `Claim`, or `Decision` relation. **Text** and **Note** hold the evidence; **Bookmark** identifies its source.                                                                 |
+| Which new or scheduled sources still need processing?                                     | **Raindrop.io Bookmarks**  | Add `Review Status`. Filter **In Trash** unchecked, status empty, and either **Created** recently or **Reminder** due.                                                                                       |
+| Which captured insights have not yet become a brief, decision, document, or other output? | **Raindrop.io Highlights** | Add `Synthesis Status` and optionally `Used in`. Exclude `Used` and `Archived`; when `Used in` exists, filter it to empty.                                                                                   |
+| Where did this idea originate?                                                            | **Raindrop.io Highlights** | Follow **Bookmark** to **URL**, **Collection**, **Domain**, **Excerpt**, and **Note**. To show Collection in Highlights, add a rollup using **Bookmark** as the relation and **Collection** as the property. |
 
-Bookmarks relate to Collections, and Highlights relate to Bookmarks. The
-Worker preserves properties you add in Notion and each page's body content.
+Each Highlight links to a **Bookmark**, and each Bookmark links to a
+**Collection**. The reciprocal **Highlights** and **Bookmarks** relations let
+you traverse the source trail in either direction. Project and output databases
+are specific to each workspace, so you add those relations in Notion. The
+Worker preserves them and each page's body content.
 
 ## Views you can build
 
-- **Inbox to review:** Add a `Review Status` select to **Raindrop.io
-  Bookmarks**. Filter for an empty status with **In Trash** unchecked, then sort
-  **Updated** newest first. Mark links `Reviewed` as you process them.
-- **Library cleanup:** In **Raindrop.io Bookmarks**, filter where **Broken** or
-  **In Trash** is checked. Add older **Last Seen** records when you want to
-  review links that may no longer be visible upstream.
-- **Project evidence:** Add a `Project` relation to **Raindrop.io Highlights**
-  and place a linked view on each project. Add the relation to Bookmarks too if
-  you also want a project reading list.
+1. **Project evidence and provenance:** Add a `Project` relation from Highlights
+   to your Projects database, filter it to the current project, and show
+   **Text**, **Note**, **Tags**, and **Bookmark**. Add the Collection rollup
+   above, then place the linked view in your project template.
+2. **Insights awaiting an output:** Add a `Synthesis Status` select with
+   `To synthesize`, `Drafting`, `Used`, and `Archived`; optionally add a
+   `Used in` relation. Exclude `Used` and `Archived`, require `Used in` to be
+   empty when present, and group by **Tags** or `Project`.
+3. **Processing queue:** Add a `Review Status` select to **Raindrop.io
+   Bookmarks**. Filter **In Trash** to unchecked and `Review Status` to empty,
+   then include recently **Created** bookmarks or those with **Reminder** on or
+   before today. Sort **Reminder** ascending, then **Created** newest first.
 
 ## Reference
 
 ### Databases
 
-| Database                    | One page per                       | Relation          | Primary key      | Schedule |
-| --------------------------- | ---------------------------------- | ----------------- | ---------------- | -------- |
-| **Raindrop.io Collections** | Root, child, or system collection  | Parent collection | `Collection Key` | Hourly   |
-| **Raindrop.io Bookmarks**   | Active or trashed bookmark         | Collection        | `Bookmark Key`   | Hourly   |
-| **Raindrop.io Highlights**  | Highlight returned for the account | Bookmark          | `Highlight Key`  | Hourly   |
+| Database                    | One page per                       | Connected by           | Primary key      | Schedule |
+| --------------------------- | ---------------------------------- | ---------------------- | ---------------- | -------- |
+| **Raindrop.io Collections** | Root, child, or system collection  | Parent, Bookmarks      | `Collection Key` | Hourly   |
+| **Raindrop.io Bookmarks**   | Active or trashed bookmark         | Collection, Highlights | `Bookmark Key`   | Hourly   |
+| **Raindrop.io Highlights**  | Highlight returned for the account | Bookmark               | `Highlight Key`  | Hourly   |
 
 ### Included data
 
-| Source      | Included                                                               | Limit                           |
-| ----------- | ---------------------------------------------------------------------- | ------------------------------- |
-| Collections | Root and child collections, plus synthetic Unsorted and Trash targets  | 10,000 collections              |
-| Bookmarks   | All active bookmarks followed by Trash                                 | 10,000 per active or Trash scan |
-| Highlights  | Highlights, notes, colors, tags, bookmark references, and source links | 10,000 highlights               |
+| Source      | Included                                                                   | Limit                           |
+| ----------- | -------------------------------------------------------------------------- | ------------------------------- |
+| Collections | Root and child collections, plus synthetic Unsorted and Trash targets      | 10,000 collections              |
+| Bookmarks   | Active bookmarks and Trash, including metadata, notes, tags, and reminders | 10,000 per active or Trash scan |
+| Highlights  | Highlights, notes, colors, tags, bookmark references, and source links     | 10,000 highlights               |
 
 The collection-list responses do not include counts for Unsorted and Trash, so
-their synthetic rows leave **Bookmarks** empty. This Worker does not call the
-separate account-statistics endpoint.
+their synthetic rows leave **Bookmark count** empty. Their **Bookmarks**
+relations still contain the bookmarks observed in each system collection. This
+Worker does not call the separate account-statistics endpoint.
+
+The Worker does not copy full article text, cached page contents, or uploaded
+file and media bodies. It syncs the metadata, excerpts, notes, and highlights
+needed for these workflows while Raindrop.io retains the complete source.
 
 ### Update behavior
 
@@ -164,6 +176,7 @@ npm run build
 
 - [Raindrop.io API overview][raindrop-overview]
 - [Paginated bookmark reads][raindrop-bookmarks]
+- [Reminders][raindrop-reminders]
 - [Highlights][raindrop-highlights]
 - [Notion Workers sync guide](https://developers.notion.com/workers/guides/syncs)
 - [Contributing guide](../../CONTRIBUTING.md)
@@ -172,3 +185,4 @@ npm run build
 [raindrop-bookmarks]: https://developer.raindrop.io/v1/raindrops/multiple
 [raindrop-highlights]: https://developer.raindrop.io/v1/highlights
 [raindrop-overview]: https://developer.raindrop.io/
+[raindrop-reminders]: https://help.raindrop.io/reminders

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -1,34 +1,42 @@
 # Worker sync: Raindrop.io reading library
 
-Bring saved links, collections, and highlights into a connected Notion research
-archive. One deployment creates three related managed databases and refreshes
-them every hour.
+Turn your Raindrop.io bookmarks and highlights into a connected Notion
+research library. Use it to review what you save, connect sources and evidence
+to projects, and preserve the notes you develop in Notion.
 
-The Worker is read-only. Keep organizing and highlighting in Raindrop.io; use
-Notion to connect what you save to projects, topics, reading queues, and notes.
-This is deliberately an archive rather than an exact mirror: Raindrop.io does
-not expose reliable deletion tombstones, so missing source records are retained
-instead of risking the loss of Notion context.
+One deploy creates three related managed databases and refreshes them every
+hour. The Worker is read-only and never deletes a Notion page. Raindrop.io
+remains the place to collect and organize; Notion becomes the project and
+knowledge layer.
 
 ## Quickstart
 
-You need Node.js 22+, npm 10.9.2+, access to deploy Notion Workers, a
-Raindrop.io account, and a personal test token. Create an app in
-[Raindrop.io App Management][raindrop-apps], open its settings, and copy the
-**Test token**.
+You need Node.js 22+, npm 10.9.2+, a Raindrop.io account, and a personal test
+token. Create an app in [Raindrop.io App Management][raindrop-apps], open its
+settings, and copy the **Test token**.
 
-From the repository root:
+From the repository root, deploy the Worker, pause its schedules, and add the
+token:
 
 ```sh
-npm install --global ntn
+npm install --global ntn@latest
 cd workers/raindrop-sync
 npm install
 ntn login
 ntn workers deploy --name raindrop-sync
+ntn workers sync pause collectionsSync
+ntn workers sync pause bookmarksSync
+ntn workers sync pause highlightsSync
 ntn workers env set RAINDROP_ACCESS_TOKEN=replace-with-your-test-token
 ```
 
-Preview the databases in dependency order:
+Use `--name raindrop-sync` only for the first deployment. After `workers.json`
+identifies it, update the Worker with `ntn workers deploy`.
+
+Preview output can contain private collection names, URLs, notes, and
+highlights. Review the databases' Notion sharing settings before writing data.
+
+Preview all three databases:
 
 ```sh
 ntn workers sync trigger collectionsSync --preview
@@ -36,202 +44,113 @@ ntn workers sync trigger bookmarksSync --preview
 ntn workers sync trigger highlightsSync --preview
 ```
 
-Previews can contain private collection names, URLs, notes, and highlights.
-Protect terminal output. When the previews look right, run the initial imports:
+Import Collections first so Bookmark relations have targets:
 
 ```sh
 ntn workers sync trigger collectionsSync
-ntn workers sync trigger bookmarksSync
-ntn workers sync trigger highlightsSync
+ntn workers sync status collectionsSync
 ```
 
-The three syncs then run hourly without recurring CLI commands. Notion creates
-the databases from the Worker schemas; no Notion API token is needed.
+When Collections succeeds, press Ctrl-C and import Bookmarks:
+
+```sh
+ntn workers sync trigger bookmarksSync
+ntn workers sync status bookmarksSync
+```
+
+When Bookmarks succeeds, press Ctrl-C and import Highlights:
+
+```sh
+ntn workers sync trigger highlightsSync
+ntn workers sync status highlightsSync
+```
+
+When Highlights succeeds, press Ctrl-C, review the databases, and resume the
+hourly schedules:
+
+```sh
+ntn workers sync resume collectionsSync
+ntn workers sync resume bookmarksSync
+ntn workers sync resume highlightsSync
+```
+
+You do not need to create the databases or provide a Notion API token.
+
+After the first successful run, each sync remains bound to the authenticated
+Raindrop.io account. You can rotate a token for that account. Use a separate
+Worker and databases for a different account.
 
 ## What you can answer
 
-| Managed database            | Questions it helps answer                                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Raindrop.io Collections** | How is my source library organized? Which collections have grown, and how do they connect to current work?  |
-| **Raindrop.io Bookmarks**   | What should I read next? What have I saved by project, collection, tag, type, favorite, or Trash state?     |
-| **Raindrop.io Highlights**  | Which quotes and annotations are relevant to a topic or project, and which saved source did each come from? |
+| Managed database            | Questions it helps answer                                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Raindrop.io Collections** | How is my library organized? Which collections contain the most saved links?                                 |
+| **Raindrop.io Bookmarks**   | What deserves review? What have I favorited, tagged, broken, or moved to Trash?                              |
+| **Raindrop.io Highlights**  | Which quotes and annotations support this project? Which bookmark and collection supplied the original idea? |
 
-Bookmarks relate to Collections, and Highlights relate to Bookmarks. You can
-add your own reading status, project relations, review dates, and notes without
-a later sync overwriting them.
+Bookmarks relate to Collections, and Highlights relate to Bookmarks. The
+Worker preserves properties you add in Notion and each page's body content.
+
+## Views you can build
+
+- **Inbox to review:** Add a `Review Status` select to **Raindrop.io
+  Bookmarks**. Filter for an empty status with **In Trash** unchecked, then sort
+  **Updated** newest first. Mark links `Reviewed` as you process them.
+- **Library cleanup:** In **Raindrop.io Bookmarks**, filter where **Broken** or
+  **In Trash** is checked. Add older **Last Seen** records when you want to
+  review links that may no longer be visible upstream.
+- **Project evidence:** Add a `Project` relation to **Raindrop.io Highlights**
+  and place a linked view on each project. Add the relation to Bookmarks too if
+  you also want a project reading list.
 
 ## Reference
 
-### Synced databases and schedules
+### Databases
 
-| Managed database            | Raindrop.io source                           | Schedule |
-| --------------------------- | -------------------------------------------- | -------- |
-| **Raindrop.io Collections** | Root, child, Unsorted, and Trash collections | Hourly   |
-| **Raindrop.io Bookmarks**   | Active bookmarks followed by Trash           | Hourly   |
-| **Raindrop.io Highlights**  | Account highlights                           | Hourly   |
+| Database                    | One page per                       | Relation          | Primary key      | Schedule |
+| --------------------------- | ---------------------------------- | ----------------- | ---------------- | -------- |
+| **Raindrop.io Collections** | Root, child, or system collection  | Parent collection | `Collection Key` | Hourly   |
+| **Raindrop.io Bookmarks**   | Active or trashed bookmark         | Collection        | `Bookmark Key`   | Hourly   |
+| **Raindrop.io Highlights**  | Highlight returned for the account | Bookmark          | `Highlight Key`  | Hourly   |
 
-Trigger Collections before Bookmarks and Bookmarks before Highlights on the
-first import so every relation target exists. Each primary key includes the
-authenticated account ID, resource type, and provider ID. Rotating a token for
-the same account updates the same rows; a different account gets a separate
-namespace.
+### Included data
 
-#### Raindrop.io Collections
+| Source      | Included                                                               | Limit                           |
+| ----------- | ---------------------------------------------------------------------- | ------------------------------- |
+| Collections | Root and child collections, plus synthetic Unsorted and Trash targets  | 10,000 collections              |
+| Bookmarks   | All active bookmarks followed by Trash                                 | 10,000 per active or Trash scan |
+| Highlights  | Highlights, notes, colors, tags, bookmark references, and source links | 10,000 highlights               |
 
-| Notion property     | Raindrop.io field or meaning              | Type                   |
-| ------------------- | ----------------------------------------- | ---------------------- |
-| Name                | `title`                                   | title                  |
-| Parent              | Account-scoped `parent.$id`               | self-relation          |
-| Subcollections      | Reciprocal of Parent                      | reciprocal relation    |
-| Bookmarks           | `count`                                   | number                 |
-| Public              | `public`                                  | checkbox               |
-| Created             | `created`                                 | date                   |
-| Updated             | `lastUpdate`                              | date                   |
-| Last Seen           | When the Worker most recently observed it | date                   |
-| Collection ID       | Raw `_id`                                 | rich text              |
-| Raindrop Account ID | Authenticated user `_id`                  | rich text              |
-| Collection Key      | Account-scoped source identity            | rich text, primary key |
-| Synced Bookmarks    | Reciprocal of each bookmark's Collection  | reciprocal relation    |
+The collection-list responses do not include counts for Unsorted and Trash, so
+their synthetic rows leave **Bookmarks** empty. This Worker does not call the
+separate account-statistics endpoint.
 
-Raindrop.io omits system collections from its collection endpoints. The Worker
-adds **Unsorted** (`-1`) and **Trash** (`-99`) as account-scoped relation
-targets; their bookmark counts remain empty because the API does not provide
-them.
+### Update behavior
 
-#### Raindrop.io Bookmarks
+- Each hourly run scans the current provider data and updates **Last Seen**.
+- Moving a bookmark to Trash updates the same page, checks **In Trash**, and
+  relates it to the synthetic Trash collection. Restoring it reverses both.
+- Hard-deleted or unavailable records remain as last-known Notion pages because
+  the API does not provide reliable deletion tombstones.
+- An older **Last Seen** value is a review signal, not proof that a record was
+  deleted.
+- Account-scoped provider IDs keep relations stable and prevent duplicates.
+- Oversized text, URLs, and tag sets are bounded and visibly marked rather than
+  blocking the scan.
+- Page content and properties added in Notion are preserved.
 
-| Notion property     | Raindrop.io field or meaning                 | Type                    |
-| ------------------- | -------------------------------------------- | ----------------------- |
-| Title               | `title`, with domain or URL as a fallback    | title                   |
-| URL                 | `link`                                       | URL                     |
-| URL Omitted         | `link` exceeded Notion's URL limit           | checkbox                |
-| Collection          | Account-scoped `collection.$id` relation     | relation to Collections |
-| Tags                | `tags`                                       | multi-select            |
-| Type                | `type`                                       | select                  |
-| Domain              | `domain`                                     | rich text               |
-| Favorite            | `important`                                  | checkbox                |
-| Broken              | `broken`                                     | checkbox                |
-| In Trash            | Whether this scan observed the item in `-99` | checkbox                |
-| Note                | `note`                                       | rich text               |
-| Excerpt             | `excerpt`                                    | rich text               |
-| Truncated           | Title, Note, or Excerpt exceeded its limit   | checkbox                |
-| Highlights          | Number of embedded highlights                | number                  |
-| Created             | `created`                                    | date                    |
-| Updated             | `lastUpdate`                                 | date                    |
-| Last Seen           | When the Worker most recently observed it    | date                    |
-| Raindrop ID         | Raw `_id`                                    | rich text               |
-| Raindrop Account ID | Authenticated user `_id`                     | rich text               |
-| Bookmark Key        | Account-scoped source identity               | rich text, primary key  |
-| Synced Highlights   | Reciprocal of each highlight's Bookmark      | reciprocal relation     |
+## Adapt the sync
 
-Moving a bookmark to Trash updates the same Notion page, checks **In Trash**,
-and relates it to the synthetic Trash collection. Restoring it clears the
-checkbox and restores its observed collection relation.
+- Change the schedules in `src/index.ts` for a slower personal archive.
+- Partition a library above the documented limits by collection rather than
+  only increasing the scan cap.
+- Add a provider field by updating response validation, the database schema,
+  its transform, and tests together.
 
-#### Raindrop.io Highlights
+## Local verification
 
-| Notion property     | Raindrop.io field or meaning              | Type                   |
-| ------------------- | ----------------------------------------- | ---------------------- |
-| Highlight           | Compact single-line excerpt of `text`     | title                  |
-| Text                | `text`                                    | rich text              |
-| Note                | `note`                                    | rich text              |
-| Bookmark            | Account-scoped `raindropRef` relation     | relation to Bookmarks  |
-| Bookmark title      | `title`                                   | rich text              |
-| URL                 | `link`                                    | URL                    |
-| URL Omitted         | `link` exceeded Notion's URL limit        | checkbox               |
-| Color               | Documented `color` enum                   | select                 |
-| Tags                | `tags`                                    | multi-select           |
-| Truncated           | Text or Note exceeded the property limit  | checkbox               |
-| Created             | `created`                                 | date                   |
-| Last Seen           | When the Worker most recently observed it | date                   |
-| Highlight ID        | Raw `_id`                                 | rich text              |
-| Raindrop Account ID | Authenticated user `_id`                  | rich text              |
-| Highlight Key       | Account-scoped source identity            | rich text, primary key |
-
-Rich-text values are bounded to 2,000 Unicode characters. Longer values receive
-an ellipsis and set **Truncated** rather than failing the page. Links above
-[Notion's 2,000-character URL limit][notion-request-limits] leave **URL** empty
-and set **URL Omitted**. The complete source values remain in Raindrop.io.
-
-Tags are trimmed, whitespace-normalized, and deduplicated case-insensitively.
-Commas become visually similar full-width commas (`，`) because the current
-multi-select wire format uses commas as separators. Otherwise-distinct tags
-that map to the same option receive a stable suffix. Records with more than 100
-resulting options fail explicitly instead of silently dropping values.
-
-### How it works
-
-1. Each sync authenticates the token and scopes stable keys to that account.
-2. Collections read both collection endpoints and add Unsorted and Trash.
-3. Bookmarks scan active items in ascending creation order, then Trash, 50 at a
-   time.
-4. Highlights scan the account's highlights 50 at a time.
-5. Every observed record is upserted and advances **Last Seen**. Unobserved
-   records remain untouched with their earlier timestamp.
-
-Raindrop.io provides page-number pagination but no change feed, snapshot cursor,
-or reliable deletion tombstones. The Worker therefore never emits deletes. A
-hard-deleted bookmark, collection, or highlight remains as its last-known
-Notion record; an older **Last Seen** value is a review signal, not proof of
-deletion. A record moved during a scan can be refreshed on the next hourly run.
-
-Raindrop.io remains the source of truth for managed fields. The Worker owns only
-the properties above and never writes page bodies, so user-added properties and
-page content remain intact.
-
-Each active-bookmark, Trash, or highlight scan stops above 10,000 records.
-Partition larger libraries by collection instead of only raising the limit.
-Requests share a conservative 100-per-minute pacer beneath Raindrop.io's
-documented 120-per-minute limit.
-
-Paginated state pins the authenticated account. If a token changes to a
-different account mid-scan, restore the original token or reset the bookmark
-and highlight sync state before importing the new account in dependency order.
-
-### Raindrop.io access and credentials
-
-This recipe uses one personal test token and does not implement multi-user
-OAuth. The token can read private collection names, URLs, notes, Trash, and
-highlights, although this Worker issues only documented `GET` requests.
-
-Store `RAINDROP_ACCESS_TOKEN` as a Worker secret, use a dedicated Raindrop.io
-app, and share the managed databases only with their intended audience. Anyone
-with database access can see the synced values even when the source collection
-is private. Review the [Raindrop.io API terms][raindrop-terms] before adapting
-the recipe for multiple users or commercial use.
-
-### Project structure
-
-```text
-src/
-├── index.ts        — databases, schedules, and shared request pacing
-├── raindrop.ts     — authenticated REST client and response validation
-├── sync-state.ts   — account-pinned pagination state
-├── keys.ts         — account- and resource-scoped identities
-├── collections.ts  — Collection schema and transform
-├── bookmarks.ts    — Bookmark schema and transform
-├── highlights.ts   — Highlight schema and transform
-└── format.ts       — bounded text, titles, and tag options
-test.ts             — offline transforms, paging, auth, and failure tests
-```
-
-### Adapting the sync
-
-- **Add a source field:** extend the validated API type, schema, transform,
-  property table, and transform tests together.
-- **Sync one collection:** replace collection ID `0` in `src/raindrop.ts`, then
-  decide whether nested collections and Trash history remain in scope.
-- **Partition a large library:** register one managed database and incremental
-  scan per collection so each capability stays below 10,000 records.
-- **Add retention:** require a reviewed user action or provider-backed deletion
-  signal; never translate one missing page-number scan into deletion.
-- **Serve multiple users:** implement Raindrop.io OAuth and refresh-token
-  handling while retaining account-scoped keys.
-
-### Local testing
-
-Offline checks use mocked HTTP responses and need no Raindrop.io credentials.
-From the repository root:
+The checks use offline fixtures and require no Raindrop.io or Notion
+credentials:
 
 ```sh
 cd workers/raindrop-sync
@@ -241,31 +160,15 @@ npm test
 npm run build
 ```
 
-After deployment, inspect a live read without writing to Notion:
-
-```sh
-ntn workers sync trigger bookmarksSync --preview
-```
-
 ## Learn more
 
-- [Raindrop.io API overview and rate limits][raindrop-overview]
-- [Authentication and personal test tokens][raindrop-token]
-- [Authenticated user identity][raindrop-user]
-- [Collection methods][raindrop-collections]
-- [Bookmark fields][raindrop-fields]
+- [Raindrop.io API overview][raindrop-overview]
 - [Paginated bookmark reads][raindrop-bookmarks]
 - [Highlights][raindrop-highlights]
-- [Notion Workers documentation](https://developers.notion.com/workers/get-started/overview)
+- [Notion Workers sync guide](https://developers.notion.com/workers/guides/syncs)
 - [Contributing guide](../../CONTRIBUTING.md)
 
-[notion-request-limits]: https://developers.notion.com/reference/request-limits
 [raindrop-apps]: https://app.raindrop.io/settings/integrations
 [raindrop-bookmarks]: https://developer.raindrop.io/v1/raindrops/multiple
-[raindrop-collections]: https://developer.raindrop.io/v1/collections/methods
-[raindrop-fields]: https://developer.raindrop.io/v1/raindrops
 [raindrop-highlights]: https://developer.raindrop.io/v1/highlights
 [raindrop-overview]: https://developer.raindrop.io/
-[raindrop-terms]: https://developer.raindrop.io/terms
-[raindrop-token]: https://developer.raindrop.io/v1/authentication/token
-[raindrop-user]: https://developer.raindrop.io/v1/user/authenticated

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -1,22 +1,30 @@
 # Worker sync: Raindrop.io research library
 
 Turn your Raindrop.io bookmarks and highlights into evidence you can connect to
-projects, claims, decisions, and finished work in Notion. Follow every passage
-back to its source while Raindrop.io remains the place to capture and organize.
+projects, claims, decisions, and finished work in Notion. Trace each synced
+passage to its bookmark and collection, plus the Raindrop contributor when the
+API provides one.
 
-One deploy creates three related managed databases and refreshes them every
-hour. The Worker is read-only and never deletes a Notion page. Raindrop.io
-remains the source of truth; Notion connects what you save to the work it
-informs.
+One deploy creates three related managed databases and schedules each sync
+hourly. The Worker only reads from Raindrop.io, upserts Notion properties, and
+never emits a page delete. Raindrop.io remains the source of truth for captured
+content; Notion connects it to the work it informs.
 
 ## Quickstart
 
 You need Node.js 22+, npm 10.9.2+, a Raindrop.io account, and a personal test
 token. Create an app in [Raindrop.io App Management][raindrop-apps], open its
-settings, and copy the **Test token**.
+settings, and copy the **Test token**. Use it to retrieve the account ID:
+
+```sh
+curl https://api.raindrop.io/rest/v1/user \
+  --header "Authorization: Bearer replace-with-your-test-token"
+```
+
+Copy `user._id` from the response.
 
 From the repository root, deploy the Worker, pause its schedules, and add the
-token:
+account configuration:
 
 ```sh
 npm install --global ntn@latest
@@ -28,15 +36,17 @@ ntn workers sync pause collectionsSync
 ntn workers sync pause bookmarksSync
 ntn workers sync pause highlightsSync
 ntn workers env set RAINDROP_ACCESS_TOKEN=replace-with-your-test-token
+ntn workers env set RAINDROP_ACCOUNT_ID=replace-with-your-user-id
 ```
 
 Use `--name raindrop-sync` only for the first deployment. After `workers.json`
 identifies it, update the Worker with `ntn workers deploy`.
 
-Preview output can contain private collection names, URLs, notes, and
-highlights. Review the databases' Notion sharing settings before writing data.
+The token may expose owned and shared collections. Raindrop.io ownership,
+access roles, and contributor names are copied as metadata but are not enforced
+by Notion. Review the databases' sharing settings before importing.
 
-Preview all three databases:
+Preview the first output batch from each sync:
 
 ```sh
 ntn workers sync trigger collectionsSync --preview
@@ -76,31 +86,34 @@ ntn workers sync resume highlightsSync
 
 You do not need to create the databases or provide a Notion API token.
 
-After the first successful run, each sync remains bound to the authenticated
-Raindrop.io account. You can rotate a token for that account. Use a separate
-Worker and databases for a different account.
+`RAINDROP_ACCOUNT_ID` binds the entire deployment to one Raindrop.io account.
+You can rotate a token for that account. Use a separate Worker and databases
+for a different account.
 
 ## What you can answer
 
-| Question                                                                                  | Start here                 | How to answer it                                                                                                                                                                                             |
-| ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Which sources and exact passages support this project, claim, or decision?                | **Raindrop.io Highlights** | Add and filter by a `Project`, `Claim`, or `Decision` relation. **Text** and **Note** hold the evidence; **Bookmark** identifies its source.                                                                 |
-| Which new or scheduled sources still need processing?                                     | **Raindrop.io Bookmarks**  | Add `Review Status`. Filter **In Trash** unchecked, status empty, and either **Created** recently or **Reminder** due.                                                                                       |
-| Which captured insights have not yet become a brief, decision, document, or other output? | **Raindrop.io Highlights** | Add `Synthesis Status` and optionally `Used in`. Exclude `Used` and `Archived`; when `Used in` exists, filter it to empty.                                                                                   |
-| Where did this idea originate?                                                            | **Raindrop.io Highlights** | Follow **Bookmark** to **URL**, **Collection**, **Domain**, **Excerpt**, and **Note**. To show Collection in Highlights, add a rollup using **Bookmark** as the relation and **Collection** as the property. |
+| Question                                                                                  | Start here                 | How to answer it                                                                                                                                                                                     |
+| ----------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which sources and exact passages support this project, claim, or decision?                | **Raindrop.io Highlights** | Add and filter by a `Project`, `Claim`, or `Decision` relation. **Text** is the synced passage, **Note** its annotation, and **Bookmark** its source. Check **Truncated** before quoting.            |
+| Which new or scheduled sources still need processing?                                     | **Raindrop.io Bookmarks**  | Add `Review Status`. Filter **In Trash** unchecked, status empty, and either **Created** recently or **Reminder** due.                                                                               |
+| Which captured insights have not yet become a brief, decision, document, or other output? | **Raindrop.io Highlights** | Add `Synthesis Status` and optionally `Used in`. Exclude `Used` and `Archived`; when `Used in` exists, filter it to empty.                                                                           |
+| Where did this idea originate?                                                            | **Raindrop.io Highlights** | Follow **Bookmark** to **Raindrop contributor**, **URL**, **Collection**, **Domain**, **Excerpt**, and **Note**. Add a rollup using **Bookmark** as the relation and **Collection** as the property. |
 
-Each Highlight links to a **Bookmark**, and each Bookmark links to a
-**Collection**. The reciprocal **Highlights** and **Bookmarks** relations let
-you traverse the source trail in either direction. Project and output databases
-are specific to each workspace, so you add those relations in Notion. The
-Worker preserves them and each page's body content.
+For imported records, each Highlight links to a **Bookmark**, and each Bookmark
+links to a **Collection**. The reciprocal relations let you traverse the source
+trail in either direction. Project and output databases are specific to each
+workspace, so you add those relations in Notion. The Worker preserves those
+properties and each page's body content.
+
+**Raindrop contributor** identifies who created the bookmark in Raindrop when
+the API returns that context. A blank value does not identify the contributor.
 
 ## Views you can build
 
 1. **Project evidence and provenance:** Add a `Project` relation from Highlights
    to your Projects database, filter it to the current project, and show
-   **Text**, **Note**, **Tags**, and **Bookmark**. Add the Collection rollup
-   above, then place the linked view in your project template.
+   **Text**, **Note**, **Tags**, **Bookmark**, and **Truncated**. Add the
+   Collection rollup above, then place the linked view in your project template.
 2. **Insights awaiting an output:** Add a `Synthesis Status` select with
    `To synthesize`, `Drafting`, `Used`, and `Archived`; optionally add a
    `Used in` relation. Exclude `Used` and `Archived`, require `Used in` to be
@@ -108,7 +121,9 @@ Worker preserves them and each page's body content.
 3. **Processing queue:** Add a `Review Status` select to **Raindrop.io
    Bookmarks**. Filter **In Trash** to unchecked and `Review Status` to empty,
    then include recently **Created** bookmarks or those with **Reminder** on or
-   before today. Sort **Reminder** ascending, then **Created** newest first.
+   before today. For a current-only queue, require **Last Seen** within the past
+   day. Sort **Reminder** ascending, then **Created** newest first. Reminder data
+   requires Raindrop Premium; `Review Status` remains the durable state.
 
 ## Reference
 
@@ -122,40 +137,53 @@ Worker preserves them and each page's body content.
 
 ### Included data
 
-| Source      | Included                                                                   | Limit                           |
-| ----------- | -------------------------------------------------------------------------- | ------------------------------- |
-| Collections | Root and child collections, plus synthetic Unsorted and Trash targets      | 10,000 collections              |
-| Bookmarks   | Active bookmarks and Trash, including metadata, notes, tags, and reminders | 10,000 per active or Trash scan |
-| Highlights  | Highlights, notes, colors, tags, bookmark references, and source links     | 10,000 highlights               |
+| Source      | Included                                                                                       | Recipe hard stop                |
+| ----------- | ---------------------------------------------------------------------------------------------- | ------------------------------- |
+| Collections | Root and child collections, access metadata, plus synthetic Unsorted and Trash targets         | 1,000 collections               |
+| Bookmarks   | Active bookmarks and Trash, including source metadata, contributor, notes, tags, and reminders | 10,000 per active or Trash scan |
+| Highlights  | Highlights, notes, colors, tags, bookmark references, and source links                         | 10,000 highlights               |
+
+Collections fit in one output batch; Bookmark and Highlight executions emit at
+most 150 changes. Tests keep the largest envelopes below the Worker output
+limit. A scan that exceeds a hard stop fails and must be partitioned.
 
 The collection-list responses do not include counts for Unsorted and Trash, so
 their synthetic rows leave **Bookmark count** empty. Their **Bookmarks**
 relations still contain the bookmarks observed in each system collection. This
 Worker does not call the separate account-statistics endpoint.
 
+If a shared collection's parent is not visible to the token, **Parent** remains
+empty while **Parent ID** and **Parent unavailable** preserve that context.
+
 The Worker does not copy full article text, cached page contents, or uploaded
-file and media bodies. It syncs the metadata, excerpts, notes, and highlights
-needed for these workflows while Raindrop.io retains the complete source.
+file and media bodies. Those remain in Raindrop.io; Notion receives the source
+metadata, excerpts, notes, and highlights used by these workflows.
 
 ### Update behavior
 
-- Each hourly run scans the current provider data and updates **Last Seen**.
-- Moving a bookmark to Trash updates the same page, checks **In Trash**, and
-  relates it to the synthetic Trash collection. Restoring it reverses both.
-- Hard-deleted or unavailable records remain as last-known Notion pages because
-  the API does not provide reliable deletion tombstones.
+- Each sync is scheduled hourly. Records observed during its paginated scan get
+  a new **Last Seen** value.
+- A bounded drift guard detects common Bookmark and Highlight page shifts and
+  restarts each phase once. Continued changes complete best-effort without
+  deleting pages; later runs may fill omissions.
+- When a bookmark is observed in Trash, the same page is checked **In Trash**
+  and related to Trash. A later observation outside Trash reverses both.
+- The Worker does not infer deletion from absence. Records no longer returned
+  remain as last-known Notion pages.
 - An older **Last Seen** value is a review signal, not proof that a record was
   deleted.
-- Account-scoped provider IDs keep relations stable and prevent duplicates.
+- Account-scoped provider IDs upsert the same Raindrop record to the same Notion
+  page and keep relation keys stable.
 - Oversized text, URLs, and tag sets are bounded and visibly marked rather than
   blocking the scan.
-- Page content and properties added in Notion are preserved.
+- Page content and user-created properties are preserved. Synced properties are
+  refreshed from Raindrop.io.
 
 ## Adapt the sync
 
 - Change the schedules in `src/index.ts` for a slower personal archive.
-- Partition a library above the documented limits by collection rather than
-  only increasing the scan cap.
+- For a library above this recipe's hard stops, implement collection-scoped
+  partitioning rather than only increasing the constants.
 - Add a provider field by updating response validation, the database schema,
   its transform, and tests together.
 

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -1,14 +1,15 @@
 # Worker sync: Raindrop.io research library
 
-Turn your Raindrop.io bookmarks and highlights into evidence you can connect to
-projects, claims, decisions, and finished work in Notion. Trace each synced
-passage to its bookmark and collection, plus the Raindrop contributor when the
-API provides one.
+Turn your Raindrop.io bookmarks and highlights into source material for
+projects, decisions, briefs, and documents in Notion. Each highlight stays
+connected to its original bookmark and collection, and shared items show who
+saved them when that information is available.
 
-One deploy creates three related managed databases and schedules each sync
-hourly. The Worker only reads from Raindrop.io, upserts Notion properties, and
-never emits a page delete. Raindrop.io remains the source of truth for captured
-content; Notion connects it to the work it informs.
+Deploy once to create three related managed databases for collections,
+bookmarks, and highlights, with each sync scheduled hourly. The Worker only
+reads from Raindrop.io and updates Notion; it never changes your Raindrop.io
+library or deletes Notion pages. Raindrop.io remains your capture library,
+while Notion is where saved material connects to active work.
 
 ## Quickstart
 

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -1,0 +1,382 @@
+# Worker sync: Raindrop.io reading library
+
+Turn saved links and highlights into a connected, non-destructive Notion
+research archive. This Worker creates managed databases for Raindrop.io
+collections, bookmarks, and highlights, then scans the account every hour.
+
+The sync is read-only. Keep organizing and highlighting in Raindrop.io; use
+Notion to connect what you save to projects, topics, reading queues, and notes.
+Account-scoped source keys update the same pages on every run. User-added Notion
+properties and page bodies remain untouched, even when a source record later
+disappears from Raindrop.io.
+
+This is deliberately an archive, not an exact mirror. Raindrop.io does not
+provide reliable tombstones for hard-deleted bookmarks, deleted collections, or
+removed highlights, so the Worker never automatically deletes managed pages.
+
+## Quickstart
+
+You need:
+
+- Node.js 22 or newer and npm 10.9.2 or newer;
+- access to deploy Notion Workers;
+- a Raindrop.io account; and
+- a Raindrop.io test token for your own account.
+
+Create an app in [Raindrop.io App Management][raindrop-apps], open its
+settings, and copy the **Test token**. Raindrop.io recommends this simpler token
+when an integration only accesses its creator's account. This recipe uses one
+personal account token at a time; it does not implement OAuth for other users.
+
+From the repository root:
+
+```sh
+npm install --global ntn@latest
+cd workers/raindrop-sync
+npm install
+npm run check
+npm test
+ntn login
+ntn workers deploy --name raindrop-sync
+```
+
+Store the token as a Worker secret. Do not add it to source control.
+
+```sh
+ntn workers env set RAINDROP_ACCESS_TOKEN=replace-with-your-test-token
+```
+
+Preview each database in dependency order:
+
+```sh
+ntn workers sync trigger collectionsSync --preview
+ntn workers sync trigger bookmarksSync --preview
+ntn workers sync trigger highlightsSync --preview
+```
+
+Previews can print private collection names, bookmark titles, URLs, notes, and
+highlights. Protect terminal output. When the previews look right, run the
+initial imports:
+
+```sh
+ntn workers sync trigger collectionsSync
+ntn workers sync trigger bookmarksSync
+ntn workers sync trigger highlightsSync
+ntn workers sync status
+```
+
+The three syncs then scan hourly without a recurring CLI command. The Worker
+does not need a Notion API token.
+
+## What you get
+
+| Managed database            | What it is useful for                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Raindrop.io Collections** | Browse the observed source hierarchy and relate collections to other Notion work.                      |
+| **Raindrop.io Bookmarks**   | Build reading queues, project libraries, and views by collection, tag, type, favorite, or Trash state. |
+| **Raindrop.io Highlights**  | Review quotes and annotations independently while retaining a relation to the source bookmark.         |
+
+The Worker creates two-way relations from Bookmarks to Collections and from
+Highlights to Bookmarks. Trigger Collections before Bookmarks, and Bookmarks
+before Highlights, on the first import so every relation target already exists.
+
+Every primary key includes the authenticated Raindrop account ID, resource type,
+and raw provider ID. For example, bookmark `42` in account `321` uses
+`raindrop:321:bookmark:42`. Rotating a token for the same account updates the
+same rows. A token for a different account creates a separate set of rows and
+cannot overwrite the earlier account's archive.
+
+### Collections
+
+| Notion property     | Raindrop.io field or meaning             | Type                   |
+| ------------------- | ---------------------------------------- | ---------------------- |
+| Name                | `title`                                  | title                  |
+| Parent              | Account-scoped `parent.$id`              | self-relation          |
+| Subcollections      | Reciprocal of Parent                     | reciprocal relation    |
+| Bookmarks           | `count`                                  | number                 |
+| Public              | `public`                                 | checkbox               |
+| Created             | `created`                                | date                   |
+| Updated             | `lastUpdate`                             | date                   |
+| Collection ID       | Raw `_id`                                | rich text              |
+| Raindrop Account ID | Authenticated user `_id`                 | rich text              |
+| Collection Key      | Account-scoped source identity           | rich text, primary key |
+| Synced Bookmarks    | Reciprocal of each bookmark's Collection | reciprocal relation    |
+
+Raindrop.io omits system collections from its collection endpoints. The Worker
+adds account-scoped **Unsorted** (`-1`) and **Trash** (`-99`) relation targets.
+Their bookmark counts are left blank because the collection responses do not
+provide them.
+
+### Bookmarks
+
+| Notion property     | Raindrop.io field or meaning                 | Type                    |
+| ------------------- | -------------------------------------------- | ----------------------- |
+| Title               | `title`, with domain or URL as a fallback    | title                   |
+| URL                 | `link`                                       | URL                     |
+| Collection          | Account-scoped `collection.$id` relation     | relation to Collections |
+| Tags                | `tags`                                       | multi-select            |
+| Type                | `type`                                       | select                  |
+| Domain              | `domain`                                     | rich text               |
+| Favorite            | `important`                                  | checkbox                |
+| Broken              | `broken`                                     | checkbox                |
+| In Trash            | Whether this scan observed the item in `-99` | checkbox                |
+| Note                | `note`                                       | rich text               |
+| Excerpt             | `excerpt`                                    | rich text               |
+| Truncated           | Note or Excerpt exceeded the property limit  | checkbox                |
+| Highlights          | Number of embedded highlights                | number                  |
+| Created             | `created`                                    | date                    |
+| Updated             | `lastUpdate`                                 | date                    |
+| Raindrop ID         | Raw `_id`                                    | rich text               |
+| Raindrop Account ID | Authenticated user `_id`                     | rich text               |
+| Bookmark Key        | Account-scoped source identity               | rich text, primary key  |
+| Synced Highlights   | Reciprocal of each highlight's Bookmark      | reciprocal relation     |
+
+Each bookmark scan reads active items and then Trash. Moving a bookmark to
+Trash updates the same Notion page to **In Trash = checked** and relates it to
+the synthetic Trash collection. Restoring it updates that page to
+**In Trash = unchecked** and restores its observed collection relation.
+
+### Highlights
+
+| Notion property     | Raindrop.io field or meaning             | Type                   |
+| ------------------- | ---------------------------------------- | ---------------------- |
+| Highlight           | Compact first line of `text`             | title                  |
+| Text                | `text`                                   | rich text              |
+| Note                | `note`                                   | rich text              |
+| Bookmark            | Account-scoped `raindropRef` relation    | relation to Bookmarks  |
+| Bookmark title      | `title`                                  | rich text              |
+| URL                 | `link`                                   | URL                    |
+| Color               | Documented `color` enum                  | select                 |
+| Tags                | `tags`                                   | multi-select           |
+| Truncated           | Text or Note exceeded the property limit | checkbox               |
+| Created             | `created`                                | date                   |
+| Highlight ID        | Raw `_id`                                | rich text              |
+| Raindrop Account ID | Authenticated user `_id`                 | rich text              |
+| Highlight Key       | Account-scoped source identity           | rich text, primary key |
+
+Notion rich-text properties are bounded to 2,000 Unicode characters in this
+reference recipe. When a source Note, Excerpt, highlight Text, or highlight Note
+is longer, the Worker adds an ellipsis and checks **Truncated** instead of
+failing the entire library. The complete values remain in Raindrop.io while the
+source record exists. Page bodies are deliberately not managed, so you can
+write longer summaries and project-specific notes there without a later scan
+overwriting them.
+
+Source timestamps are normalized to UTC before they are written to Notion date
+properties.
+
+Tag names are normalized into deterministic Notion options. Because the Worker
+multi-select wire format uses commas as separators, a comma inside one
+Raindrop.io tag becomes a visually similar full-width comma (`，`). More than
+100 distinct tags on one record fails the page instead of silently dropping
+source values.
+
+## Archive and refresh semantics
+
+Raindrop.io's documented REST API provides stable IDs and page-number
+pagination, but not a change feed, snapshot cursor, or reliable deletion feed.
+Each capability therefore uses `mode: "incremental"` for a complete,
+non-destructive scan:
+
+1. The Worker fetches the authenticated user's stable account ID.
+2. Collections read both collection endpoints and add Unsorted and Trash.
+3. Bookmarks read all active items in ascending creation order, then all Trash
+   items, 50 at a time.
+4. Highlights read the global highlights endpoint, 50 at a time.
+5. Every observed record is upserted. Unobserved records are left untouched.
+
+This means:
+
+- A moved or restored Trash item is updated explicitly through **In Trash**.
+- A hard-deleted bookmark remains as its last-known Notion record.
+- A deleted collection remains as its last-known Notion record.
+- A removed or hard-deleted highlight remains as its last-known Notion record.
+- The API does not provide enough information to label those last three cases
+  as deleted reliably. Treat them as archive records, not confirmed live data.
+
+This non-destructive behavior is intentional. With page-number pagination, a
+save or deletion during a long scan can move another item across a page
+boundary. A missed item is refreshed on a later scan, but its Notion page and
+user-owned annotations are never deleted merely because one scan did not see
+it.
+
+The reference Worker stops above 10,000 active Bookmarks, 10,000 Trash
+Bookmarks, or 10,000 Highlights instead of accepting an unbounded run.
+Partition larger libraries by collection. Collection responses are also capped
+at 10,000 records.
+
+Each execution captures one token and uses it for both the authenticated-user
+lookup and its following data request. Every paginated continuation also stores
+the authenticated account ID. If the token changes to another account during a
+scan, the capability fails before reading the next data page. Restore the
+original token or reset that capability's state before intentionally continuing
+with the other account.
+
+All requests share a Worker pacer set to 100 requests per minute, below
+Raindrop.io's documented limit of 120 authenticated requests per minute. HTTP
+429 responses become Worker rate-limit signals. Requests time out after 30
+seconds, reject redirects, and cap decoded response bodies at 10 MiB.
+
+## Source of truth and editing
+
+This is a one-way refresh and archive. Change managed fields, collection
+membership, tags, notes, and highlights in Raindrop.io. Observed records update
+on the next complete scan.
+
+In Notion, you can safely add properties such as:
+
+- Reading status
+- Project or topic relations
+- Why it matters
+- Review date
+- Shared with
+
+The Worker schema owns only the properties listed above and does not write page
+bodies. Because it never emits deletes, source disappearance does not remove a
+managed page or its user-added values. If your workflow needs a confirmed-live
+view, add a separate reviewed retention process instead of inferring deletion
+from absence in one Raindrop.io scan.
+
+## Privacy and access
+
+The token can read private URLs, notes, tags, collection names, Trash, and
+highlights. The Worker sends those selected fields to managed Notion databases.
+Anyone who can access those databases can see the synced values, even when the
+original Raindrop.io collection is private or the bookmark is in Trash.
+
+- Use a dedicated Raindrop.io app and its test token; do not reuse credentials
+  from another integration.
+- Share the managed databases only with the intended audience.
+- Never commit `.env`, tokens, preview output, or generated `workers.json`
+  state.
+- Review the [Raindrop.io API terms][raindrop-terms] before adapting this into a
+  multi-user or commercial product.
+
+Although a Raindrop.io bearer token can authorize writes, this Worker only
+issues documented `GET` requests.
+
+## Project structure
+
+```text
+src/
+├── index.ts        — registers databases, schedules, and the shared pacer
+├── raindrop.ts     — authenticated REST client and response validation
+├── sync-state.ts   — account-pinned active, Trash, and highlight scan state
+├── keys.ts         — account- and resource-scoped stable identities
+├── collections.ts  — Collections schema and transform
+├── bookmarks.ts    — Bookmarks schema and transform
+├── highlights.ts   — Highlights schema and transform
+└── format.ts       — labels, titles, and disclosed text bounds
+test.ts             — offline transforms, paging, auth, and failure tests
+```
+
+## Adapt the recipe
+
+Common extensions:
+
+1. **Sync one collection.** Replace collection ID `0` in `src/raindrop.ts` with
+   a configured collection ID and document whether nested collections are
+   included. Decide separately whether its Trash history is still required.
+2. **Partition a large library.** Declare one managed database and incremental
+   full scan per collection so each capability remains below 10,000 records.
+3. **Add an explicit retention workflow.** If stale archive records must be
+   removed, require a reviewed user action or a provider-backed deletion signal;
+   do not translate one missing page-number scan into deletion.
+4. **Change the cadence.** Adjust the three `schedule` values in `src/index.ts`.
+   Keep complete scans affordable for the library size.
+5. **Add source fields.** Extend the validated API type, its schema, its
+   transform, and the property table in this README together.
+6. **Serve multiple users.** Replace the personal test-token setup with a
+   reviewed OAuth design using Raindrop.io's authorization and refresh-token
+   flow. Keep account-scoped keys; do not share one user's token between
+   deployments.
+
+## Verify locally
+
+The checks use fixtures and mocked HTTP responses; they do not call
+Raindrop.io or require credentials.
+
+```sh
+npm install
+npm run check
+npm test
+npm run build
+```
+
+To inspect a live response without writing managed databases after deployment:
+
+```sh
+ntn workers sync trigger bookmarksSync --preview
+```
+
+## Troubleshooting
+
+### The Worker reports an invalid token
+
+Open the app in [Raindrop.io App Management][raindrop-apps], replace its test
+token in Worker secrets, and preview again:
+
+```sh
+ntn workers env set RAINDROP_ACCESS_TOKEN=replace-with-your-test-token
+ntn workers sync trigger collectionsSync --preview
+```
+
+### The account changed during a scan
+
+If the token was changed accidentally, restore the original account's token. To
+intentionally continue with a different account, reset only the in-flight
+paginated capabilities, then trigger the imports in dependency order:
+
+```sh
+ntn workers sync state reset bookmarksSync
+ntn workers sync state reset highlightsSync
+ntn workers sync trigger collectionsSync
+ntn workers sync trigger bookmarksSync
+ntn workers sync trigger highlightsSync
+```
+
+The previous account's rows remain as an archive. New rows use a different
+account namespace.
+
+### Relations are empty
+
+Run the initial imports in dependency order: Collections, Bookmarks, then
+Highlights. The hourly scans keep using the same account-scoped keys.
+
+### A deleted source record still appears
+
+This is expected archive behavior. Raindrop.io does not expose reliable
+tombstones for hard-deleted bookmarks, deleted collections, or removed
+highlights. The Worker preserves last-known rows so an ambiguous absence cannot
+destroy Notion notes or user-added properties.
+
+### A moved bookmark has the wrong Trash state temporarily
+
+Check that the latest bookmark scan completed. Page-number APIs cannot freeze a
+changing library; the next complete active-and-Trash scan refreshes the same
+account-scoped bookmark key.
+
+### The sync exceeds 10,000 records
+
+Partition it by collection. Do not only raise the limit: larger full scans
+increase runtime, rate-limit pressure, and the window for page movement.
+
+## API references
+
+- [Raindrop.io API overview and rate limits][raindrop-overview]
+- [Authentication and personal test tokens][raindrop-token]
+- [Authenticated user identity][raindrop-user]
+- [Collection methods][raindrop-collections]
+- [Bookmark fields][raindrop-fields]
+- [Paginated bookmark reads][raindrop-bookmarks]
+- [Highlights][raindrop-highlights]
+
+[raindrop-apps]: https://app.raindrop.io/settings/integrations
+[raindrop-bookmarks]: https://developer.raindrop.io/v1/raindrops/multiple
+[raindrop-collections]: https://developer.raindrop.io/v1/collections/methods
+[raindrop-fields]: https://developer.raindrop.io/v1/raindrops
+[raindrop-highlights]: https://developer.raindrop.io/v1/highlights
+[raindrop-overview]: https://developer.raindrop.io/
+[raindrop-terms]: https://developer.raindrop.io/terms
+[raindrop-token]: https://developer.raindrop.io/v1/authentication/token
+[raindrop-user]: https://developer.raindrop.io/v1/user/authenticated

--- a/workers/raindrop-sync/README.md
+++ b/workers/raindrop-sync/README.md
@@ -88,19 +88,20 @@ cannot overwrite the earlier account's archive.
 
 ### Collections
 
-| Notion property     | Raindrop.io field or meaning             | Type                   |
-| ------------------- | ---------------------------------------- | ---------------------- |
-| Name                | `title`                                  | title                  |
-| Parent              | Account-scoped `parent.$id`              | self-relation          |
-| Subcollections      | Reciprocal of Parent                     | reciprocal relation    |
-| Bookmarks           | `count`                                  | number                 |
-| Public              | `public`                                 | checkbox               |
-| Created             | `created`                                | date                   |
-| Updated             | `lastUpdate`                             | date                   |
-| Collection ID       | Raw `_id`                                | rich text              |
-| Raindrop Account ID | Authenticated user `_id`                 | rich text              |
-| Collection Key      | Account-scoped source identity           | rich text, primary key |
-| Synced Bookmarks    | Reciprocal of each bookmark's Collection | reciprocal relation    |
+| Notion property     | Raindrop.io field or meaning              | Type                   |
+| ------------------- | ----------------------------------------- | ---------------------- |
+| Name                | `title`                                   | title                  |
+| Parent              | Account-scoped `parent.$id`               | self-relation          |
+| Subcollections      | Reciprocal of Parent                      | reciprocal relation    |
+| Bookmarks           | `count`                                   | number                 |
+| Public              | `public`                                  | checkbox               |
+| Created             | `created`                                 | date                   |
+| Updated             | `lastUpdate`                              | date                   |
+| Last Seen           | When the Worker most recently observed it | date                   |
+| Collection ID       | Raw `_id`                                 | rich text              |
+| Raindrop Account ID | Authenticated user `_id`                  | rich text              |
+| Collection Key      | Account-scoped source identity            | rich text, primary key |
+| Synced Bookmarks    | Reciprocal of each bookmark's Collection  | reciprocal relation    |
 
 Raindrop.io omits system collections from its collection endpoints. The Worker
 adds account-scoped **Unsorted** (`-1`) and **Trash** (`-99`) relation targets.
@@ -113,6 +114,7 @@ provide them.
 | ------------------- | -------------------------------------------- | ----------------------- |
 | Title               | `title`, with domain or URL as a fallback    | title                   |
 | URL                 | `link`                                       | URL                     |
+| URL Omitted         | `link` exceeded Notion's URL limit           | checkbox                |
 | Collection          | Account-scoped `collection.$id` relation     | relation to Collections |
 | Tags                | `tags`                                       | multi-select            |
 | Type                | `type`                                       | select                  |
@@ -122,10 +124,11 @@ provide them.
 | In Trash            | Whether this scan observed the item in `-99` | checkbox                |
 | Note                | `note`                                       | rich text               |
 | Excerpt             | `excerpt`                                    | rich text               |
-| Truncated           | Note or Excerpt exceeded the property limit  | checkbox                |
+| Truncated           | Title, Note, or Excerpt exceeded its limit   | checkbox                |
 | Highlights          | Number of embedded highlights                | number                  |
 | Created             | `created`                                    | date                    |
 | Updated             | `lastUpdate`                                 | date                    |
+| Last Seen           | When the Worker most recently observed it    | date                    |
 | Raindrop ID         | Raw `_id`                                    | rich text               |
 | Raindrop Account ID | Authenticated user `_id`                     | rich text               |
 | Bookmark Key        | Account-scoped source identity               | rich text, primary key  |
@@ -138,21 +141,23 @@ the synthetic Trash collection. Restoring it updates that page to
 
 ### Highlights
 
-| Notion property     | Raindrop.io field or meaning             | Type                   |
-| ------------------- | ---------------------------------------- | ---------------------- |
-| Highlight           | Compact first line of `text`             | title                  |
-| Text                | `text`                                   | rich text              |
-| Note                | `note`                                   | rich text              |
-| Bookmark            | Account-scoped `raindropRef` relation    | relation to Bookmarks  |
-| Bookmark title      | `title`                                  | rich text              |
-| URL                 | `link`                                   | URL                    |
-| Color               | Documented `color` enum                  | select                 |
-| Tags                | `tags`                                   | multi-select           |
-| Truncated           | Text or Note exceeded the property limit | checkbox               |
-| Created             | `created`                                | date                   |
-| Highlight ID        | Raw `_id`                                | rich text              |
-| Raindrop Account ID | Authenticated user `_id`                 | rich text              |
-| Highlight Key       | Account-scoped source identity           | rich text, primary key |
+| Notion property     | Raindrop.io field or meaning              | Type                   |
+| ------------------- | ----------------------------------------- | ---------------------- |
+| Highlight           | Compact single-line excerpt of `text`     | title                  |
+| Text                | `text`                                    | rich text              |
+| Note                | `note`                                    | rich text              |
+| Bookmark            | Account-scoped `raindropRef` relation     | relation to Bookmarks  |
+| Bookmark title      | `title`                                   | rich text              |
+| URL                 | `link`                                    | URL                    |
+| URL Omitted         | `link` exceeded Notion's URL limit        | checkbox               |
+| Color               | Documented `color` enum                   | select                 |
+| Tags                | `tags`                                    | multi-select           |
+| Truncated           | Text or Note exceeded the property limit  | checkbox               |
+| Created             | `created`                                 | date                   |
+| Last Seen           | When the Worker most recently observed it | date                   |
+| Highlight ID        | Raw `_id`                                 | rich text              |
+| Raindrop Account ID | Authenticated user `_id`                  | rich text              |
+| Highlight Key       | Account-scoped source identity            | rich text, primary key |
 
 Notion rich-text properties are bounded to 2,000 Unicode characters in this
 reference recipe. When a source Note, Excerpt, highlight Text, or highlight Note
@@ -162,14 +167,21 @@ source record exists. Page bodies are deliberately not managed, so you can
 write longer summaries and project-specific notes there without a later scan
 overwriting them.
 
+[Notion URL properties accept at most 2,000 characters][notion-request-limits].
+When a bookmark or highlight link is longer, the Worker leaves **URL** empty and
+checks **URL Omitted** instead of failing that page and blocking the rest of the
+scan. The complete link remains in Raindrop.io.
+
 Source timestamps are normalized to UTC before they are written to Notion date
 properties.
 
-Tag names are normalized into deterministic Notion options. Because the Worker
-multi-select wire format uses commas as separators, a comma inside one
-Raindrop.io tag becomes a visually similar full-width comma (`，`). More than
-100 distinct tags on one record fails the page instead of silently dropping
-source values.
+Tag names are trimmed, whitespace-normalized, and deduplicated
+case-insensitively. Because the Worker multi-select wire format uses commas as
+separators, a comma inside one Raindrop.io tag becomes a visually similar
+full-width comma (`，`). If otherwise-distinct tags map to the same Notion
+option, the Worker adds a stable suffix to preserve both. More than 100
+resulting options on one record fails the page instead of silently dropping
+values.
 
 ## Archive and refresh semantics
 
@@ -183,14 +195,18 @@ non-destructive scan:
 3. Bookmarks read all active items in ascending creation order, then all Trash
    items, 50 at a time.
 4. Highlights read the global highlights endpoint, 50 at a time.
-5. Every observed record is upserted. Unobserved records are left untouched.
+5. Every observed record is upserted and advances **Last Seen**. Unobserved
+   records are left untouched with their earlier timestamp.
 
 This means:
 
 - A moved or restored Trash item is updated explicitly through **In Trash**.
-- A hard-deleted bookmark remains as its last-known Notion record.
-- A deleted collection remains as its last-known Notion record.
-- A removed or hard-deleted highlight remains as its last-known Notion record.
+- A hard-deleted bookmark remains as its last-known Notion record and retains
+  its earlier **Last Seen** value.
+- A deleted collection remains as its last-known Notion record and retains its
+  earlier **Last Seen** value.
+- A removed or hard-deleted highlight remains as its last-known Notion record
+  and retains its earlier **Last Seen** value.
 - The API does not provide enough information to label those last three cases
   as deleted reliably. Treat them as archive records, not confirmed live data.
 
@@ -233,9 +249,9 @@ In Notion, you can safely add properties such as:
 
 The Worker schema owns only the properties listed above and does not write page
 bodies. Because it never emits deletes, source disappearance does not remove a
-managed page or its user-added values. If your workflow needs a confirmed-live
-view, add a separate reviewed retention process instead of inferring deletion
-from absence in one Raindrop.io scan.
+managed page or its user-added values. Use **Last Seen** to find records that
+have not been observed recently, then verify them in Raindrop.io before taking
+destructive action. Absence from one scan is not proof of deletion.
 
 ## Privacy and access
 
@@ -363,6 +379,7 @@ increase runtime, rate-limit pressure, and the window for page movement.
 
 ## API references
 
+- [Notion request limits][notion-request-limits]
 - [Raindrop.io API overview and rate limits][raindrop-overview]
 - [Authentication and personal test tokens][raindrop-token]
 - [Authenticated user identity][raindrop-user]
@@ -372,6 +389,7 @@ increase runtime, rate-limit pressure, and the window for page movement.
 - [Highlights][raindrop-highlights]
 
 [raindrop-apps]: https://app.raindrop.io/settings/integrations
+[notion-request-limits]: https://developers.notion.com/reference/request-limits
 [raindrop-bookmarks]: https://developer.raindrop.io/v1/raindrops/multiple
 [raindrop-collections]: https://developer.raindrop.io/v1/collections/methods
 [raindrop-fields]: https://developer.raindrop.io/v1/raindrops

--- a/workers/raindrop-sync/package.json
+++ b/workers/raindrop-sync/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@notion-cookbook/raindrop-sync",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --project tsconfig.test.json",
+    "test": "node --import tsx --test test.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@notionhq/workers": "^0.4.0"
+  }
+}

--- a/workers/raindrop-sync/src/bookmarks.ts
+++ b/workers/raindrop-sync/src/bookmarks.ts
@@ -21,6 +21,8 @@ export const bookmarkSchema = {
 
     URL: Schema.url(),
 
+    "URL Omitted": Schema.checkbox(),
+
     Collection: Schema.relation("collections", {
       twoWay: true,
       relatedPropertyName: "Synced Bookmarks",
@@ -57,6 +59,8 @@ export const bookmarkSchema = {
 
     Updated: Schema.date(),
 
+    "Last Seen": Schema.date(),
+
     "Raindrop ID": Schema.richText(),
 
     "Raindrop Account ID": Schema.richText(),
@@ -68,17 +72,23 @@ export const bookmarkSchema = {
 export function bookmarkToChange(
   accountId: number,
   bookmark: RaindropBookmark,
-  inTrash: boolean
+  inTrash: boolean,
+  observedAt: string
 ): SyncChangeUpsert<typeof PRIMARY_KEY, typeof bookmarkSchema.properties> {
-  const title = bookmark.title.trim() || bookmark.domain.trim() || bookmark.link
+  const sourceTitle =
+    bookmark.title.trim() ||
+    bookmark.domain.trim() ||
+    bookmark.link ||
+    "Untitled bookmark"
   const tags = optionNames("bookmark tags", bookmark.tags)
   const key = bookmarkKey(accountId, bookmark._id)
   return {
     type: "upsert",
     key,
     properties: {
-      Title: Builder.title(title),
-      URL: Builder.url(bookmark.link),
+      Title: Builder.title(boundedText(sourceTitle)),
+      URL: bookmark.link ? Builder.url(bookmark.link) : [],
+      "URL Omitted": Builder.checkbox(bookmark.linkOmitted),
       Collection: [
         Builder.relation(collectionKey(accountId, bookmark.collection.$id)),
       ],
@@ -93,11 +103,14 @@ export function bookmarkToChange(
         ? Builder.richText(boundedText(bookmark.excerpt))
         : [],
       Truncated: Builder.checkbox(
-        textWasTruncated(bookmark.note) || textWasTruncated(bookmark.excerpt)
+        textWasTruncated(sourceTitle) ||
+          textWasTruncated(bookmark.note) ||
+          textWasTruncated(bookmark.excerpt)
       ),
       Highlights: Builder.number(bookmark.highlights.length),
       Created: Builder.dateTime(bookmark.created, "UTC"),
       Updated: Builder.dateTime(bookmark.lastUpdate, "UTC"),
+      "Last Seen": Builder.dateTime(observedAt, "UTC"),
       "Raindrop ID": Builder.richText(String(bookmark._id)),
       "Raindrop Account ID": Builder.richText(String(accountId)),
       "Bookmark Key": Builder.richText(key),

--- a/workers/raindrop-sync/src/bookmarks.ts
+++ b/workers/raindrop-sync/src/bookmarks.ts
@@ -23,18 +23,24 @@ export const bookmarkSchema = {
 
     Collection: Schema.relation("collections", {
       twoWay: true,
-      relatedPropertyName: "Synced Bookmarks",
+      relatedPropertyName: "Bookmarks",
     }),
+
+    Reminder: Schema.date(),
+
+    Created: Schema.date(),
 
     Tags: Schema.multiSelect([]),
 
     Favorite: Schema.checkbox(),
 
-    Updated: Schema.date(),
-
     Note: Schema.richText(),
 
     Excerpt: Schema.richText(),
+
+    "Highlight count": Schema.number(),
+
+    Updated: Schema.date(),
 
     "In Trash": Schema.checkbox(),
 
@@ -52,10 +58,6 @@ export const bookmarkSchema = {
     ]),
 
     Domain: Schema.richText(),
-
-    Highlights: Schema.number(),
-
-    Created: Schema.date(),
 
     Truncated: Schema.checkbox(),
 
@@ -92,6 +94,9 @@ export function bookmarkToChange(
       Collection: [
         Builder.relation(collectionKey(accountId, bookmark.collection.$id)),
       ],
+      Reminder: bookmark.reminderAt
+        ? Builder.dateTime(bookmark.reminderAt, "UTC")
+        : [],
       Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
       Type: Builder.select(displayLabel(bookmark.type)),
       Domain: bookmark.domain ? Builder.richText(bookmark.domain) : [],
@@ -107,7 +112,7 @@ export function bookmarkToChange(
           textWasTruncated(bookmark.note) ||
           textWasTruncated(bookmark.excerpt)
       ),
-      Highlights: Builder.number(bookmark.highlights.length),
+      "Highlight count": Builder.number(bookmark.highlights.length),
       Created: Builder.dateTime(bookmark.created, "UTC"),
       Updated: Builder.dateTime(bookmark.lastUpdate, "UTC"),
       "Last Seen": Builder.dateTime(observedAt, "UTC"),

--- a/workers/raindrop-sync/src/bookmarks.ts
+++ b/workers/raindrop-sync/src/bookmarks.ts
@@ -32,6 +32,10 @@ export const bookmarkSchema = {
 
     Tags: Schema.multiSelect([]),
 
+    "Raindrop contributor": Schema.richText(),
+
+    "Raindrop contributor ID": Schema.richText(),
+
     Favorite: Schema.checkbox(),
 
     Note: Schema.richText(),
@@ -104,13 +108,20 @@ export function bookmarkToChange(
       Broken: Builder.checkbox(bookmark.broken),
       "In Trash": Builder.checkbox(inTrash),
       Note: bookmark.note ? Builder.richText(boundedText(bookmark.note)) : [],
+      "Raindrop contributor": bookmark.contributor
+        ? Builder.richText(boundedText(bookmark.contributor.fullName))
+        : [],
+      "Raindrop contributor ID": bookmark.contributor
+        ? Builder.richText(String(bookmark.contributor.id))
+        : [],
       Excerpt: bookmark.excerpt
         ? Builder.richText(boundedText(bookmark.excerpt))
         : [],
       Truncated: Builder.checkbox(
         textWasTruncated(sourceTitle) ||
           textWasTruncated(bookmark.note) ||
-          textWasTruncated(bookmark.excerpt)
+          textWasTruncated(bookmark.excerpt) ||
+          textWasTruncated(bookmark.contributor?.fullName ?? "")
       ),
       "Highlight count": Builder.number(bookmark.highlights.length),
       Created: Builder.dateTime(bookmark.created, "UTC"),

--- a/workers/raindrop-sync/src/bookmarks.ts
+++ b/workers/raindrop-sync/src/bookmarks.ts
@@ -21,14 +21,26 @@ export const bookmarkSchema = {
 
     URL: Schema.url(),
 
-    "URL Omitted": Schema.checkbox(),
-
     Collection: Schema.relation("collections", {
       twoWay: true,
       relatedPropertyName: "Synced Bookmarks",
     }),
 
     Tags: Schema.multiSelect([]),
+
+    Favorite: Schema.checkbox(),
+
+    Updated: Schema.date(),
+
+    Note: Schema.richText(),
+
+    Excerpt: Schema.richText(),
+
+    "In Trash": Schema.checkbox(),
+
+    Broken: Schema.checkbox(),
+
+    "Last Seen": Schema.date(),
 
     Type: Schema.select([
       { name: "Link" },
@@ -41,25 +53,13 @@ export const bookmarkSchema = {
 
     Domain: Schema.richText(),
 
-    Favorite: Schema.checkbox(),
-
-    Broken: Schema.checkbox(),
-
-    "In Trash": Schema.checkbox(),
-
-    Note: Schema.richText(),
-
-    Excerpt: Schema.richText(),
-
-    Truncated: Schema.checkbox(),
-
     Highlights: Schema.number(),
 
     Created: Schema.date(),
 
-    Updated: Schema.date(),
+    Truncated: Schema.checkbox(),
 
-    "Last Seen": Schema.date(),
+    "URL Omitted": Schema.checkbox(),
 
     "Raindrop ID": Schema.richText(),
 
@@ -80,7 +80,7 @@ export function bookmarkToChange(
     bookmark.domain.trim() ||
     bookmark.link ||
     "Untitled bookmark"
-  const tags = optionNames("bookmark tags", bookmark.tags)
+  const tags = optionNames(bookmark.tags)
   const key = bookmarkKey(accountId, bookmark._id)
   return {
     type: "upsert",

--- a/workers/raindrop-sync/src/bookmarks.ts
+++ b/workers/raindrop-sync/src/bookmarks.ts
@@ -1,0 +1,106 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  boundedText,
+  displayLabel,
+  optionNames,
+  textWasTruncated,
+} from "./format.js"
+import { bookmarkKey, collectionKey } from "./keys.js"
+import type { RaindropBookmark } from "./raindrop.js"
+
+export const INITIAL_TITLE = "Raindrop.io Bookmarks"
+export const PRIMARY_KEY = "Bookmark Key"
+
+export const bookmarkSchema = {
+  databaseIcon: notionIcon("bookmark"),
+  properties: {
+    Title: Schema.title(),
+
+    URL: Schema.url(),
+
+    Collection: Schema.relation("collections", {
+      twoWay: true,
+      relatedPropertyName: "Synced Bookmarks",
+    }),
+
+    Tags: Schema.multiSelect([]),
+
+    Type: Schema.select([
+      { name: "Link" },
+      { name: "Article" },
+      { name: "Image" },
+      { name: "Video" },
+      { name: "Document" },
+      { name: "Audio" },
+    ]),
+
+    Domain: Schema.richText(),
+
+    Favorite: Schema.checkbox(),
+
+    Broken: Schema.checkbox(),
+
+    "In Trash": Schema.checkbox(),
+
+    Note: Schema.richText(),
+
+    Excerpt: Schema.richText(),
+
+    Truncated: Schema.checkbox(),
+
+    Highlights: Schema.number(),
+
+    Created: Schema.date(),
+
+    Updated: Schema.date(),
+
+    "Raindrop ID": Schema.richText(),
+
+    "Raindrop Account ID": Schema.richText(),
+
+    "Bookmark Key": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+export function bookmarkToChange(
+  accountId: number,
+  bookmark: RaindropBookmark,
+  inTrash: boolean
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof bookmarkSchema.properties> {
+  const title = bookmark.title.trim() || bookmark.domain.trim() || bookmark.link
+  const tags = optionNames("bookmark tags", bookmark.tags)
+  const key = bookmarkKey(accountId, bookmark._id)
+  return {
+    type: "upsert",
+    key,
+    properties: {
+      Title: Builder.title(title),
+      URL: Builder.url(bookmark.link),
+      Collection: [
+        Builder.relation(collectionKey(accountId, bookmark.collection.$id)),
+      ],
+      Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
+      Type: Builder.select(displayLabel(bookmark.type)),
+      Domain: bookmark.domain ? Builder.richText(bookmark.domain) : [],
+      Favorite: Builder.checkbox(bookmark.important),
+      Broken: Builder.checkbox(bookmark.broken),
+      "In Trash": Builder.checkbox(inTrash),
+      Note: bookmark.note ? Builder.richText(boundedText(bookmark.note)) : [],
+      Excerpt: bookmark.excerpt
+        ? Builder.richText(boundedText(bookmark.excerpt))
+        : [],
+      Truncated: Builder.checkbox(
+        textWasTruncated(bookmark.note) || textWasTruncated(bookmark.excerpt)
+      ),
+      Highlights: Builder.number(bookmark.highlights.length),
+      Created: Builder.dateTime(bookmark.created, "UTC"),
+      Updated: Builder.dateTime(bookmark.lastUpdate, "UTC"),
+      "Raindrop ID": Builder.richText(String(bookmark._id)),
+      "Raindrop Account ID": Builder.richText(String(accountId)),
+      "Bookmark Key": Builder.richText(key),
+    },
+  }
+}

--- a/workers/raindrop-sync/src/collections.ts
+++ b/workers/raindrop-sync/src/collections.ts
@@ -19,7 +19,7 @@ export const collectionSchema = {
       relatedPropertyName: "Subcollections",
     }),
 
-    Bookmarks: Schema.number(),
+    "Bookmark count": Schema.number(),
 
     Updated: Schema.date(),
 
@@ -55,7 +55,7 @@ export function collectionToChange(
         collection.parentId === undefined
           ? []
           : [Builder.relation(collectionKey(accountId, collection.parentId))],
-      Bookmarks:
+      "Bookmark count":
         collection.count === undefined ? [] : Builder.number(collection.count),
       Public: Builder.checkbox(collection.public),
       Created: collection.created

--- a/workers/raindrop-sync/src/collections.ts
+++ b/workers/raindrop-sync/src/collections.ts
@@ -25,7 +25,22 @@ export const collectionSchema = {
 
     "Last Seen": Schema.date(),
 
-    Public: Schema.checkbox(),
+    "Raindrop access": Schema.select([
+      { name: "Public: view" },
+      { name: "Collaborator: view" },
+      { name: "Collaborator: edit" },
+      { name: "Owner" },
+    ]),
+
+    "Shared in Raindrop": Schema.checkbox(),
+
+    "Public in Raindrop": Schema.checkbox(),
+
+    "Raindrop Owner ID": Schema.richText(),
+
+    "Parent unavailable": Schema.checkbox(),
+
+    "Parent ID": Schema.richText(),
 
     Created: Schema.date(),
 
@@ -52,12 +67,25 @@ export function collectionToChange(
     properties: {
       Name: Builder.title(boundedText(sourceTitle)),
       Parent:
-        collection.parentId === undefined
+        collection.parentId === undefined || !collection.parentAvailable
           ? []
           : [Builder.relation(collectionKey(accountId, collection.parentId))],
+      "Parent unavailable": Builder.checkbox(
+        collection.parentId !== undefined && !collection.parentAvailable
+      ),
+      "Parent ID": collection.parentId
+        ? Builder.richText(String(collection.parentId))
+        : [],
       "Bookmark count":
         collection.count === undefined ? [] : Builder.number(collection.count),
-      Public: Builder.checkbox(collection.public),
+      "Raindrop access": collection.accessLevel
+        ? Builder.select(accessLabel(collection.accessLevel))
+        : [],
+      "Shared in Raindrop": Builder.checkbox(collection.shared),
+      "Public in Raindrop": Builder.checkbox(collection.public),
+      "Raindrop Owner ID": collection.ownerId
+        ? Builder.richText(String(collection.ownerId))
+        : [],
       Created: collection.created
         ? Builder.dateTime(collection.created, "UTC")
         : [],
@@ -70,5 +98,20 @@ export function collectionToChange(
       "Raindrop Account ID": Builder.richText(String(accountId)),
       "Collection Key": Builder.richText(key),
     },
+  }
+}
+
+function accessLabel(
+  level: NonNullable<RaindropCollection["accessLevel"]>
+): string {
+  switch (level) {
+    case 1:
+      return "Public: view"
+    case 2:
+      return "Collaborator: view"
+    case 3:
+      return "Collaborator: edit"
+    case 4:
+      return "Owner"
   }
 }

--- a/workers/raindrop-sync/src/collections.ts
+++ b/workers/raindrop-sync/src/collections.ts
@@ -2,6 +2,7 @@ import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
 import * as Builder from "@notionhq/workers/builder"
 import * as Schema from "@notionhq/workers/schema"
 
+import { boundedText, textWasTruncated } from "./format.js"
 import { collectionKey } from "./keys.js"
 import type { RaindropCollection } from "./raindrop.js"
 
@@ -20,13 +21,15 @@ export const collectionSchema = {
 
     Bookmarks: Schema.number(),
 
+    Updated: Schema.date(),
+
+    "Last Seen": Schema.date(),
+
     Public: Schema.checkbox(),
 
     Created: Schema.date(),
 
-    Updated: Schema.date(),
-
-    "Last Seen": Schema.date(),
+    Truncated: Schema.checkbox(),
 
     "Collection ID": Schema.richText(),
 
@@ -42,11 +45,12 @@ export function collectionToChange(
   observedAt: string
 ): SyncChangeUpsert<typeof PRIMARY_KEY, typeof collectionSchema.properties> {
   const key = collectionKey(accountId, collection._id)
+  const sourceTitle = collection.title.trim() || "Untitled collection"
   return {
     type: "upsert",
     key,
     properties: {
-      Name: Builder.title(collection.title),
+      Name: Builder.title(boundedText(sourceTitle)),
       Parent:
         collection.parentId === undefined
           ? []
@@ -61,6 +65,7 @@ export function collectionToChange(
         ? Builder.dateTime(collection.lastUpdate, "UTC")
         : [],
       "Last Seen": Builder.dateTime(observedAt, "UTC"),
+      Truncated: Builder.checkbox(textWasTruncated(sourceTitle)),
       "Collection ID": Builder.richText(String(collection._id)),
       "Raindrop Account ID": Builder.richText(String(accountId)),
       "Collection Key": Builder.richText(key),

--- a/workers/raindrop-sync/src/collections.ts
+++ b/workers/raindrop-sync/src/collections.ts
@@ -26,6 +26,8 @@ export const collectionSchema = {
 
     Updated: Schema.date(),
 
+    "Last Seen": Schema.date(),
+
     "Collection ID": Schema.richText(),
 
     "Raindrop Account ID": Schema.richText(),
@@ -36,7 +38,8 @@ export const collectionSchema = {
 
 export function collectionToChange(
   accountId: number,
-  collection: RaindropCollection
+  collection: RaindropCollection,
+  observedAt: string
 ): SyncChangeUpsert<typeof PRIMARY_KEY, typeof collectionSchema.properties> {
   const key = collectionKey(accountId, collection._id)
   return {
@@ -57,6 +60,7 @@ export function collectionToChange(
       Updated: collection.lastUpdate
         ? Builder.dateTime(collection.lastUpdate, "UTC")
         : [],
+      "Last Seen": Builder.dateTime(observedAt, "UTC"),
       "Collection ID": Builder.richText(String(collection._id)),
       "Raindrop Account ID": Builder.richText(String(accountId)),
       "Collection Key": Builder.richText(key),

--- a/workers/raindrop-sync/src/collections.ts
+++ b/workers/raindrop-sync/src/collections.ts
@@ -1,0 +1,65 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import { collectionKey } from "./keys.js"
+import type { RaindropCollection } from "./raindrop.js"
+
+export const INITIAL_TITLE = "Raindrop.io Collections"
+export const PRIMARY_KEY = "Collection Key"
+
+export const collectionSchema = {
+  databaseIcon: notionIcon("folder"),
+  properties: {
+    Name: Schema.title(),
+
+    Parent: Schema.relation("collections", {
+      twoWay: true,
+      relatedPropertyName: "Subcollections",
+    }),
+
+    Bookmarks: Schema.number(),
+
+    Public: Schema.checkbox(),
+
+    Created: Schema.date(),
+
+    Updated: Schema.date(),
+
+    "Collection ID": Schema.richText(),
+
+    "Raindrop Account ID": Schema.richText(),
+
+    "Collection Key": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+export function collectionToChange(
+  accountId: number,
+  collection: RaindropCollection
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof collectionSchema.properties> {
+  const key = collectionKey(accountId, collection._id)
+  return {
+    type: "upsert",
+    key,
+    properties: {
+      Name: Builder.title(collection.title),
+      Parent:
+        collection.parentId === undefined
+          ? []
+          : [Builder.relation(collectionKey(accountId, collection.parentId))],
+      Bookmarks:
+        collection.count === undefined ? [] : Builder.number(collection.count),
+      Public: Builder.checkbox(collection.public),
+      Created: collection.created
+        ? Builder.dateTime(collection.created, "UTC")
+        : [],
+      Updated: collection.lastUpdate
+        ? Builder.dateTime(collection.lastUpdate, "UTC")
+        : [],
+      "Collection ID": Builder.richText(String(collection._id)),
+      "Raindrop Account ID": Builder.richText(String(accountId)),
+      "Collection Key": Builder.richText(key),
+    },
+  }
+}

--- a/workers/raindrop-sync/src/format.ts
+++ b/workers/raindrop-sync/src/format.ts
@@ -3,15 +3,40 @@ import { createHash } from "node:crypto"
 export const NOTION_TEXT_LIMIT = 2_000
 export const NOTION_OPTION_LIMIT = 100
 export const NOTION_MULTI_SELECT_LIMIT = 100
+export const TAG_OVERFLOW_SENTINEL = "⚠ More tags omitted"
+
+function fitsWithinLimit(value: string, limit: number): boolean {
+  return value.length <= limit && Array.from(value).length <= limit
+}
+
+function withBoundedSuffix(
+  value: string,
+  limit: number,
+  suffix: string
+): string {
+  const suffixCharacters = Array.from(suffix).length
+  let prefix = ""
+  let prefixCharacters = 0
+  for (const character of value) {
+    if (
+      prefix.length + character.length + suffix.length > limit ||
+      prefixCharacters + 1 + suffixCharacters > limit
+    ) {
+      break
+    }
+    prefix += character
+    prefixCharacters += 1
+  }
+  return `${prefix}${suffix}`
+}
 
 export function boundedText(value: string): string {
-  const characters = Array.from(value)
-  if (characters.length <= NOTION_TEXT_LIMIT) return value
-  return `${characters.slice(0, NOTION_TEXT_LIMIT - 1).join("")}…`
+  if (fitsWithinLimit(value, NOTION_TEXT_LIMIT)) return value
+  return withBoundedSuffix(value, NOTION_TEXT_LIMIT, "…")
 }
 
 export function textWasTruncated(value: string): boolean {
-  return Array.from(value).length > NOTION_TEXT_LIMIT
+  return !fitsWithinLimit(value, NOTION_TEXT_LIMIT)
 }
 
 export function displayLabel(value: string): string {
@@ -29,7 +54,7 @@ export function highlightTitle(text: string, fallback: string): string {
   return `${characters.slice(0, 119).join("")}…`
 }
 
-export function optionNames(property: string, values: string[]): string[] {
+export function optionNames(values: string[]): string[] {
   const candidatesBySource = new Map<
     string,
     { baseName: string; sourceIdentity: string }
@@ -83,12 +108,15 @@ export function optionNames(property: string, values: string[]): string[] {
     }
   }
 
-  if (result.length > NOTION_MULTI_SELECT_LIMIT) {
-    throw new Error(
-      `Raindrop.io ${property} produced ${result.length} values; this Worker supports at most ${NOTION_MULTI_SELECT_LIMIT}.`
+  const sorted = result.sort(compareOptionNames)
+  if (sorted.length <= NOTION_MULTI_SELECT_LIMIT) return sorted
+
+  const retained = sorted
+    .filter(
+      (name) => optionIdentity(name) !== optionIdentity(TAG_OVERFLOW_SENTINEL)
     )
-  }
-  return result.sort(compareOptionNames)
+    .slice(0, NOTION_MULTI_SELECT_LIMIT - 1)
+  return [...retained, TAG_OVERFLOW_SENTINEL].sort(compareOptionNames)
 }
 
 function compareOptionNames(left: string, right: string): number {
@@ -121,8 +149,7 @@ function optionNameWithIdentitySuffix(
       ? digest.slice(0, 12)
       : `${digest.slice(0, 12)}-${attempt + 1}`
   const suffix = ` … ${discriminator}`
-  const prefixLength = NOTION_OPTION_LIMIT - Array.from(suffix).length
-  return `${Array.from(baseName).slice(0, prefixLength).join("")}${suffix}`
+  return withBoundedSuffix(baseName, NOTION_OPTION_LIMIT, suffix)
 }
 
 function optionName(value: string): string | undefined {
@@ -134,14 +161,12 @@ function optionName(value: string): string | undefined {
     .replace(/,/gu, "，")
   if (!normalized) return undefined
 
-  const characters = Array.from(normalized)
-  if (characters.length <= NOTION_OPTION_LIMIT) return normalized
+  if (fitsWithinLimit(normalized, NOTION_OPTION_LIMIT)) return normalized
 
   const digest = createHash("sha256")
     .update(normalized)
     .digest("hex")
     .slice(0, 8)
   const suffix = `… ${digest}`
-  const prefixLength = NOTION_OPTION_LIMIT - Array.from(suffix).length
-  return `${characters.slice(0, prefixLength).join("")}${suffix}`
+  return withBoundedSuffix(normalized, NOTION_OPTION_LIMIT, suffix)
 }

--- a/workers/raindrop-sync/src/format.ts
+++ b/workers/raindrop-sync/src/format.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto"
+
+export const NOTION_TEXT_LIMIT = 2_000
+export const NOTION_OPTION_LIMIT = 100
+export const NOTION_MULTI_SELECT_LIMIT = 100
+
+export function boundedText(value: string): string {
+  const characters = Array.from(value)
+  if (characters.length <= NOTION_TEXT_LIMIT) return value
+  return `${characters.slice(0, NOTION_TEXT_LIMIT - 1).join("")}…`
+}
+
+export function textWasTruncated(value: string): boolean {
+  return Array.from(value).length > NOTION_TEXT_LIMIT
+}
+
+export function displayLabel(value: string): string {
+  if (!value) return value
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+export function highlightTitle(text: string, fallback: string): string {
+  const singleLine = text.replace(/\s+/g, " ").trim() || fallback.trim()
+  if (!singleLine) return "Untitled highlight"
+  const characters = Array.from(singleLine)
+  if (characters.length <= 120) return singleLine
+  return `${characters.slice(0, 119).join("")}…`
+}
+
+export function optionNames(property: string, values: string[]): string[] {
+  const names = values
+    .map((value) => optionName(value))
+    .filter((value): value is string => value !== undefined)
+    .sort(
+      (left, right) =>
+        left.localeCompare(right, "en-US", { sensitivity: "base" }) ||
+        (left < right ? -1 : left > right ? 1 : 0)
+    )
+  const unique = new Map<string, string>()
+  for (const name of names) {
+    const identity = name.toLocaleLowerCase("en-US")
+    if (!unique.has(identity)) unique.set(identity, name)
+  }
+
+  const result = [...unique.values()]
+  if (result.length > NOTION_MULTI_SELECT_LIMIT) {
+    throw new Error(
+      `Raindrop.io ${property} produced ${result.length} values; this Worker supports at most ${NOTION_MULTI_SELECT_LIMIT}.`
+    )
+  }
+  return result
+}
+
+function optionName(value: string): string | undefined {
+  const normalized = value
+    .normalize("NFKC")
+    .trim()
+    .replace(/\s+/gu, " ")
+    // The current Worker builder serializes multi-select options with commas.
+    .replace(/,/gu, "，")
+  if (!normalized) return undefined
+
+  const characters = Array.from(normalized)
+  if (characters.length <= NOTION_OPTION_LIMIT) return normalized
+
+  const digest = createHash("sha256")
+    .update(normalized)
+    .digest("hex")
+    .slice(0, 8)
+  const suffix = `… ${digest}`
+  const prefixLength = NOTION_OPTION_LIMIT - Array.from(suffix).length
+  return `${characters.slice(0, prefixLength).join("")}${suffix}`
+}

--- a/workers/raindrop-sync/src/format.ts
+++ b/workers/raindrop-sync/src/format.ts
@@ -30,27 +30,99 @@ export function highlightTitle(text: string, fallback: string): string {
 }
 
 export function optionNames(property: string, values: string[]): string[] {
-  const names = values
-    .map((value) => optionName(value))
-    .filter((value): value is string => value !== undefined)
-    .sort(
-      (left, right) =>
-        left.localeCompare(right, "en-US", { sensitivity: "base" }) ||
-        (left < right ? -1 : left > right ? 1 : 0)
-    )
-  const unique = new Map<string, string>()
-  for (const name of names) {
-    const identity = name.toLocaleLowerCase("en-US")
-    if (!unique.has(identity)) unique.set(identity, name)
+  const candidatesBySource = new Map<
+    string,
+    { baseName: string; sourceIdentity: string }
+  >()
+  for (const value of values) {
+    const baseName = optionName(value)
+    if (!baseName) continue
+
+    const sourceIdentity = sourceOptionIdentity(value)
+    const existing = candidatesBySource.get(sourceIdentity)
+    if (!existing || compareOptionNames(baseName, existing.baseName) < 0) {
+      candidatesBySource.set(sourceIdentity, { baseName, sourceIdentity })
+    }
   }
 
-  const result = [...unique.values()]
+  const candidates = [...candidatesBySource.values()].sort(
+    (left, right) =>
+      compareOptionNames(left.baseName, right.baseName) ||
+      compareOptionNames(left.sourceIdentity, right.sourceIdentity)
+  )
+  const candidatesByOption = new Map<
+    string,
+    Array<(typeof candidates)[number]>
+  >()
+  for (const candidate of candidates) {
+    const identity = optionIdentity(candidate.baseName)
+    const group = candidatesByOption.get(identity)
+    if (group) group.push(candidate)
+    else candidatesByOption.set(identity, [candidate])
+  }
+
+  // Reserve every natural option name before disambiguating collisions so a
+  // generated suffix can never take the name of another source tag.
+  const usedOptionIdentities = new Set(candidatesByOption.keys())
+  const result: string[] = []
+  for (const group of candidatesByOption.values()) {
+    result.push(group[0].baseName)
+    for (const candidate of group.slice(1)) {
+      let attempt = 0
+      let name: string
+      do {
+        name = optionNameWithIdentitySuffix(
+          candidate.baseName,
+          candidate.sourceIdentity,
+          attempt
+        )
+        attempt += 1
+      } while (usedOptionIdentities.has(optionIdentity(name)))
+      usedOptionIdentities.add(optionIdentity(name))
+      result.push(name)
+    }
+  }
+
   if (result.length > NOTION_MULTI_SELECT_LIMIT) {
     throw new Error(
       `Raindrop.io ${property} produced ${result.length} values; this Worker supports at most ${NOTION_MULTI_SELECT_LIMIT}.`
     )
   }
-  return result
+  return result.sort(compareOptionNames)
+}
+
+function compareOptionNames(left: string, right: string): number {
+  return (
+    left.localeCompare(right, "en-US", { sensitivity: "base" }) ||
+    (left < right ? -1 : left > right ? 1 : 0)
+  )
+}
+
+function sourceOptionIdentity(value: string): string {
+  return value
+    .normalize("NFC")
+    .trim()
+    .replace(/\s+/gu, " ")
+    .toLocaleLowerCase("en-US")
+}
+
+function optionIdentity(value: string): string {
+  return value.toLocaleLowerCase("en-US")
+}
+
+function optionNameWithIdentitySuffix(
+  baseName: string,
+  sourceIdentity: string,
+  attempt: number
+): string {
+  const digest = createHash("sha256").update(sourceIdentity).digest("hex")
+  const discriminator =
+    attempt === 0
+      ? digest.slice(0, 12)
+      : `${digest.slice(0, 12)}-${attempt + 1}`
+  const suffix = ` … ${discriminator}`
+  const prefixLength = NOTION_OPTION_LIMIT - Array.from(suffix).length
+  return `${Array.from(baseName).slice(0, prefixLength).join("")}${suffix}`
 }
 
 function optionName(value: string): string | undefined {

--- a/workers/raindrop-sync/src/highlights.ts
+++ b/workers/raindrop-sync/src/highlights.ts
@@ -22,7 +22,7 @@ export const highlightSchema = {
 
     Bookmark: Schema.relation("bookmarks", {
       twoWay: true,
-      relatedPropertyName: "Synced Highlights",
+      relatedPropertyName: "Highlights",
     }),
 
     Text: Schema.richText(),

--- a/workers/raindrop-sync/src/highlights.ts
+++ b/workers/raindrop-sync/src/highlights.ts
@@ -1,0 +1,96 @@
+import { notionIcon, type SyncChangeUpsert } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+import {
+  boundedText,
+  displayLabel,
+  highlightTitle,
+  optionNames,
+  textWasTruncated,
+} from "./format.js"
+import { bookmarkKey, highlightKey } from "./keys.js"
+import type { RaindropHighlight } from "./raindrop.js"
+
+export const INITIAL_TITLE = "Raindrop.io Highlights"
+export const PRIMARY_KEY = "Highlight Key"
+
+export const highlightSchema = {
+  databaseIcon: notionIcon("book"),
+  properties: {
+    Highlight: Schema.title(),
+
+    Text: Schema.richText(),
+
+    Note: Schema.richText(),
+
+    Bookmark: Schema.relation("bookmarks", {
+      twoWay: true,
+      relatedPropertyName: "Synced Highlights",
+    }),
+
+    "Bookmark title": Schema.richText(),
+
+    URL: Schema.url(),
+
+    Color: Schema.select([
+      { name: "Blue" },
+      { name: "Brown" },
+      { name: "Cyan" },
+      { name: "Gray" },
+      { name: "Green" },
+      { name: "Indigo" },
+      { name: "Orange" },
+      { name: "Pink" },
+      { name: "Purple" },
+      { name: "Red" },
+      { name: "Teal" },
+      { name: "Yellow" },
+    ]),
+
+    Tags: Schema.multiSelect([]),
+
+    Truncated: Schema.checkbox(),
+
+    Created: Schema.date(),
+
+    "Highlight ID": Schema.richText(),
+
+    "Raindrop Account ID": Schema.richText(),
+
+    "Highlight Key": Schema.richText(),
+  },
+} satisfies Schema.Schema<typeof PRIMARY_KEY>
+
+export function highlightToChange(
+  accountId: number,
+  highlight: RaindropHighlight
+): SyncChangeUpsert<typeof PRIMARY_KEY, typeof highlightSchema.properties> {
+  const tags = optionNames("highlight tags", highlight.tags)
+  const key = highlightKey(accountId, highlight._id)
+  return {
+    type: "upsert",
+    key,
+    properties: {
+      Highlight: Builder.title(highlightTitle(highlight.text, highlight.title)),
+      Text: Builder.richText(boundedText(highlight.text)),
+      Note: highlight.note ? Builder.richText(boundedText(highlight.note)) : [],
+      Bookmark: [
+        Builder.relation(bookmarkKey(accountId, highlight.raindropRef)),
+      ],
+      "Bookmark title": highlight.title
+        ? Builder.richText(boundedText(highlight.title))
+        : [],
+      URL: Builder.url(highlight.link),
+      Color: Builder.select(displayLabel(highlight.color)),
+      Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
+      Truncated: Builder.checkbox(
+        textWasTruncated(highlight.text) || textWasTruncated(highlight.note)
+      ),
+      Created: Builder.dateTime(highlight.created, "UTC"),
+      "Highlight ID": Builder.richText(highlight._id),
+      "Raindrop Account ID": Builder.richText(String(accountId)),
+      "Highlight Key": Builder.richText(key),
+    },
+  }
+}

--- a/workers/raindrop-sync/src/highlights.ts
+++ b/workers/raindrop-sync/src/highlights.ts
@@ -33,6 +33,8 @@ export const highlightSchema = {
 
     URL: Schema.url(),
 
+    "URL Omitted": Schema.checkbox(),
+
     Color: Schema.select([
       { name: "Blue" },
       { name: "Brown" },
@@ -54,6 +56,8 @@ export const highlightSchema = {
 
     Created: Schema.date(),
 
+    "Last Seen": Schema.date(),
+
     "Highlight ID": Schema.richText(),
 
     "Raindrop Account ID": Schema.richText(),
@@ -64,7 +68,8 @@ export const highlightSchema = {
 
 export function highlightToChange(
   accountId: number,
-  highlight: RaindropHighlight
+  highlight: RaindropHighlight,
+  observedAt: string
 ): SyncChangeUpsert<typeof PRIMARY_KEY, typeof highlightSchema.properties> {
   const tags = optionNames("highlight tags", highlight.tags)
   const key = highlightKey(accountId, highlight._id)
@@ -81,13 +86,15 @@ export function highlightToChange(
       "Bookmark title": highlight.title
         ? Builder.richText(boundedText(highlight.title))
         : [],
-      URL: Builder.url(highlight.link),
+      URL: highlight.link ? Builder.url(highlight.link) : [],
+      "URL Omitted": Builder.checkbox(highlight.linkOmitted),
       Color: Builder.select(displayLabel(highlight.color)),
       Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
       Truncated: Builder.checkbox(
         textWasTruncated(highlight.text) || textWasTruncated(highlight.note)
       ),
       Created: Builder.dateTime(highlight.created, "UTC"),
+      "Last Seen": Builder.dateTime(observedAt, "UTC"),
       "Highlight ID": Builder.richText(highlight._id),
       "Raindrop Account ID": Builder.richText(String(accountId)),
       "Highlight Key": Builder.richText(key),

--- a/workers/raindrop-sync/src/highlights.ts
+++ b/workers/raindrop-sync/src/highlights.ts
@@ -20,20 +20,18 @@ export const highlightSchema = {
   properties: {
     Highlight: Schema.title(),
 
-    Text: Schema.richText(),
-
-    Note: Schema.richText(),
-
     Bookmark: Schema.relation("bookmarks", {
       twoWay: true,
       relatedPropertyName: "Synced Highlights",
     }),
 
-    "Bookmark title": Schema.richText(),
+    Text: Schema.richText(),
 
-    URL: Schema.url(),
+    Note: Schema.richText(),
 
-    "URL Omitted": Schema.checkbox(),
+    Tags: Schema.multiSelect([]),
+
+    Created: Schema.date(),
 
     Color: Schema.select([
       { name: "Blue" },
@@ -50,13 +48,15 @@ export const highlightSchema = {
       { name: "Yellow" },
     ]),
 
-    Tags: Schema.multiSelect([]),
+    URL: Schema.url(),
+
+    "Bookmark title": Schema.richText(),
+
+    "Last Seen": Schema.date(),
 
     Truncated: Schema.checkbox(),
 
-    Created: Schema.date(),
-
-    "Last Seen": Schema.date(),
+    "URL Omitted": Schema.checkbox(),
 
     "Highlight ID": Schema.richText(),
 
@@ -71,7 +71,7 @@ export function highlightToChange(
   highlight: RaindropHighlight,
   observedAt: string
 ): SyncChangeUpsert<typeof PRIMARY_KEY, typeof highlightSchema.properties> {
-  const tags = optionNames("highlight tags", highlight.tags)
+  const tags = optionNames(highlight.tags)
   const key = highlightKey(accountId, highlight._id)
   return {
     type: "upsert",
@@ -91,7 +91,9 @@ export function highlightToChange(
       Color: Builder.select(displayLabel(highlight.color)),
       Tags: tags.length > 0 ? Builder.multiSelect(...tags) : [],
       Truncated: Builder.checkbox(
-        textWasTruncated(highlight.text) || textWasTruncated(highlight.note)
+        textWasTruncated(highlight.text) ||
+          textWasTruncated(highlight.note) ||
+          textWasTruncated(highlight.title)
       ),
       Created: Builder.dateTime(highlight.created, "UTC"),
       "Last Seen": Builder.dateTime(observedAt, "UTC"),

--- a/workers/raindrop-sync/src/index.ts
+++ b/workers/raindrop-sync/src/index.ts
@@ -1,0 +1,124 @@
+// Raindrop.io reading library — collections, bookmarks, and highlights in
+// three connected managed Notion databases. The public Raindrop.io API does
+// not expose reliable deletion tombstones, so hourly full scans only upsert
+// observed records and preserve last-known rows that disappear upstream.
+
+import { Worker } from "@notionhq/workers"
+
+import {
+  INITIAL_TITLE as BOOKMARKS_TITLE,
+  PRIMARY_KEY as BOOKMARKS_PRIMARY_KEY,
+  bookmarkSchema,
+  bookmarkToChange,
+} from "./bookmarks.js"
+import {
+  INITIAL_TITLE as COLLECTIONS_TITLE,
+  PRIMARY_KEY as COLLECTIONS_PRIMARY_KEY,
+  collectionSchema,
+  collectionToChange,
+} from "./collections.js"
+import {
+  INITIAL_TITLE as HIGHLIGHTS_TITLE,
+  PRIMARY_KEY as HIGHLIGHTS_PRIMARY_KEY,
+  highlightSchema,
+  highlightToChange,
+} from "./highlights.js"
+import { createRaindropClient } from "./raindrop.js"
+import {
+  bookmarkPageResult,
+  currentBookmarkPosition,
+  currentPage,
+  pageResult,
+  type BookmarkSyncState,
+  type PageSyncState,
+} from "./sync-state.js"
+
+const worker = new Worker()
+
+// Raindrop.io permits 120 authenticated requests per minute. All three syncs
+// share a conservative budget so scheduled runs leave room for normal use.
+const pacer = worker.pacer("raindrop", {
+  allowedRequests: 100,
+  intervalMs: 60_000,
+})
+
+const client = createRaindropClient({
+  beforeRequest: () => pacer.wait(),
+})
+
+const collections = worker.database("collections", {
+  type: "managed",
+  initialTitle: COLLECTIONS_TITLE,
+  primaryKeyProperty: COLLECTIONS_PRIMARY_KEY,
+  schema: collectionSchema,
+})
+
+const bookmarks = worker.database("bookmarks", {
+  type: "managed",
+  initialTitle: BOOKMARKS_TITLE,
+  primaryKeyProperty: BOOKMARKS_PRIMARY_KEY,
+  schema: bookmarkSchema,
+})
+
+const highlights = worker.database("highlights", {
+  type: "managed",
+  initialTitle: HIGHLIGHTS_TITLE,
+  primaryKeyProperty: HIGHLIGHTS_PRIMARY_KEY,
+  schema: highlightSchema,
+})
+
+// Register relation targets first. For the initial import, trigger these in
+// the same order so Collections and Bookmarks exist before their dependants.
+worker.sync("collectionsSync", {
+  database: collections,
+  mode: "incremental",
+  schedule: "1h",
+  execute: async () => {
+    const session = await client.authenticate()
+    const items = await session.fetchCollections()
+    return {
+      changes: items.map((item) => collectionToChange(session.accountId, item)),
+      hasMore: false,
+    }
+  },
+})
+
+worker.sync("bookmarksSync", {
+  database: bookmarks,
+  mode: "incremental",
+  schedule: "1h",
+  execute: async (state: BookmarkSyncState | undefined) => {
+    const session = await client.authenticate()
+    const { phase, page } = currentBookmarkPosition(state, session.accountId)
+    const result = await session.fetchBookmarksPage(phase, page)
+    return bookmarkPageResult(
+      state,
+      session.accountId,
+      phase,
+      result.items,
+      result.items.map((item) =>
+        bookmarkToChange(session.accountId, item, phase === "trash")
+      )
+    )
+  },
+})
+
+worker.sync("highlightsSync", {
+  database: highlights,
+  mode: "incremental",
+  schedule: "1h",
+  execute: async (state: PageSyncState | undefined) => {
+    const session = await client.authenticate()
+    const page = currentPage(state, session.accountId, "highlights")
+    const result = await session.fetchHighlightsPage(page)
+    return pageResult(
+      state,
+      session.accountId,
+      result.items,
+      result.items.map((item) => highlightToChange(session.accountId, item)),
+      "highlights"
+    )
+  },
+})
+
+export default worker

--- a/workers/raindrop-sync/src/index.ts
+++ b/workers/raindrop-sync/src/index.ts
@@ -25,10 +25,12 @@ import {
 } from "./highlights.js"
 import { createRaindropClient } from "./raindrop.js"
 import {
+  accountState,
   bookmarkPageResult,
   currentBookmarkPosition,
   currentPage,
   pageResult,
+  type AccountSyncState,
   type BookmarkSyncState,
   type PageSyncState,
 } from "./sync-state.js"
@@ -73,8 +75,9 @@ worker.sync("collectionsSync", {
   database: collections,
   mode: "incremental",
   schedule: "1h",
-  execute: async () => {
+  execute: async (state: AccountSyncState | undefined) => {
     const session = await client.authenticate()
+    const nextState = accountState(state, session.accountId, "collections")
     const items = await session.fetchCollections()
     const observedAt = new Date().toISOString()
     return {
@@ -82,6 +85,7 @@ worker.sync("collectionsSync", {
         collectionToChange(session.accountId, item, observedAt)
       ),
       hasMore: false,
+      nextState,
     }
   },
 })

--- a/workers/raindrop-sync/src/index.ts
+++ b/workers/raindrop-sync/src/index.ts
@@ -1,7 +1,7 @@
-// Raindrop.io reading library — collections, bookmarks, and highlights in
-// three connected managed Notion databases. The public Raindrop.io API does
-// not expose reliable deletion tombstones, so hourly full scans only upsert
-// observed records and preserve last-known rows that disappear upstream.
+// Raindrop.io research library — collections, bookmarks, and highlights in
+// three connected managed Notion databases. The available list endpoints do
+// not expose deletion tombstones, so scheduled scans only upsert observed
+// records and preserve last-known rows that disappear upstream.
 
 import { Worker } from "@notionhq/workers"
 
@@ -23,7 +23,7 @@ import {
   highlightSchema,
   highlightToChange,
 } from "./highlights.js"
-import { createRaindropClient } from "./raindrop.js"
+import { PAGE_SIZE, createRaindropClient } from "./raindrop.js"
 import {
   accountState,
   bookmarkPageResult,
@@ -97,16 +97,23 @@ worker.sync("bookmarksSync", {
   execute: async (state: BookmarkSyncState | undefined) => {
     const session = await client.authenticate()
     const { phase, page } = currentBookmarkPosition(state, session.accountId)
-    const result = await session.fetchBookmarksPage(phase, page)
+    const result = await session.fetchBookmarksBatch(phase, page)
+    const complete = result.pages.at(-1)!.length < PAGE_SIZE
+    const terminalFirstPageIds = complete
+      ? (await session.fetchBookmarksPage(phase, 0)).items.map((item) =>
+          String(item._id)
+        )
+      : undefined
     const observedAt = new Date().toISOString()
     return bookmarkPageResult(
       state,
       session.accountId,
       phase,
-      result.items,
+      result.pages.map((items) => items.map((item) => String(item._id))),
       result.items.map((item) =>
         bookmarkToChange(session.accountId, item, phase === "trash", observedAt)
-      )
+      ),
+      terminalFirstPageIds
     )
   },
 })
@@ -118,16 +125,21 @@ worker.sync("highlightsSync", {
   execute: async (state: PageSyncState | undefined) => {
     const session = await client.authenticate()
     const page = currentPage(state, session.accountId, "highlights")
-    const result = await session.fetchHighlightsPage(page)
+    const result = await session.fetchHighlightsBatch(page)
+    const complete = result.pages.at(-1)!.length < PAGE_SIZE
+    const terminalFirstPageIds = complete
+      ? (await session.fetchHighlightsPage(0)).items.map((item) => item._id)
+      : undefined
     const observedAt = new Date().toISOString()
     return pageResult(
       state,
       session.accountId,
-      result.items,
+      result.pages.map((items) => items.map((item) => item._id)),
       result.items.map((item) =>
         highlightToChange(session.accountId, item, observedAt)
       ),
-      "highlights"
+      "highlights",
+      terminalFirstPageIds
     )
   },
 })

--- a/workers/raindrop-sync/src/index.ts
+++ b/workers/raindrop-sync/src/index.ts
@@ -76,8 +76,11 @@ worker.sync("collectionsSync", {
   execute: async () => {
     const session = await client.authenticate()
     const items = await session.fetchCollections()
+    const observedAt = new Date().toISOString()
     return {
-      changes: items.map((item) => collectionToChange(session.accountId, item)),
+      changes: items.map((item) =>
+        collectionToChange(session.accountId, item, observedAt)
+      ),
       hasMore: false,
     }
   },
@@ -91,13 +94,14 @@ worker.sync("bookmarksSync", {
     const session = await client.authenticate()
     const { phase, page } = currentBookmarkPosition(state, session.accountId)
     const result = await session.fetchBookmarksPage(phase, page)
+    const observedAt = new Date().toISOString()
     return bookmarkPageResult(
       state,
       session.accountId,
       phase,
       result.items,
       result.items.map((item) =>
-        bookmarkToChange(session.accountId, item, phase === "trash")
+        bookmarkToChange(session.accountId, item, phase === "trash", observedAt)
       )
     )
   },
@@ -111,11 +115,14 @@ worker.sync("highlightsSync", {
     const session = await client.authenticate()
     const page = currentPage(state, session.accountId, "highlights")
     const result = await session.fetchHighlightsPage(page)
+    const observedAt = new Date().toISOString()
     return pageResult(
       state,
       session.accountId,
       result.items,
-      result.items.map((item) => highlightToChange(session.accountId, item)),
+      result.items.map((item) =>
+        highlightToChange(session.accountId, item, observedAt)
+      ),
       "highlights"
     )
   },

--- a/workers/raindrop-sync/src/keys.ts
+++ b/workers/raindrop-sync/src/keys.ts
@@ -1,0 +1,21 @@
+export type RaindropResource = "collection" | "bookmark" | "highlight"
+
+function namespacedKey(
+  accountId: number,
+  resource: RaindropResource,
+  providerId: number | string
+): string {
+  return `raindrop:${accountId}:${resource}:${providerId}`
+}
+
+export function collectionKey(accountId: number, collectionId: number): string {
+  return namespacedKey(accountId, "collection", collectionId)
+}
+
+export function bookmarkKey(accountId: number, bookmarkId: number): string {
+  return namespacedKey(accountId, "bookmark", bookmarkId)
+}
+
+export function highlightKey(accountId: number, highlightId: string): string {
+  return namespacedKey(accountId, "highlight", highlightId)
+}

--- a/workers/raindrop-sync/src/raindrop.ts
+++ b/workers/raindrop-sync/src/raindrop.ts
@@ -70,6 +70,7 @@ export type RaindropHighlightColor =
   | "yellow"
 
 export type BookmarkScope = "active" | "trash"
+type CollectionScope = "root" | "child"
 
 export type RaindropCollection = {
   _id: number
@@ -174,11 +175,12 @@ export function createRaindropClient(
   async function fetchCollectionList(
     path: string,
     label: string,
+    scope: CollectionScope,
     accessToken: string
   ): Promise<RaindropCollection[]> {
     const payload = responseObject(await request(path, accessToken), label)
     return responseItems(payload, label).map((item, index) =>
-      parseCollection(item, `${label}.items[${index}]`)
+      parseCollection(item, `${label}.items[${index}]`, scope)
     )
   }
 
@@ -203,11 +205,13 @@ export function createRaindropClient(
           const root = await fetchCollectionList(
             "/rest/v1/collections",
             "root collections",
+            "root",
             accessToken
           )
           const children = await fetchCollectionList(
             "/rest/v1/collections/childrens",
             "child collections",
+            "child",
             accessToken
           )
           const collections: RaindropCollection[] = [
@@ -252,6 +256,7 @@ export function createRaindropClient(
           const items = responseItems(bookmarkPayload, "bookmarks").map(
             (item, index) => parseBookmark(item, `bookmarks.items[${index}]`)
           )
+          assertBookmarkScope(items, scope)
           assertPage(items, (item) => String(item._id), "bookmark")
           return { items }
         },
@@ -515,7 +520,7 @@ function parseBookmark(value: unknown, label: string): RaindropBookmark {
   const item = objectValue(value, label)
   const collection = objectValue(item.collection, `${label}.collection`)
   const link = notionUrlValue(item.link, `${label}.link`)
-  const highlights = item.highlights ?? []
+  const highlights = item.highlights
   if (!Array.isArray(highlights)) {
     throw new Error(`Raindrop.io ${label}.highlights must be an array.`)
   }
@@ -529,7 +534,7 @@ function parseBookmark(value: unknown, label: string): RaindropBookmark {
     excerpt: optionalString(item.excerpt, `${label}.excerpt`),
     note: optionalString(item.note, `${label}.note`),
     type: bookmarkType(item.type, `${label}.type`),
-    tags: stringArray(item.tags ?? [], `${label}.tags`),
+    tags: stringArray(item.tags, `${label}.tags`),
     collection: {
       $id: collectionIdValue(collection.$id, `${label}.collection.$id`),
     },
@@ -557,20 +562,29 @@ function parseHighlight(value: unknown, label: string): RaindropHighlight {
     title: optionalString(item.title, `${label}.title`),
     link: link.value,
     linkOmitted: link.omitted,
-    tags: stringArray(item.tags ?? [], `${label}.tags`),
+    tags: stringArray(item.tags, `${label}.tags`),
     created: dateTimeValue(item.created, `${label}.created`),
   }
 }
 
-function parseCollection(value: unknown, label: string): RaindropCollection {
+function parseCollection(
+  value: unknown,
+  label: string,
+  scope: CollectionScope
+): RaindropCollection {
   const item = objectValue(value, label)
   const parent = item.parent
   let parentId: number | undefined
-  if (parent !== undefined && parent !== null) {
+  if (scope === "child") {
+    if (parent === undefined || parent === null) {
+      throw new Error(`Raindrop.io ${label}.parent is required for a child.`)
+    }
     parentId = positiveInteger(
       objectValue(parent, `${label}.parent`).$id,
       `${label}.parent.$id`
     )
+  } else if (parent !== undefined && parent !== null) {
+    throw new Error(`Raindrop.io ${label}.parent must be absent for a root.`)
   }
 
   return {
@@ -581,6 +595,25 @@ function parseCollection(value: unknown, label: string): RaindropCollection {
     parentId,
     created: dateTimeValue(item.created, `${label}.created`),
     lastUpdate: dateTimeValue(item.lastUpdate, `${label}.lastUpdate`),
+  }
+}
+
+function assertBookmarkScope(
+  items: RaindropBookmark[],
+  scope: BookmarkScope
+): void {
+  for (const item of items) {
+    const collectionId = item.collection.$id
+    if (scope === "trash" && collectionId !== -99) {
+      throw new Error(
+        "Raindrop.io Trash response returned a bookmark outside Trash."
+      )
+    }
+    if (scope === "active" && collectionId === -99) {
+      throw new Error(
+        "Raindrop.io active response returned a bookmark from Trash."
+      )
+    }
   }
 }
 

--- a/workers/raindrop-sync/src/raindrop.ts
+++ b/workers/raindrop-sync/src/raindrop.ts
@@ -4,6 +4,7 @@ const API_BASE_URL = "https://api.raindrop.io"
 export const PAGE_SIZE = 50
 export const MAX_RESPONSE_BYTES = 10 * 1_024 * 1_024
 export const REQUEST_TIMEOUT_MS = 30_000
+export const NOTION_URL_LIMIT = 2_000
 const MAX_COLLECTIONS = 10_000
 
 export type BeforeRequest = () => Promise<void>
@@ -26,7 +27,8 @@ export type RaindropType =
 export type RaindropBookmark = {
   _id: number
   title: string
-  link: string
+  link: string | undefined
+  linkOmitted: boolean
   domain: string
   excerpt: string
   note: string
@@ -47,7 +49,8 @@ export type RaindropHighlight = {
   note: string
   color: RaindropHighlightColor
   title: string
-  link: string
+  link: string | undefined
+  linkOmitted: boolean
   tags: string[]
   created: string
 }
@@ -435,7 +438,12 @@ function dateTimeValue(value: unknown, label: string): string {
   return new Date(dateTime).toISOString()
 }
 
-function urlValue(value: unknown, label: string): string {
+type NotionUrlValue = {
+  value: string | undefined
+  omitted: boolean
+}
+
+function notionUrlValue(value: unknown, label: string): NotionUrlValue {
   const url = stringValue(value, label)
   let parsed: URL
   try {
@@ -446,7 +454,11 @@ function urlValue(value: unknown, label: string): string {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(`Raindrop.io ${label} must use HTTP or HTTPS.`)
   }
-  return url
+  const omitted = url.length > NOTION_URL_LIMIT
+  return {
+    value: omitted ? undefined : url,
+    omitted,
+  }
 }
 
 function stringArray(value: unknown, label: string): string[] {
@@ -502,6 +514,7 @@ function highlightColor(value: unknown, label: string): RaindropHighlightColor {
 function parseBookmark(value: unknown, label: string): RaindropBookmark {
   const item = objectValue(value, label)
   const collection = objectValue(item.collection, `${label}.collection`)
+  const link = notionUrlValue(item.link, `${label}.link`)
   const highlights = item.highlights ?? []
   if (!Array.isArray(highlights)) {
     throw new Error(`Raindrop.io ${label}.highlights must be an array.`)
@@ -510,7 +523,8 @@ function parseBookmark(value: unknown, label: string): RaindropBookmark {
   return {
     _id: positiveInteger(item._id, `${label}._id`),
     title: stringValue(item.title, `${label}.title`),
-    link: urlValue(item.link, `${label}.link`),
+    link: link.value,
+    linkOmitted: link.omitted,
     domain: optionalString(item.domain, `${label}.domain`),
     excerpt: optionalString(item.excerpt, `${label}.excerpt`),
     note: optionalString(item.note, `${label}.note`),
@@ -533,6 +547,7 @@ function parseHighlight(value: unknown, label: string): RaindropHighlight {
   if (!id) {
     throw new Error(`Raindrop.io ${label}._id must not be empty.`)
   }
+  const link = notionUrlValue(item.link, `${label}.link`)
   return {
     _id: id,
     raindropRef: positiveInteger(item.raindropRef, `${label}.raindropRef`),
@@ -540,7 +555,8 @@ function parseHighlight(value: unknown, label: string): RaindropHighlight {
     note: optionalString(item.note, `${label}.note`),
     color: highlightColor(item.color, `${label}.color`),
     title: optionalString(item.title, `${label}.title`),
-    link: urlValue(item.link, `${label}.link`),
+    link: link.value,
+    linkOmitted: link.omitted,
     tags: stringArray(item.tags ?? [], `${label}.tags`),
     created: dateTimeValue(item.created, `${label}.created`),
   }

--- a/workers/raindrop-sync/src/raindrop.ts
+++ b/workers/raindrop-sync/src/raindrop.ts
@@ -1,0 +1,586 @@
+import { RateLimitError } from "@notionhq/workers"
+
+const API_BASE_URL = "https://api.raindrop.io"
+export const PAGE_SIZE = 50
+export const MAX_RESPONSE_BYTES = 10 * 1_024 * 1_024
+export const REQUEST_TIMEOUT_MS = 30_000
+const MAX_COLLECTIONS = 10_000
+
+export type BeforeRequest = () => Promise<void>
+
+export type RaindropClientOptions = {
+  beforeRequest: BeforeRequest
+  fetchImpl?: typeof fetch
+  getAccessToken?: () => string
+  requestTimeoutMs?: number
+}
+
+export type RaindropType =
+  | "link"
+  | "article"
+  | "image"
+  | "video"
+  | "document"
+  | "audio"
+
+export type RaindropBookmark = {
+  _id: number
+  title: string
+  link: string
+  domain: string
+  excerpt: string
+  note: string
+  type: RaindropType
+  tags: string[]
+  collection: { $id: number }
+  important: boolean
+  broken: boolean
+  created: string
+  lastUpdate: string
+  highlights: unknown[]
+}
+
+export type RaindropHighlight = {
+  _id: string
+  raindropRef: number
+  text: string
+  note: string
+  color: RaindropHighlightColor
+  title: string
+  link: string
+  tags: string[]
+  created: string
+}
+
+export type RaindropHighlightColor =
+  | "blue"
+  | "brown"
+  | "cyan"
+  | "gray"
+  | "green"
+  | "indigo"
+  | "orange"
+  | "pink"
+  | "purple"
+  | "red"
+  | "teal"
+  | "yellow"
+
+export type BookmarkScope = "active" | "trash"
+
+export type RaindropCollection = {
+  _id: number
+  title: string
+  count?: number
+  public: boolean
+  parentId?: number
+  created?: string
+  lastUpdate?: string
+}
+
+export type RaindropPage<T> = {
+  items: T[]
+}
+
+export type RaindropSession = {
+  accountId: number
+  fetchCollections(): Promise<RaindropCollection[]>
+  fetchBookmarksPage(
+    scope: BookmarkScope,
+    page: number
+  ): Promise<RaindropPage<RaindropBookmark>>
+  fetchHighlightsPage(page: number): Promise<RaindropPage<RaindropHighlight>>
+}
+
+export type RaindropClient = {
+  authenticate(): Promise<RaindropSession>
+}
+
+export function createRaindropClient(
+  options: RaindropClientOptions
+): RaindropClient {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const getAccessToken = options.getAccessToken ?? requireAccessToken
+  const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
+  if (!Number.isSafeInteger(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error("Raindrop.io request timeout must be a positive integer.")
+  }
+
+  async function request(path: string, accessToken: string): Promise<unknown> {
+    await options.beforeRequest()
+    const signal = AbortSignal.timeout(requestTimeoutMs)
+    let response: Response
+    try {
+      response = await fetchImpl(new URL(path, API_BASE_URL), {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${accessToken}`,
+          "User-Agent": "notion-cookbook-raindrop-sync",
+        },
+        redirect: "error",
+        signal,
+      })
+    } catch {
+      if (signal.aborted) {
+        throw new Error(
+          `Raindrop.io API request timed out after ${requestTimeoutMs}ms.`
+        )
+      }
+      throw new Error(
+        "Raindrop.io API request failed before a response was received."
+      )
+    }
+
+    if (response.status === 429) {
+      const retryAfter = retryAfterSeconds(response.headers)
+      await cancelResponseBody(response)
+      throw new RateLimitError({
+        retryAfter,
+      })
+    }
+    if (response.status === 401 || response.status === 403) {
+      await cancelResponseBody(response)
+      throw new Error(
+        "Raindrop.io rejected RAINDROP_ACCESS_TOKEN. Create or replace the test token, then retry."
+      )
+    }
+    if (!response.ok) {
+      await cancelResponseBody(response)
+      throw new Error(`Raindrop.io API request failed (${response.status}).`)
+    }
+
+    let responseText: string
+    try {
+      responseText = await readBoundedResponseText(response)
+    } catch (error) {
+      if (signal.aborted) {
+        throw new Error(
+          `Raindrop.io API request timed out after ${requestTimeoutMs}ms.`
+        )
+      }
+      throw error
+    }
+    try {
+      return JSON.parse(responseText) as unknown
+    } catch {
+      throw new Error("Raindrop.io returned an invalid JSON response.")
+    }
+  }
+
+  async function fetchCollectionList(
+    path: string,
+    label: string,
+    accessToken: string
+  ): Promise<RaindropCollection[]> {
+    const payload = responseObject(await request(path, accessToken), label)
+    return responseItems(payload, label).map((item, index) =>
+      parseCollection(item, `${label}.items[${index}]`)
+    )
+  }
+
+  return {
+    async authenticate() {
+      const accessToken = getAccessToken().trim()
+      if (!accessToken) {
+        throw new Error("RAINDROP_ACCESS_TOKEN is not set.")
+      }
+
+      const payload = responseObject(
+        await request("/rest/v1/user", accessToken),
+        "user"
+      )
+      const user = objectValue(payload.user, "user.user")
+      const accountId = positiveInteger(user._id, "user.user._id")
+
+      return {
+        accountId,
+
+        async fetchCollections() {
+          const root = await fetchCollectionList(
+            "/rest/v1/collections",
+            "root collections",
+            accessToken
+          )
+          const children = await fetchCollectionList(
+            "/rest/v1/collections/childrens",
+            "child collections",
+            accessToken
+          )
+          const collections: RaindropCollection[] = [
+            {
+              _id: -1,
+              title: "Unsorted",
+              public: false,
+            },
+            {
+              _id: -99,
+              title: "Trash",
+              public: false,
+            },
+            ...root,
+            ...children,
+          ]
+          if (collections.length > MAX_COLLECTIONS) {
+            throw new Error(
+              `Raindrop.io returned more than ${MAX_COLLECTIONS} collections.`
+            )
+          }
+          assertUnique(
+            collections.map((collection) => String(collection._id)),
+            "collection ID"
+          )
+          return collections
+        },
+
+        async fetchBookmarksPage(scope, page) {
+          const collectionId = scope === "active" ? 0 : -99
+          const url = new URL(
+            `/rest/v1/raindrops/${collectionId}`,
+            API_BASE_URL
+          )
+          url.searchParams.set("sort", "created")
+          url.searchParams.set("perpage", String(PAGE_SIZE))
+          url.searchParams.set("page", String(page))
+          const bookmarkPayload = responseObject(
+            await request(`${url.pathname}${url.search}`, accessToken),
+            "bookmarks"
+          )
+          const items = responseItems(bookmarkPayload, "bookmarks").map(
+            (item, index) => parseBookmark(item, `bookmarks.items[${index}]`)
+          )
+          assertPage(items, (item) => String(item._id), "bookmark")
+          return { items }
+        },
+
+        async fetchHighlightsPage(page) {
+          const url = new URL("/rest/v1/highlights", API_BASE_URL)
+          url.searchParams.set("perpage", String(PAGE_SIZE))
+          url.searchParams.set("page", String(page))
+          const highlightPayload = responseObject(
+            await request(`${url.pathname}${url.search}`, accessToken),
+            "highlights"
+          )
+          const items = responseItems(highlightPayload, "highlights").map(
+            (item, index) => parseHighlight(item, `highlights.items[${index}]`)
+          )
+          assertPage(items, (item) => item._id, "highlight")
+          return { items }
+        },
+      }
+    },
+  }
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  if (!response.body) return
+  await response.body.cancel().catch(() => undefined)
+}
+
+async function readBoundedResponseText(response: Response): Promise<string> {
+  const contentLength = response.headers.get("Content-Length")?.trim()
+  if (
+    contentLength &&
+    /^\d+$/.test(contentLength) &&
+    Number(contentLength) > MAX_RESPONSE_BYTES
+  ) {
+    await cancelResponseBody(response)
+    throw new Error("Raindrop.io response exceeded the allowed size.")
+  }
+
+  if (!response.body) return ""
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const chunks: string[] = []
+  let bytesRead = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      bytesRead += value.byteLength
+      if (bytesRead > MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => undefined)
+        throw new Error("Raindrop.io response exceeded the allowed size.")
+      }
+      chunks.push(decoder.decode(value, { stream: true }))
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  chunks.push(decoder.decode())
+  return chunks.join("")
+}
+
+function requireAccessToken(): string {
+  const token = process.env.RAINDROP_ACCESS_TOKEN?.trim()
+  if (!token) {
+    throw new Error("RAINDROP_ACCESS_TOKEN is not set.")
+  }
+  return token
+}
+
+function retryAfterSeconds(headers: Headers): number {
+  const retryAfter = headers.get("Retry-After")
+  if (retryAfter) {
+    const seconds = Number(retryAfter)
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds)
+
+    const retryAt = Date.parse(retryAfter)
+    if (Number.isFinite(retryAt)) {
+      return Math.max(1, Math.ceil((retryAt - Date.now()) / 1_000))
+    }
+  }
+
+  const resetAt = Number(headers.get("X-RateLimit-Reset"))
+  if (Number.isFinite(resetAt) && resetAt > 0) {
+    return Math.max(1, Math.ceil(resetAt - Date.now() / 1_000))
+  }
+  return 60
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function responseObject(
+  value: unknown,
+  label: string
+): Record<string, unknown> {
+  const object = objectValue(value, label)
+  if (object.result !== true) {
+    throw new Error(`Raindrop.io ${label} response reported a failure.`)
+  }
+  return object
+}
+
+function responseItems(
+  value: Record<string, unknown>,
+  label: string
+): unknown[] {
+  if (!Array.isArray(value.items)) {
+    throw new Error(`Raindrop.io ${label} response is missing items.`)
+  }
+  return value.items
+}
+
+function objectValue(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Raindrop.io ${label} must be an object.`)
+  }
+  return value
+}
+
+function stringValue(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Raindrop.io ${label} must be a string.`)
+  }
+  return value
+}
+
+function optionalString(value: unknown, label: string): string {
+  if (value === undefined || value === null) return ""
+  return stringValue(value, label)
+}
+
+function integerValue(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`Raindrop.io ${label} must be an integer.`)
+  }
+  return Number(value)
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  const integer = integerValue(value, label)
+  if (integer < 0) {
+    throw new Error(`Raindrop.io ${label} must not be negative.`)
+  }
+  return integer
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  const integer = integerValue(value, label)
+  if (integer <= 0) {
+    throw new Error(`Raindrop.io ${label} must be positive.`)
+  }
+  return integer
+}
+
+function collectionIdValue(value: unknown, label: string): number {
+  const integer = integerValue(value, label)
+  if (integer !== -99 && integer !== -1 && integer <= 0) {
+    throw new Error(`Raindrop.io ${label} must be -99, -1, or positive.`)
+  }
+  return integer
+}
+
+function booleanValue(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`Raindrop.io ${label} must be a boolean.`)
+  }
+  return value
+}
+
+function optionalBoolean(value: unknown, label: string): boolean {
+  if (value === undefined || value === null) return false
+  return booleanValue(value, label)
+}
+
+function dateTimeValue(value: unknown, label: string): string {
+  const dateTime = stringValue(value, label)
+  if (!dateTime || !Number.isFinite(Date.parse(dateTime))) {
+    throw new Error(`Raindrop.io ${label} must be an ISO 8601 timestamp.`)
+  }
+  return new Date(dateTime).toISOString()
+}
+
+function urlValue(value: unknown, label: string): string {
+  const url = stringValue(value, label)
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`Raindrop.io ${label} must be an absolute URL.`)
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Raindrop.io ${label} must use HTTP or HTTPS.`)
+  }
+  return url
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Raindrop.io ${label} must be an array.`)
+  }
+  const strings = value.map((item, index) =>
+    stringValue(item, `${label}[${index}]`).trim()
+  )
+  return [...new Set(strings.filter(Boolean))]
+}
+
+function bookmarkType(value: unknown, label: string): RaindropType {
+  switch (value) {
+    case "link":
+    case "article":
+    case "image":
+    case "video":
+    case "document":
+    case "audio":
+      return value
+    default:
+      throw new Error(`Raindrop.io ${label} has an unsupported bookmark type.`)
+  }
+}
+
+function highlightColor(value: unknown, label: string): RaindropHighlightColor {
+  if (value === undefined || value === null || value === "") return "yellow"
+  if (typeof value !== "string") {
+    throw new Error(`Raindrop.io ${label} has an unsupported highlight color.`)
+  }
+  switch (value) {
+    case "blue":
+    case "brown":
+    case "cyan":
+    case "gray":
+    case "green":
+    case "indigo":
+    case "orange":
+    case "pink":
+    case "purple":
+    case "red":
+    case "teal":
+    case "yellow":
+      return value
+    default:
+      throw new Error(
+        `Raindrop.io ${label} has an unsupported highlight color.`
+      )
+  }
+}
+
+function parseBookmark(value: unknown, label: string): RaindropBookmark {
+  const item = objectValue(value, label)
+  const collection = objectValue(item.collection, `${label}.collection`)
+  const highlights = item.highlights ?? []
+  if (!Array.isArray(highlights)) {
+    throw new Error(`Raindrop.io ${label}.highlights must be an array.`)
+  }
+
+  return {
+    _id: positiveInteger(item._id, `${label}._id`),
+    title: stringValue(item.title, `${label}.title`),
+    link: urlValue(item.link, `${label}.link`),
+    domain: optionalString(item.domain, `${label}.domain`),
+    excerpt: optionalString(item.excerpt, `${label}.excerpt`),
+    note: optionalString(item.note, `${label}.note`),
+    type: bookmarkType(item.type, `${label}.type`),
+    tags: stringArray(item.tags ?? [], `${label}.tags`),
+    collection: {
+      $id: collectionIdValue(collection.$id, `${label}.collection.$id`),
+    },
+    important: optionalBoolean(item.important, `${label}.important`),
+    broken: optionalBoolean(item.broken, `${label}.broken`),
+    created: dateTimeValue(item.created, `${label}.created`),
+    lastUpdate: dateTimeValue(item.lastUpdate, `${label}.lastUpdate`),
+    highlights,
+  }
+}
+
+function parseHighlight(value: unknown, label: string): RaindropHighlight {
+  const item = objectValue(value, label)
+  const id = stringValue(item._id, `${label}._id`).trim()
+  if (!id) {
+    throw new Error(`Raindrop.io ${label}._id must not be empty.`)
+  }
+  return {
+    _id: id,
+    raindropRef: positiveInteger(item.raindropRef, `${label}.raindropRef`),
+    text: stringValue(item.text, `${label}.text`),
+    note: optionalString(item.note, `${label}.note`),
+    color: highlightColor(item.color, `${label}.color`),
+    title: optionalString(item.title, `${label}.title`),
+    link: urlValue(item.link, `${label}.link`),
+    tags: stringArray(item.tags ?? [], `${label}.tags`),
+    created: dateTimeValue(item.created, `${label}.created`),
+  }
+}
+
+function parseCollection(value: unknown, label: string): RaindropCollection {
+  const item = objectValue(value, label)
+  const parent = item.parent
+  let parentId: number | undefined
+  if (parent !== undefined && parent !== null) {
+    parentId = positiveInteger(
+      objectValue(parent, `${label}.parent`).$id,
+      `${label}.parent.$id`
+    )
+  }
+
+  return {
+    _id: positiveInteger(item._id, `${label}._id`),
+    title: stringValue(item.title, `${label}.title`),
+    count: nonNegativeInteger(item.count, `${label}.count`),
+    public: booleanValue(item.public, `${label}.public`),
+    parentId,
+    created: dateTimeValue(item.created, `${label}.created`),
+    lastUpdate: dateTimeValue(item.lastUpdate, `${label}.lastUpdate`),
+  }
+}
+
+function assertPage<T>(
+  items: T[],
+  key: (item: T) => string,
+  label: string
+): void {
+  if (items.length > PAGE_SIZE) {
+    throw new Error(`Raindrop.io returned too many ${label}s in one page.`)
+  }
+  assertUnique(items.map(key), `${label} ID`)
+}
+
+function assertUnique(values: string[], label: string): void {
+  if (new Set(values).size !== values.length) {
+    throw new Error(`Raindrop.io returned a duplicate ${label}.`)
+  }
+}

--- a/workers/raindrop-sync/src/raindrop.ts
+++ b/workers/raindrop-sync/src/raindrop.ts
@@ -2,10 +2,13 @@ import { RateLimitError } from "@notionhq/workers"
 
 const API_BASE_URL = "https://api.raindrop.io"
 export const PAGE_SIZE = 50
+export const PAGES_PER_SYNC_EXECUTION = 3
+export const MAX_PAGINATED_RECORDS = 10_000
+export const MAX_COLLECTIONS = 1_000
 export const MAX_RESPONSE_BYTES = 10 * 1_024 * 1_024
 export const REQUEST_TIMEOUT_MS = 30_000
 export const NOTION_URL_LIMIT = 2_000
-const MAX_COLLECTIONS = 10_000
+const MAX_PROVIDER_PAGE = MAX_PAGINATED_RECORDS / PAGE_SIZE
 
 export type BeforeRequest = () => Promise<void>
 
@@ -13,6 +16,7 @@ export type RaindropClientOptions = {
   beforeRequest: BeforeRequest
   fetchImpl?: typeof fetch
   getAccessToken?: () => string
+  getExpectedAccountId?: () => number
   requestTimeoutMs?: number
 }
 
@@ -41,6 +45,10 @@ export type RaindropBookmark = {
   created: string
   lastUpdate: string
   highlights: unknown[]
+  contributor?: {
+    id: number
+    fullName: string
+  }
 }
 
 export type RaindropHighlight = {
@@ -73,18 +81,29 @@ export type RaindropHighlightColor =
 export type BookmarkScope = "active" | "trash"
 type CollectionScope = "root" | "child"
 
+export type RaindropAccessLevel = 1 | 2 | 3 | 4
+
 export type RaindropCollection = {
   _id: number
   title: string
   count?: number
   public: boolean
+  ownerId?: number
+  accessLevel?: RaindropAccessLevel
+  shared: boolean
   parentId?: number
+  parentAvailable: boolean
   created?: string
   lastUpdate?: string
 }
 
 export type RaindropPage<T> = {
   items: T[]
+}
+
+export type RaindropPageBatch<T> = {
+  items: T[]
+  pages: T[][]
 }
 
 export type RaindropSession = {
@@ -94,7 +113,14 @@ export type RaindropSession = {
     scope: BookmarkScope,
     page: number
   ): Promise<RaindropPage<RaindropBookmark>>
+  fetchBookmarksBatch(
+    scope: BookmarkScope,
+    page: number
+  ): Promise<RaindropPageBatch<RaindropBookmark>>
   fetchHighlightsPage(page: number): Promise<RaindropPage<RaindropHighlight>>
+  fetchHighlightsBatch(
+    page: number
+  ): Promise<RaindropPageBatch<RaindropHighlight>>
 }
 
 export type RaindropClient = {
@@ -106,6 +132,8 @@ export function createRaindropClient(
 ): RaindropClient {
   const fetchImpl = options.fetchImpl ?? fetch
   const getAccessToken = options.getAccessToken ?? requireAccessToken
+  const getExpectedAccountId =
+    options.getExpectedAccountId ?? requireExpectedAccountId
   const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
   if (!Number.isSafeInteger(requestTimeoutMs) || requestTimeoutMs <= 0) {
     throw new Error("Raindrop.io request timeout must be a positive integer.")
@@ -185,11 +213,32 @@ export function createRaindropClient(
     )
   }
 
+  async function fetchPageBatch<T>(
+    startPage: number,
+    fetchPage: (page: number) => Promise<RaindropPage<T>>
+  ): Promise<RaindropPageBatch<T>> {
+    const pages: T[][] = []
+    for (let offset = 0; offset < PAGES_PER_SYNC_EXECUTION; offset += 1) {
+      const pageNumber = startPage + offset
+      if (pageNumber > MAX_PROVIDER_PAGE) break
+      const page = await fetchPage(pageNumber)
+      pages.push(page.items)
+      if (page.items.length < PAGE_SIZE) break
+    }
+    return { items: pages.flat(), pages }
+  }
+
   return {
     async authenticate() {
       const accessToken = getAccessToken().trim()
       if (!accessToken) {
         throw new Error("RAINDROP_ACCESS_TOKEN is not set.")
+      }
+      const expectedAccountId = getExpectedAccountId()
+      if (!Number.isSafeInteger(expectedAccountId) || expectedAccountId <= 0) {
+        throw new Error(
+          "RAINDROP_ACCOUNT_ID must be a positive integer account ID."
+        )
       }
 
       const payload = responseObject(
@@ -198,6 +247,49 @@ export function createRaindropClient(
       )
       const user = objectValue(payload.user, "user.user")
       const accountId = positiveInteger(user._id, "user.user._id")
+      if (accountId !== expectedAccountId) {
+        throw new Error(
+          "Raindrop.io authenticated a different account than RAINDROP_ACCOUNT_ID. Restore a token for the configured account or deploy a separate Worker."
+        )
+      }
+
+      const fetchBookmarksPage = async (
+        scope: BookmarkScope,
+        page: number
+      ): Promise<RaindropPage<RaindropBookmark>> => {
+        const collectionId = scope === "active" ? 0 : -99
+        const url = new URL(`/rest/v1/raindrops/${collectionId}`, API_BASE_URL)
+        url.searchParams.set("sort", "created")
+        url.searchParams.set("perpage", String(PAGE_SIZE))
+        url.searchParams.set("page", String(page))
+        const bookmarkPayload = responseObject(
+          await request(`${url.pathname}${url.search}`, accessToken),
+          "bookmarks"
+        )
+        const items = responseItems(bookmarkPayload, "bookmarks").map(
+          (item, index) => parseBookmark(item, `bookmarks.items[${index}]`)
+        )
+        assertBookmarkScope(items, scope)
+        assertPage(items, (item) => String(item._id), "bookmark")
+        return { items }
+      }
+
+      const fetchHighlightsPage = async (
+        page: number
+      ): Promise<RaindropPage<RaindropHighlight>> => {
+        const url = new URL("/rest/v1/highlights", API_BASE_URL)
+        url.searchParams.set("perpage", String(PAGE_SIZE))
+        url.searchParams.set("page", String(page))
+        const highlightPayload = responseObject(
+          await request(`${url.pathname}${url.search}`, accessToken),
+          "highlights"
+        )
+        const items = responseItems(highlightPayload, "highlights").map(
+          (item, index) => parseHighlight(item, `highlights.items[${index}]`)
+        )
+        assertPage(items, (item) => item._id, "highlight")
+        return { items }
+      }
 
       return {
         accountId,
@@ -220,16 +312,20 @@ export function createRaindropClient(
               _id: -1,
               title: "Unsorted",
               public: false,
+              shared: false,
+              parentAvailable: true,
             },
             {
               _id: -99,
               title: "Trash",
               public: false,
+              shared: false,
+              parentAvailable: true,
             },
             ...root,
             ...children,
           ]
-          if (collections.length > MAX_COLLECTIONS) {
+          if (root.length + children.length > MAX_COLLECTIONS) {
             throw new Error(
               `Raindrop.io returned more than ${MAX_COLLECTIONS} collections.`
             )
@@ -238,43 +334,21 @@ export function createRaindropClient(
             collections.map((collection) => String(collection._id)),
             "collection ID"
           )
-          return collections
+          return validateCollectionHierarchy(collections)
         },
 
-        async fetchBookmarksPage(scope, page) {
-          const collectionId = scope === "active" ? 0 : -99
-          const url = new URL(
-            `/rest/v1/raindrops/${collectionId}`,
-            API_BASE_URL
+        fetchBookmarksPage,
+
+        async fetchBookmarksBatch(scope, page) {
+          return fetchPageBatch(page, (nextPage) =>
+            fetchBookmarksPage(scope, nextPage)
           )
-          url.searchParams.set("sort", "created")
-          url.searchParams.set("perpage", String(PAGE_SIZE))
-          url.searchParams.set("page", String(page))
-          const bookmarkPayload = responseObject(
-            await request(`${url.pathname}${url.search}`, accessToken),
-            "bookmarks"
-          )
-          const items = responseItems(bookmarkPayload, "bookmarks").map(
-            (item, index) => parseBookmark(item, `bookmarks.items[${index}]`)
-          )
-          assertBookmarkScope(items, scope)
-          assertPage(items, (item) => String(item._id), "bookmark")
-          return { items }
         },
 
-        async fetchHighlightsPage(page) {
-          const url = new URL("/rest/v1/highlights", API_BASE_URL)
-          url.searchParams.set("perpage", String(PAGE_SIZE))
-          url.searchParams.set("page", String(page))
-          const highlightPayload = responseObject(
-            await request(`${url.pathname}${url.search}`, accessToken),
-            "highlights"
-          )
-          const items = responseItems(highlightPayload, "highlights").map(
-            (item, index) => parseHighlight(item, `highlights.items[${index}]`)
-          )
-          assertPage(items, (item) => item._id, "highlight")
-          return { items }
+        fetchHighlightsPage,
+
+        async fetchHighlightsBatch(page) {
+          return fetchPageBatch(page, fetchHighlightsPage)
         },
       }
     },
@@ -328,6 +402,22 @@ function requireAccessToken(): string {
     throw new Error("RAINDROP_ACCESS_TOKEN is not set.")
   }
   return token
+}
+
+function requireExpectedAccountId(): number {
+  const value = process.env.RAINDROP_ACCOUNT_ID?.trim()
+  if (!value || !/^\d+$/.test(value)) {
+    throw new Error(
+      "RAINDROP_ACCOUNT_ID must be a positive integer account ID."
+    )
+  }
+  const accountId = Number(value)
+  if (!Number.isSafeInteger(accountId) || accountId <= 0) {
+    throw new Error(
+      "RAINDROP_ACCOUNT_ID must be a positive integer account ID."
+    )
+  }
+  return accountId
 }
 
 function retryAfterSeconds(headers: Headers): number {
@@ -445,6 +535,26 @@ function optionalReminderDate(
   return dateTimeValue(reminder.data, `${label}.data`)
 }
 
+function optionalContributor(
+  value: unknown,
+  label: string
+): RaindropBookmark["contributor"] {
+  if (value === undefined) return undefined
+  const author = objectValue(value, label)
+  return {
+    id: positiveInteger(author._id, `${label}._id`),
+    fullName: stringValue(author.fullName, `${label}.fullName`),
+  }
+}
+
+function accessLevel(value: unknown, label: string): RaindropAccessLevel {
+  const level = integerValue(value, label)
+  if (level !== 1 && level !== 2 && level !== 3 && level !== 4) {
+    throw new Error(`Raindrop.io ${label} must be 1, 2, 3, or 4.`)
+  }
+  return level
+}
+
 function dateTimeValue(value: unknown, label: string): string {
   const dateTime = stringValue(value, label)
   if (!dateTime || !Number.isFinite(Date.parse(dateTime))) {
@@ -554,6 +664,7 @@ function parseBookmark(value: unknown, label: string): RaindropBookmark {
     created: dateTimeValue(item.created, `${label}.created`),
     lastUpdate: dateTimeValue(item.lastUpdate, `${label}.lastUpdate`),
     highlights,
+    contributor: optionalContributor(item.creatorRef, `${label}.creatorRef`),
   }
 }
 
@@ -584,6 +695,15 @@ function parseCollection(
   scope: CollectionScope
 ): RaindropCollection {
   const item = objectValue(value, label)
+  const owner = objectValue(item.user, `${label}.user`)
+  const access = objectValue(item.access, `${label}.access`)
+  const parsedAccessLevel = accessLevel(access.level, `${label}.access.level`)
+  let shared = false
+  if (item.collaborators !== undefined) {
+    objectValue(item.collaborators, `${label}.collaborators`)
+    shared = true
+  }
+  shared ||= parsedAccessLevel === 2 || parsedAccessLevel === 3
   const parent = item.parent
   let parentId: number | undefined
   if (scope === "child") {
@@ -603,10 +723,39 @@ function parseCollection(
     title: stringValue(item.title, `${label}.title`),
     count: nonNegativeInteger(item.count, `${label}.count`),
     public: booleanValue(item.public, `${label}.public`),
+    ownerId: positiveInteger(owner.$id, `${label}.user.$id`),
+    accessLevel: parsedAccessLevel,
+    shared,
     parentId,
+    parentAvailable: true,
     created: dateTimeValue(item.created, `${label}.created`),
     lastUpdate: dateTimeValue(item.lastUpdate, `${label}.lastUpdate`),
   }
+}
+
+function validateCollectionHierarchy(
+  items: RaindropCollection[]
+): RaindropCollection[] {
+  const byId = new Map(items.map((item) => [item._id, item]))
+  const normalized = items.map((item) => ({
+    ...item,
+    parentAvailable: item.parentId === undefined || byId.has(item.parentId),
+  }))
+  const normalizedById = new Map(normalized.map((item) => [item._id, item]))
+  for (const item of normalized) {
+    const ancestors = new Set<number>([item._id])
+    let current = item
+    while (current.parentId !== undefined) {
+      const parent = normalizedById.get(current.parentId)
+      if (!parent) break
+      if (ancestors.has(parent._id)) {
+        throw new Error("Raindrop.io returned a cyclic collection hierarchy.")
+      }
+      ancestors.add(parent._id)
+      current = parent
+    }
+  }
+  return normalized
 }
 
 function assertBookmarkScope(

--- a/workers/raindrop-sync/src/raindrop.ts
+++ b/workers/raindrop-sync/src/raindrop.ts
@@ -37,6 +37,7 @@ export type RaindropBookmark = {
   collection: { $id: number }
   important: boolean
   broken: boolean
+  reminderAt?: string
   created: string
   lastUpdate: string
   highlights: unknown[]
@@ -435,6 +436,15 @@ function optionalBoolean(value: unknown, label: string): boolean {
   return booleanValue(value, label)
 }
 
+function optionalReminderDate(
+  value: unknown,
+  label: string
+): string | undefined {
+  if (value === undefined || value === null) return undefined
+  const reminder = objectValue(value, label)
+  return dateTimeValue(reminder.data, `${label}.data`)
+}
+
 function dateTimeValue(value: unknown, label: string): string {
   const dateTime = stringValue(value, label)
   if (!dateTime || !Number.isFinite(Date.parse(dateTime))) {
@@ -540,6 +550,7 @@ function parseBookmark(value: unknown, label: string): RaindropBookmark {
     },
     important: optionalBoolean(item.important, `${label}.important`),
     broken: optionalBoolean(item.broken, `${label}.broken`),
+    reminderAt: optionalReminderDate(item.reminder, `${label}.reminder`),
     created: dateTimeValue(item.created, `${label}.created`),
     lastUpdate: dateTimeValue(item.lastUpdate, `${label}.lastUpdate`),
     highlights,

--- a/workers/raindrop-sync/src/sync-state.ts
+++ b/workers/raindrop-sync/src/sync-state.ts
@@ -1,14 +1,29 @@
-import { PAGE_SIZE } from "./raindrop.js"
+import { createHash } from "node:crypto"
 
-export const MAX_SYNC_RECORDS = 10_000
+import {
+  MAX_PAGINATED_RECORDS,
+  PAGE_SIZE,
+  PAGES_PER_SYNC_EXECUTION,
+} from "./raindrop.js"
+
+export const MAX_SYNC_RECORDS = MAX_PAGINATED_RECORDS
 const MAX_DATA_PAGES = MAX_SYNC_RECORDS / PAGE_SIZE
+const ID_FINGERPRINT_LENGTH = 32
+const PAGE_DIGEST_LENGTH = 64
 
 export type AccountSyncState = {
   accountId: number
 }
 
+export type PaginationGuardState = {
+  firstPageDigest?: string
+  previousPageFingerprints?: string[]
+  restartUsed?: boolean
+}
+
 export type PageSyncState = AccountSyncState & {
   page: number
+  guard?: PaginationGuardState
 }
 
 export type BookmarkPhase = "active" | "trash"
@@ -21,6 +36,13 @@ type SyncPageResult<T, State> = {
   changes: T[]
   hasMore: boolean
   nextState: State
+}
+
+type EvaluatedPageBatch = {
+  complete: boolean
+  nextPage: number
+  guard: PaginationGuardState
+  restart: boolean
 }
 
 function assertAccountId(accountId: number, resourceName: string): void {
@@ -48,6 +70,49 @@ function validateAccountState(
   }
 }
 
+function validateGuard(
+  guard: PaginationGuardState | undefined,
+  resourceName: string
+): void {
+  if (!guard) return
+  if (typeof guard !== "object" || Array.isArray(guard)) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync state has an invalid pagination guard.`
+    )
+  }
+  if (
+    guard.firstPageDigest !== undefined &&
+    !new RegExp(`^[a-f0-9]{${PAGE_DIGEST_LENGTH}}$`).test(guard.firstPageDigest)
+  ) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync state has an invalid first-page digest.`
+    )
+  }
+  if (guard.previousPageFingerprints !== undefined) {
+    if (
+      !Array.isArray(guard.previousPageFingerprints) ||
+      guard.previousPageFingerprints.length > PAGE_SIZE ||
+      guard.previousPageFingerprints.some(
+        (fingerprint) =>
+          typeof fingerprint !== "string" ||
+          !new RegExp(`^[a-f0-9]{${ID_FINGERPRINT_LENGTH}}$`).test(fingerprint)
+      )
+    ) {
+      throw new Error(
+        `Raindrop.io ${resourceName} sync state has invalid page fingerprints.`
+      )
+    }
+  }
+  if (
+    guard.restartUsed !== undefined &&
+    typeof guard.restartUsed !== "boolean"
+  ) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync state has an invalid restart flag.`
+    )
+  }
+}
+
 function validatePageState(
   state: PageSyncState,
   accountId: number,
@@ -63,6 +128,7 @@ function validatePageState(
       `Raindrop.io ${resourceName} sync state has an invalid page.`
     )
   }
+  validateGuard(state.guard, resourceName)
 }
 
 export function accountState(
@@ -118,28 +184,160 @@ function validatePage(
   }
 }
 
+function fingerprintId(id: string): string {
+  return createHash("sha256")
+    .update(id)
+    .digest("hex")
+    .slice(0, ID_FINGERPRINT_LENGTH)
+}
+
+function pageFingerprints(ids: string[], resourceName: string): string[] {
+  if (new Set(ids).size !== ids.length) {
+    throw new Error(`Raindrop.io returned a duplicate ${resourceName} ID.`)
+  }
+  return ids.map(fingerprintId)
+}
+
+function membershipDigest(fingerprints: string[]): string {
+  return createHash("sha256")
+    .update([...fingerprints].sort().join(""))
+    .digest("hex")
+}
+
+function hasOverlap(left: string[], right: string[]): boolean {
+  const leftSet = new Set(left)
+  return right.some((fingerprint) => leftSet.has(fingerprint))
+}
+
+function validatePageBatch(
+  startPage: number,
+  pageIds: string[][],
+  changeCount: number,
+  resourceName: string
+): void {
+  if (pageIds.length === 0 || pageIds.length > PAGES_PER_SYNC_EXECUTION) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync received an invalid page batch.`
+    )
+  }
+  pageIds.forEach((ids, index) => {
+    validatePage(startPage + index, ids.length, resourceName)
+    if (index < pageIds.length - 1 && ids.length !== PAGE_SIZE) {
+      throw new Error(
+        `Raindrop.io ${resourceName} sync received data after a terminal page.`
+      )
+    }
+  })
+  const lastPage = pageIds.at(-1)!
+  if (
+    lastPage.length === PAGE_SIZE &&
+    pageIds.length < PAGES_PER_SYNC_EXECUTION
+  ) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync ended a full page batch early.`
+    )
+  }
+  if (pageIds.reduce((total, ids) => total + ids.length, 0) !== changeCount) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync produced an unexpected number of changes.`
+    )
+  }
+}
+
+function evaluatePageBatch(
+  state: PageSyncState | undefined,
+  accountId: number,
+  pageIds: string[][],
+  changeCount: number,
+  resourceName: string,
+  terminalFirstPageIds?: string[]
+): EvaluatedPageBatch {
+  const page = currentPage(state, accountId, resourceName)
+  validatePageBatch(page, pageIds, changeCount, resourceName)
+
+  const pageFingerprintLists = pageIds.map((ids) =>
+    pageFingerprints(ids, resourceName)
+  )
+  const firstPageDigest =
+    state?.guard?.firstPageDigest ??
+    (page === 0 ? membershipDigest(pageFingerprintLists[0]) : undefined)
+  let driftDetected = false
+  let previous = state?.guard?.previousPageFingerprints
+  for (const fingerprints of pageFingerprintLists) {
+    if (previous && hasOverlap(previous, fingerprints)) {
+      driftDetected = true
+    }
+    previous = fingerprints
+  }
+
+  const complete = pageIds.at(-1)!.length < PAGE_SIZE
+  if (complete && terminalFirstPageIds !== undefined && firstPageDigest) {
+    const terminalDigest = membershipDigest(
+      pageFingerprints(terminalFirstPageIds, resourceName)
+    )
+    driftDetected ||= terminalDigest !== firstPageDigest
+  }
+
+  const restartUsed = state?.guard?.restartUsed === true
+  if (driftDetected && !restartUsed) {
+    return {
+      complete: false,
+      nextPage: 0,
+      guard: { restartUsed: true },
+      restart: true,
+    }
+  }
+
+  return {
+    complete,
+    nextPage: page + pageIds.length,
+    guard: {
+      ...(firstPageDigest ? { firstPageDigest } : {}),
+      previousPageFingerprints: previous,
+      ...(restartUsed ? { restartUsed: true } : {}),
+    },
+    restart: false,
+  }
+}
+
 export function pageResult<T>(
   state: PageSyncState | undefined,
   accountId: number,
-  items: unknown[],
+  pageIds: string[][],
   changes: T[],
-  resourceName: string
+  resourceName: string,
+  terminalFirstPageIds?: string[]
 ): SyncPageResult<T, PageSyncState> {
-  const page = currentPage(state, accountId, resourceName)
-  validatePage(page, items.length, resourceName)
-
-  const hasMore = items.length === PAGE_SIZE
+  const result = evaluatePageBatch(
+    state,
+    accountId,
+    pageIds,
+    changes.length,
+    resourceName,
+    terminalFirstPageIds
+  )
+  if (result.restart) {
+    return {
+      changes: [],
+      hasMore: true,
+      nextState: { accountId, page: 0, guard: result.guard },
+    }
+  }
+  if (result.complete) {
+    return {
+      changes,
+      hasMore: false,
+      nextState: { accountId, page: 0 },
+    }
+  }
   return {
     changes,
-    hasMore,
-    ...(hasMore
-      ? {
-          nextState: {
-            accountId,
-            page: page + 1,
-          },
-        }
-      : { nextState: { accountId, page: 0 } }),
+    hasMore: true,
+    nextState: {
+      accountId,
+      page: result.nextPage,
+      guard: result.guard,
+    },
   }
 }
 
@@ -147,27 +345,46 @@ export function bookmarkPageResult<T>(
   state: BookmarkSyncState | undefined,
   accountId: number,
   phase: BookmarkPhase,
-  items: unknown[],
-  changes: T[]
+  pageIds: string[][],
+  changes: T[],
+  terminalFirstPageIds?: string[]
 ): SyncPageResult<T, BookmarkSyncState> {
   const position = currentBookmarkPosition(state, accountId)
   if (position.phase !== phase) {
     throw new Error("Raindrop.io bookmarks sync phase changed unexpectedly.")
   }
-  validatePage(position.page, items.length, `${phase} bookmarks`)
-
-  if (items.length === PAGE_SIZE) {
+  const result = evaluatePageBatch(
+    state,
+    accountId,
+    pageIds,
+    changes.length,
+    `${phase} bookmarks`,
+    terminalFirstPageIds
+  )
+  if (result.restart) {
+    return {
+      changes: [],
+      hasMore: true,
+      nextState: {
+        accountId,
+        phase,
+        page: 0,
+        guard: result.guard,
+      },
+    }
+  }
+  if (!result.complete) {
     return {
       changes,
       hasMore: true,
       nextState: {
         accountId,
         phase,
-        page: position.page + 1,
+        page: result.nextPage,
+        guard: result.guard,
       },
     }
   }
-
   if (phase === "active") {
     return {
       changes,
@@ -179,7 +396,6 @@ export function bookmarkPageResult<T>(
       },
     }
   }
-
   return {
     changes,
     hasMore: false,

--- a/workers/raindrop-sync/src/sync-state.ts
+++ b/workers/raindrop-sync/src/sync-state.ts
@@ -1,0 +1,173 @@
+import { PAGE_SIZE } from "./raindrop.js"
+
+export const SYNC_STATE_VERSION = 1
+export const MAX_SYNC_RECORDS = 10_000
+const MAX_DATA_PAGES = MAX_SYNC_RECORDS / PAGE_SIZE
+
+export type PageSyncState = {
+  stateVersion: typeof SYNC_STATE_VERSION
+  accountId: number
+  page: number
+}
+
+export type BookmarkPhase = "active" | "trash"
+
+export type BookmarkSyncState = PageSyncState & {
+  phase: BookmarkPhase
+}
+
+type SyncPageResult<T, State> = {
+  changes: T[]
+  hasMore: boolean
+  nextState?: State
+}
+
+function assertAccountId(accountId: number, resourceName: string): void {
+  if (!Number.isSafeInteger(accountId) || accountId <= 0) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync received an invalid account ID.`
+    )
+  }
+}
+
+function validateState(
+  state: PageSyncState,
+  accountId: number,
+  resourceName: string
+): void {
+  if (state.stateVersion !== SYNC_STATE_VERSION) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync state is incompatible; reset the capability state before retrying.`
+    )
+  }
+  if (!Number.isSafeInteger(state.accountId) || state.accountId <= 0) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync state has an invalid account ID.`
+    )
+  }
+  if (state.accountId !== accountId) {
+    throw new Error(
+      `Raindrop.io account changed during the ${resourceName} scan; restore the original token or reset this capability state before retrying.`
+    )
+  }
+  if (
+    !Number.isSafeInteger(state.page) ||
+    state.page < 0 ||
+    state.page > MAX_DATA_PAGES
+  ) {
+    throw new Error(
+      `Raindrop.io ${resourceName} sync state has an invalid page.`
+    )
+  }
+}
+
+export function currentPage(
+  state: PageSyncState | undefined,
+  accountId: number,
+  resourceName: string
+): number {
+  assertAccountId(accountId, resourceName)
+  if (!state) return 0
+  validateState(state, accountId, resourceName)
+  return state.page
+}
+
+export function currentBookmarkPosition(
+  state: BookmarkSyncState | undefined,
+  accountId: number
+): { phase: BookmarkPhase; page: number } {
+  if (!state) {
+    assertAccountId(accountId, "bookmarks")
+    return { phase: "active", page: 0 }
+  }
+  validateState(state, accountId, "bookmarks")
+  if (state.phase !== "active" && state.phase !== "trash") {
+    throw new Error("Raindrop.io bookmarks sync state has an invalid phase.")
+  }
+  return { phase: state.phase, page: state.page }
+}
+
+function validatePage(
+  page: number,
+  itemCount: number,
+  resourceName: string
+): void {
+  if (itemCount > PAGE_SIZE) {
+    throw new Error(
+      `Raindrop.io ${resourceName} response exceeds the documented page size.`
+    )
+  }
+  if (page === MAX_DATA_PAGES && itemCount > 0) {
+    throw new Error(
+      `Raindrop.io ${resourceName} exceeds ${MAX_SYNC_RECORDS} records; narrow or partition this reference sync before retrying.`
+    )
+  }
+}
+
+export function pageResult<T>(
+  state: PageSyncState | undefined,
+  accountId: number,
+  items: unknown[],
+  changes: T[],
+  resourceName: string
+): SyncPageResult<T, PageSyncState> {
+  const page = currentPage(state, accountId, resourceName)
+  validatePage(page, items.length, resourceName)
+
+  const hasMore = items.length === PAGE_SIZE
+  return {
+    changes,
+    hasMore,
+    ...(hasMore
+      ? {
+          nextState: {
+            stateVersion: SYNC_STATE_VERSION,
+            accountId,
+            page: page + 1,
+          },
+        }
+      : {}),
+  }
+}
+
+export function bookmarkPageResult<T>(
+  state: BookmarkSyncState | undefined,
+  accountId: number,
+  phase: BookmarkPhase,
+  items: unknown[],
+  changes: T[]
+): SyncPageResult<T, BookmarkSyncState> {
+  const position = currentBookmarkPosition(state, accountId)
+  if (position.phase !== phase) {
+    throw new Error("Raindrop.io bookmarks sync phase changed unexpectedly.")
+  }
+  validatePage(position.page, items.length, `${phase} bookmarks`)
+
+  if (items.length === PAGE_SIZE) {
+    return {
+      changes,
+      hasMore: true,
+      nextState: {
+        stateVersion: SYNC_STATE_VERSION,
+        accountId,
+        phase,
+        page: position.page + 1,
+      },
+    }
+  }
+
+  if (phase === "active") {
+    return {
+      changes,
+      hasMore: true,
+      nextState: {
+        stateVersion: SYNC_STATE_VERSION,
+        accountId,
+        phase: "trash",
+        page: 0,
+      },
+    }
+  }
+
+  return { changes, hasMore: false }
+}

--- a/workers/raindrop-sync/src/sync-state.ts
+++ b/workers/raindrop-sync/src/sync-state.ts
@@ -1,12 +1,13 @@
 import { PAGE_SIZE } from "./raindrop.js"
 
-export const SYNC_STATE_VERSION = 1
 export const MAX_SYNC_RECORDS = 10_000
 const MAX_DATA_PAGES = MAX_SYNC_RECORDS / PAGE_SIZE
 
-export type PageSyncState = {
-  stateVersion: typeof SYNC_STATE_VERSION
+export type AccountSyncState = {
   accountId: number
+}
+
+export type PageSyncState = AccountSyncState & {
   page: number
 }
 
@@ -19,7 +20,7 @@ export type BookmarkSyncState = PageSyncState & {
 type SyncPageResult<T, State> = {
   changes: T[]
   hasMore: boolean
-  nextState?: State
+  nextState: State
 }
 
 function assertAccountId(accountId: number, resourceName: string): void {
@@ -30,16 +31,11 @@ function assertAccountId(accountId: number, resourceName: string): void {
   }
 }
 
-function validateState(
-  state: PageSyncState,
+function validateAccountState(
+  state: AccountSyncState,
   accountId: number,
   resourceName: string
 ): void {
-  if (state.stateVersion !== SYNC_STATE_VERSION) {
-    throw new Error(
-      `Raindrop.io ${resourceName} sync state is incompatible; reset the capability state before retrying.`
-    )
-  }
   if (!Number.isSafeInteger(state.accountId) || state.accountId <= 0) {
     throw new Error(
       `Raindrop.io ${resourceName} sync state has an invalid account ID.`
@@ -47,9 +43,17 @@ function validateState(
   }
   if (state.accountId !== accountId) {
     throw new Error(
-      `Raindrop.io account changed during the ${resourceName} scan; restore the original token or reset this capability state before retrying.`
+      `Raindrop.io account changed for ${resourceName}; restore the original token or deploy a separate Worker for the other account.`
     )
   }
+}
+
+function validatePageState(
+  state: PageSyncState,
+  accountId: number,
+  resourceName: string
+): void {
+  validateAccountState(state, accountId, resourceName)
   if (
     !Number.isSafeInteger(state.page) ||
     state.page < 0 ||
@@ -61,6 +65,16 @@ function validateState(
   }
 }
 
+export function accountState(
+  state: AccountSyncState | undefined,
+  accountId: number,
+  resourceName: string
+): AccountSyncState {
+  assertAccountId(accountId, resourceName)
+  if (state) validateAccountState(state, accountId, resourceName)
+  return { accountId }
+}
+
 export function currentPage(
   state: PageSyncState | undefined,
   accountId: number,
@@ -68,7 +82,7 @@ export function currentPage(
 ): number {
   assertAccountId(accountId, resourceName)
   if (!state) return 0
-  validateState(state, accountId, resourceName)
+  validatePageState(state, accountId, resourceName)
   return state.page
 }
 
@@ -80,7 +94,7 @@ export function currentBookmarkPosition(
     assertAccountId(accountId, "bookmarks")
     return { phase: "active", page: 0 }
   }
-  validateState(state, accountId, "bookmarks")
+  validatePageState(state, accountId, "bookmarks")
   if (state.phase !== "active" && state.phase !== "trash") {
     throw new Error("Raindrop.io bookmarks sync state has an invalid phase.")
   }
@@ -121,12 +135,11 @@ export function pageResult<T>(
     ...(hasMore
       ? {
           nextState: {
-            stateVersion: SYNC_STATE_VERSION,
             accountId,
             page: page + 1,
           },
         }
-      : {}),
+      : { nextState: { accountId, page: 0 } }),
   }
 }
 
@@ -148,7 +161,6 @@ export function bookmarkPageResult<T>(
       changes,
       hasMore: true,
       nextState: {
-        stateVersion: SYNC_STATE_VERSION,
         accountId,
         phase,
         page: position.page + 1,
@@ -161,7 +173,6 @@ export function bookmarkPageResult<T>(
       changes,
       hasMore: true,
       nextState: {
-        stateVersion: SYNC_STATE_VERSION,
         accountId,
         phase: "trash",
         page: 0,
@@ -169,5 +180,9 @@ export function bookmarkPageResult<T>(
     }
   }
 
-  return { changes, hasMore: false }
+  return {
+    changes,
+    hasMore: false,
+    nextState: { accountId, phase: "active", page: 0 },
+  }
 }

--- a/workers/raindrop-sync/test.ts
+++ b/workers/raindrop-sync/test.ts
@@ -19,6 +19,7 @@ import { bookmarkKey, collectionKey, highlightKey } from "./src/keys.js"
 import {
   createRaindropClient,
   MAX_RESPONSE_BYTES,
+  NOTION_URL_LIMIT,
   PAGE_SIZE,
   type RaindropBookmark,
   type RaindropCollection,
@@ -36,11 +37,13 @@ import {
 } from "./src/sync-state.js"
 
 const accountId = 321
+const observedAt = "2026-07-03T12:34:56.000Z"
 
 const bookmark: RaindropBookmark = {
   _id: 42,
   title: "Workers worth reading",
   link: "https://example.com/workers",
+  linkOmitted: false,
   domain: "example.com",
   excerpt: "A useful description.",
   note: "Use this in the next project.",
@@ -62,6 +65,7 @@ const highlight: RaindropHighlight = {
   color: "purple",
   title: "Workers worth reading",
   link: "https://example.com/workers",
+  linkOmitted: false,
   tags: ["notion"],
   created: "2026-06-01T10:05:00.000Z",
 }
@@ -235,7 +239,7 @@ test("resource keys are stable within an account and isolated across accounts an
 })
 
 test("bookmark transform scopes keys and relations while preserving raw IDs", () => {
-  const change = bookmarkToChange(accountId, bookmark, false)
+  const change = bookmarkToChange(accountId, bookmark, false, observedAt)
 
   assert.equal(change.key, "raindrop:321:bookmark:42")
   assert.equal("upstreamUpdatedAt" in change, false)
@@ -248,6 +252,8 @@ test("bookmark transform scopes keys and relations while preserving raw IDs", ()
   assert.ok(propertyIncludes(change.properties.Highlights, "1"))
   assert.ok(propertyIncludes(change.properties.Created, "UTC"))
   assert.ok(propertyIncludes(change.properties.Updated, "UTC"))
+  assert.ok(propertyIncludes(change.properties["Last Seen"], "2026-07-03"))
+  assert.ok(propertyIncludes(change.properties["Last Seen"], "12:34"))
   assert.ok(propertyIncludes(change.properties["Raindrop ID"], "42"))
   assert.ok(propertyIncludes(change.properties["Raindrop Account ID"], "321"))
   assert.ok(
@@ -264,8 +270,8 @@ test("trash and restored bookmark upserts use one key and explicitly flip In Tra
     ...bookmark,
     collection: { $id: -99 },
   }
-  const trashed = bookmarkToChange(accountId, trashedBookmark, true)
-  const restored = bookmarkToChange(accountId, bookmark, false)
+  const trashed = bookmarkToChange(accountId, trashedBookmark, true, observedAt)
+  const restored = bookmarkToChange(accountId, bookmark, false, observedAt)
 
   assert.equal(trashed.key, restored.key)
   assert.ok(propertyIncludes(trashed.properties["In Trash"], "Yes"))
@@ -288,7 +294,8 @@ test("bookmark transform clears optional values without owning page content", ()
       note: "",
       tags: [],
     },
-    false
+    false,
+    observedAt
   )
 
   assert.deepEqual(change.properties.Domain, [])
@@ -299,7 +306,7 @@ test("bookmark transform clears optional values without owning page content", ()
 })
 
 test("highlight transform scopes its key and bookmark relation", () => {
-  const change = highlightToChange(accountId, highlight)
+  const change = highlightToChange(accountId, highlight, observedAt)
 
   assert.equal(change.key, "raindrop:321:highlight:highlight-1")
   assert.ok(
@@ -308,17 +315,23 @@ test("highlight transform scopes its key and bookmark relation", () => {
   assert.ok(propertyIncludes(change.properties.Text, "agent decides when"))
   assert.ok(propertyIncludes(change.properties.Color, "Purple"))
   assert.ok(propertyIncludes(change.properties.Created, "UTC"))
+  assert.ok(propertyIncludes(change.properties["Last Seen"], "2026-07-03"))
+  assert.ok(propertyIncludes(change.properties["Last Seen"], "12:34"))
   assert.ok(propertyIncludes(change.properties["Highlight ID"], "highlight-1"))
   assert.equal("pageContentMarkdown" in change, false)
 })
 
 test("collection transform scopes parent relations and exposes raw identity", () => {
-  const child = collectionToChange(accountId, collection)
-  const root = collectionToChange(accountId, {
-    ...collection,
-    _id: 3,
-    parentId: undefined,
-  })
+  const child = collectionToChange(accountId, collection, observedAt)
+  const root = collectionToChange(
+    accountId,
+    {
+      ...collection,
+      _id: 3,
+      parentId: undefined,
+    },
+    observedAt
+  )
 
   assert.equal(child.key, "raindrop:321:collection:7")
   assert.ok(
@@ -328,7 +341,41 @@ test("collection transform scopes parent relations and exposes raw identity", ()
   assert.ok(propertyIncludes(child.properties["Collection ID"], "7"))
   assert.ok(propertyIncludes(child.properties.Created, "UTC"))
   assert.ok(propertyIncludes(child.properties.Updated, "UTC"))
+  assert.ok(propertyIncludes(child.properties["Last Seen"], "2026-07-03"))
+  assert.ok(propertyIncludes(child.properties["Last Seen"], "12:34"))
   assert.equal("upstreamUpdatedAt" in child, false)
+})
+
+test("omitted source URLs are disclosed without breaking transforms", () => {
+  const bookmarkChange = bookmarkToChange(
+    accountId,
+    {
+      ...bookmark,
+      title: "",
+      domain: "",
+      link: undefined,
+      linkOmitted: true,
+    },
+    false,
+    observedAt
+  )
+  const highlightChange = highlightToChange(
+    accountId,
+    {
+      ...highlight,
+      link: undefined,
+      linkOmitted: true,
+    },
+    observedAt
+  )
+
+  assert.deepEqual(bookmarkChange.properties.URL, [])
+  assert.ok(
+    propertyIncludes(bookmarkChange.properties.Title, "Untitled bookmark")
+  )
+  assert.ok(propertyIncludes(bookmarkChange.properties["URL Omitted"], "Yes"))
+  assert.deepEqual(highlightChange.properties.URL, [])
+  assert.ok(propertyIncludes(highlightChange.properties["URL Omitted"], "Yes"))
 })
 
 test("text helpers truncate by Unicode character and disclose truncation", () => {
@@ -343,11 +390,51 @@ test("text helpers truncate by Unicode character and disclose truncation", () =>
   assert.equal(highlightTitle("a\n  b", "fallback"), "a b")
 })
 
-test("tag options are deterministic, comma-safe, and never silently dropped", () => {
-  assert.deepEqual(optionNames("bookmark tags", [" API ", "api", "a,b"]), [
+test("tag options deduplicate case variants and preserve normalization collisions", () => {
+  const sourceTags = [" API ", "api", "a,b", "a，b"]
+  const normalized = optionNames("bookmark tags", sourceTags)
+
+  assert.equal(normalized.length, 3)
+  assert.equal(normalized.includes("a，b"), true)
+  assert.equal(
+    normalized.some((name) => /^a，b.*[0-9a-f]{12}$/.test(name)),
+    true
+  )
+  assert.deepEqual(
+    optionNames("bookmark tags", [...sourceTags].reverse()),
+    normalized
+  )
+  assert.equal(
+    normalized.filter((name) => name.toLocaleLowerCase("en-US") === "api")
+      .length,
+    1
+  )
+  assert.equal(
+    normalized.every((name) => Array.from(name).length <= 100),
+    true
+  )
+
+  const generatedName = optionNames("bookmark tags", ["a,b", "a，b"]).find(
+    (name) => name !== "a，b"
+  )
+  assert.ok(generatedName)
+  const naturalNameCollision = optionNames("bookmark tags", [
+    "a,b",
     "a，b",
-    "API",
+    generatedName,
   ])
+  assert.equal(naturalNameCollision.length, 3)
+  assert.equal(naturalNameCollision.includes(generatedName), true)
+  assert.equal(
+    new Set(naturalNameCollision.map((name) => name.toLocaleLowerCase("en-US")))
+      .size,
+    3
+  )
+  assert.equal(
+    naturalNameCollision.every((name) => Array.from(name).length <= 100),
+    true
+  )
+
   assert.equal(optionNames("bookmark tags", ["x".repeat(101)])[0].length, 100)
   assert.throws(
     () =>
@@ -570,6 +657,64 @@ test("client normalizes provider timestamp offsets to UTC", async () => {
   const session = await client.authenticate()
   const page = await session.fetchBookmarksPage("active", 0)
   assert.equal(page.items[0].created, "2026-06-01T10:00:00.000Z")
+})
+
+test("client preserves 2,000-character URLs and omits longer links", async () => {
+  const prefix = "https://example.com/"
+  const exact = `${prefix}${"a".repeat(NOTION_URL_LIMIT - prefix.length)}`
+  const overlong = `${exact}a`
+  const astralOverlong = `${exact.slice(0, -1)}😀`
+  assert.equal(Array.from(astralOverlong).length, NOTION_URL_LIMIT)
+  assert.equal(astralOverlong.length, NOTION_URL_LIMIT + 1)
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      const path = new URL(input instanceof Request ? input.url : String(input))
+        .pathname
+      return path.startsWith("/rest/v1/raindrops/")
+        ? jsonResponse({
+            result: true,
+            items: [
+              bookmarkPayload({ _id: 42, link: exact }),
+              bookmarkPayload({ _id: 43, link: overlong }),
+              bookmarkPayload({ _id: 44, link: astralOverlong }),
+            ],
+          })
+        : jsonResponse({
+            result: true,
+            items: [
+              highlightPayload({ _id: "exact", link: exact }),
+              highlightPayload({ _id: "overlong", link: overlong }),
+              highlightPayload({
+                _id: "astral-overlong",
+                link: astralOverlong,
+              }),
+            ],
+          })
+    }),
+    getAccessToken: () => "test-token",
+  })
+
+  const session = await client.authenticate()
+  const bookmarks = await session.fetchBookmarksPage("active", 0)
+  const highlights = await session.fetchHighlightsPage(0)
+
+  assert.deepEqual(
+    bookmarks.items.map(({ link, linkOmitted }) => ({ link, linkOmitted })),
+    [
+      { link: exact, linkOmitted: false },
+      { link: undefined, linkOmitted: true },
+      { link: undefined, linkOmitted: true },
+    ]
+  )
+  assert.deepEqual(
+    highlights.items.map(({ link, linkOmitted }) => ({ link, linkOmitted })),
+    [
+      { link: exact, linkOmitted: false },
+      { link: undefined, linkOmitted: true },
+      { link: undefined, linkOmitted: true },
+    ]
+  )
 })
 
 test("client scans Trash and accepts the Trash collection relation", async () => {

--- a/workers/raindrop-sync/test.ts
+++ b/workers/raindrop-sync/test.ts
@@ -1,0 +1,857 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { RateLimitError } from "@notionhq/workers"
+
+import { bookmarkToChange } from "./src/bookmarks.js"
+import { collectionToChange } from "./src/collections.js"
+import {
+  boundedText,
+  displayLabel,
+  highlightTitle,
+  NOTION_TEXT_LIMIT,
+  optionNames,
+  textWasTruncated,
+} from "./src/format.js"
+import { highlightToChange } from "./src/highlights.js"
+import worker from "./src/index.js"
+import { bookmarkKey, collectionKey, highlightKey } from "./src/keys.js"
+import {
+  createRaindropClient,
+  MAX_RESPONSE_BYTES,
+  PAGE_SIZE,
+  type RaindropBookmark,
+  type RaindropCollection,
+  type RaindropHighlight,
+} from "./src/raindrop.js"
+import {
+  bookmarkPageResult,
+  currentBookmarkPosition,
+  currentPage,
+  MAX_SYNC_RECORDS,
+  pageResult,
+  SYNC_STATE_VERSION,
+  type BookmarkSyncState,
+  type PageSyncState,
+} from "./src/sync-state.js"
+
+const accountId = 321
+
+const bookmark: RaindropBookmark = {
+  _id: 42,
+  title: "Workers worth reading",
+  link: "https://example.com/workers",
+  domain: "example.com",
+  excerpt: "A useful description.",
+  note: "Use this in the next project.",
+  type: "article",
+  tags: ["notion", "typescript"],
+  collection: { $id: 7 },
+  important: true,
+  broken: false,
+  created: "2026-06-01T10:00:00.000Z",
+  lastUpdate: "2026-06-02T11:00:00.000Z",
+  highlights: [{ _id: "highlight-1" }],
+}
+
+const highlight: RaindropHighlight = {
+  _id: "highlight-1",
+  raindropRef: 42,
+  text: "The agent decides when; your code determines how.",
+  note: "Strong positioning.",
+  color: "purple",
+  title: "Workers worth reading",
+  link: "https://example.com/workers",
+  tags: ["notion"],
+  created: "2026-06-01T10:05:00.000Z",
+}
+
+const collection: RaindropCollection = {
+  _id: 7,
+  title: "Developer tools",
+  count: 12,
+  public: false,
+  parentId: 3,
+  created: "2026-01-01T00:00:00.000Z",
+  lastUpdate: "2026-06-02T11:00:00.000Z",
+}
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers: HeadersInit = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  })
+}
+
+function bookmarkPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: bookmark._id,
+    title: bookmark.title,
+    link: bookmark.link,
+    domain: bookmark.domain,
+    excerpt: bookmark.excerpt,
+    note: bookmark.note,
+    type: bookmark.type,
+    tags: bookmark.tags,
+    collection: bookmark.collection,
+    important: bookmark.important,
+    broken: bookmark.broken,
+    created: bookmark.created,
+    lastUpdate: bookmark.lastUpdate,
+    highlights: bookmark.highlights,
+    ...overrides,
+  }
+}
+
+function highlightPayload(overrides: Record<string, unknown> = {}) {
+  return { ...highlight, ...overrides }
+}
+
+function collectionPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: collection._id,
+    title: collection.title,
+    count: collection.count,
+    public: collection.public,
+    parent: { $id: collection.parentId },
+    created: collection.created,
+    lastUpdate: collection.lastUpdate,
+    ...overrides,
+  }
+}
+
+function withAuthenticatedUser(dataFetch: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : String(input))
+    if (url.pathname === "/rest/v1/user") {
+      return jsonResponse({ result: true, user: { _id: accountId } })
+    }
+    return dataFetch(input, init)
+  }
+}
+
+async function captureError(
+  action: () => unknown | Promise<unknown>
+): Promise<unknown> {
+  try {
+    await action()
+  } catch (error) {
+    return error
+  }
+  assert.fail("expected action to throw")
+}
+
+function propertyIncludes(value: unknown, expected: string): boolean {
+  return JSON.stringify(value).includes(expected)
+}
+
+test("worker manifest declares account-scoped relation targets in dependency order", () => {
+  assert.deepEqual(
+    worker.manifest.databases.map((database) => ({
+      key: database.key,
+      title: database.config.initialTitle,
+      primaryKey: database.config.primaryKeyProperty,
+    })),
+    [
+      {
+        key: "collections",
+        title: "Raindrop.io Collections",
+        primaryKey: "Collection Key",
+      },
+      {
+        key: "bookmarks",
+        title: "Raindrop.io Bookmarks",
+        primaryKey: "Bookmark Key",
+      },
+      {
+        key: "highlights",
+        title: "Raindrop.io Highlights",
+        primaryKey: "Highlight Key",
+      },
+    ]
+  )
+})
+
+test("worker manifest uses non-destructive hourly scans behind one shared pacer", () => {
+  type SyncConfig = {
+    databaseKey: string
+    mode: string
+    schedule: { type: string; intervalMs: number }
+  }
+
+  assert.deepEqual(worker.manifest.pacers, [
+    {
+      key: "raindrop",
+      config: { allowedRequests: 100, intervalMs: 60_000 },
+    },
+  ])
+  assert.deepEqual(
+    worker.manifest.capabilities.map((capability) => {
+      assert.equal(capability._tag, "sync")
+      const config = capability.config as SyncConfig
+      return {
+        key: capability.key,
+        databaseKey: config.databaseKey,
+        mode: config.mode,
+        schedule: config.schedule,
+      }
+    }),
+    [
+      {
+        key: "collectionsSync",
+        databaseKey: "collections",
+        mode: "incremental",
+        schedule: { type: "interval", intervalMs: 60 * 60_000 },
+      },
+      {
+        key: "bookmarksSync",
+        databaseKey: "bookmarks",
+        mode: "incremental",
+        schedule: { type: "interval", intervalMs: 60 * 60_000 },
+      },
+      {
+        key: "highlightsSync",
+        databaseKey: "highlights",
+        mode: "incremental",
+        schedule: { type: "interval", intervalMs: 60 * 60_000 },
+      },
+    ]
+  )
+})
+
+test("resource keys are stable within an account and isolated across accounts and types", () => {
+  assert.equal(collectionKey(accountId, 42), "raindrop:321:collection:42")
+  assert.equal(bookmarkKey(accountId, 42), "raindrop:321:bookmark:42")
+  assert.equal(
+    highlightKey(accountId, "highlight-1"),
+    "raindrop:321:highlight:highlight-1"
+  )
+  assert.notEqual(bookmarkKey(accountId, 42), bookmarkKey(999, 42))
+  assert.notEqual(bookmarkKey(accountId, 42), collectionKey(accountId, 42))
+})
+
+test("bookmark transform scopes keys and relations while preserving raw IDs", () => {
+  const change = bookmarkToChange(accountId, bookmark, false)
+
+  assert.equal(change.key, "raindrop:321:bookmark:42")
+  assert.equal("upstreamUpdatedAt" in change, false)
+  assert.ok(propertyIncludes(change.properties.Title, "Workers worth reading"))
+  assert.ok(
+    propertyIncludes(change.properties.Collection, "raindrop:321:collection:7")
+  )
+  assert.ok(propertyIncludes(change.properties.Tags, "typescript"))
+  assert.ok(propertyIncludes(change.properties.Type, "Article"))
+  assert.ok(propertyIncludes(change.properties.Highlights, "1"))
+  assert.ok(propertyIncludes(change.properties.Created, "UTC"))
+  assert.ok(propertyIncludes(change.properties.Updated, "UTC"))
+  assert.ok(propertyIncludes(change.properties["Raindrop ID"], "42"))
+  assert.ok(propertyIncludes(change.properties["Raindrop Account ID"], "321"))
+  assert.ok(
+    propertyIncludes(
+      change.properties["Bookmark Key"],
+      "raindrop:321:bookmark:42"
+    )
+  )
+  assert.ok(propertyIncludes(change.properties["In Trash"], "No"))
+})
+
+test("trash and restored bookmark upserts use one key and explicitly flip In Trash", () => {
+  const trashedBookmark = {
+    ...bookmark,
+    collection: { $id: -99 },
+  }
+  const trashed = bookmarkToChange(accountId, trashedBookmark, true)
+  const restored = bookmarkToChange(accountId, bookmark, false)
+
+  assert.equal(trashed.key, restored.key)
+  assert.ok(propertyIncludes(trashed.properties["In Trash"], "Yes"))
+  assert.ok(propertyIncludes(restored.properties["In Trash"], "No"))
+  assert.ok(
+    propertyIncludes(
+      trashed.properties.Collection,
+      "raindrop:321:collection:-99"
+    )
+  )
+})
+
+test("bookmark transform clears optional values without owning page content", () => {
+  const change = bookmarkToChange(
+    accountId,
+    {
+      ...bookmark,
+      domain: "",
+      excerpt: "",
+      note: "",
+      tags: [],
+    },
+    false
+  )
+
+  assert.deepEqual(change.properties.Domain, [])
+  assert.deepEqual(change.properties.Excerpt, [])
+  assert.deepEqual(change.properties.Note, [])
+  assert.deepEqual(change.properties.Tags, [])
+  assert.equal("pageContentMarkdown" in change, false)
+})
+
+test("highlight transform scopes its key and bookmark relation", () => {
+  const change = highlightToChange(accountId, highlight)
+
+  assert.equal(change.key, "raindrop:321:highlight:highlight-1")
+  assert.ok(
+    propertyIncludes(change.properties.Bookmark, "raindrop:321:bookmark:42")
+  )
+  assert.ok(propertyIncludes(change.properties.Text, "agent decides when"))
+  assert.ok(propertyIncludes(change.properties.Color, "Purple"))
+  assert.ok(propertyIncludes(change.properties.Created, "UTC"))
+  assert.ok(propertyIncludes(change.properties["Highlight ID"], "highlight-1"))
+  assert.equal("pageContentMarkdown" in change, false)
+})
+
+test("collection transform scopes parent relations and exposes raw identity", () => {
+  const child = collectionToChange(accountId, collection)
+  const root = collectionToChange(accountId, {
+    ...collection,
+    _id: 3,
+    parentId: undefined,
+  })
+
+  assert.equal(child.key, "raindrop:321:collection:7")
+  assert.ok(
+    propertyIncludes(child.properties.Parent, "raindrop:321:collection:3")
+  )
+  assert.deepEqual(root.properties.Parent, [])
+  assert.ok(propertyIncludes(child.properties["Collection ID"], "7"))
+  assert.ok(propertyIncludes(child.properties.Created, "UTC"))
+  assert.ok(propertyIncludes(child.properties.Updated, "UTC"))
+  assert.equal("upstreamUpdatedAt" in child, false)
+})
+
+test("text helpers truncate by Unicode character and disclose truncation", () => {
+  const source = "🧠".repeat(NOTION_TEXT_LIMIT + 1)
+  const bounded = boundedText(source)
+
+  assert.equal(Array.from(bounded).length, NOTION_TEXT_LIMIT)
+  assert.equal(bounded.endsWith("…"), true)
+  assert.equal(textWasTruncated(source), true)
+  assert.equal(textWasTruncated("short"), false)
+  assert.equal(displayLabel("article"), "Article")
+  assert.equal(highlightTitle("a\n  b", "fallback"), "a b")
+})
+
+test("tag options are deterministic, comma-safe, and never silently dropped", () => {
+  assert.deepEqual(optionNames("bookmark tags", [" API ", "api", "a,b"]), [
+    "a，b",
+    "API",
+  ])
+  assert.equal(optionNames("bookmark tags", ["x".repeat(101)])[0].length, 100)
+  assert.throws(
+    () =>
+      optionNames(
+        "bookmark tags",
+        Array.from({ length: 101 }, (_, index) => `tag-${index}`)
+      ),
+    /supports at most 100/
+  )
+})
+
+test("highlight scan state pins account identity and advances full pages", () => {
+  const full = Array.from({ length: PAGE_SIZE })
+  const first = pageResult(undefined, accountId, full, ["change"], "highlights")
+  assert.deepEqual(first, {
+    changes: ["change"],
+    hasMore: true,
+    nextState: {
+      stateVersion: SYNC_STATE_VERSION,
+      accountId,
+      page: 1,
+    },
+  })
+  assert.deepEqual(
+    pageResult(
+      first.nextState,
+      accountId,
+      full.slice(1),
+      ["change"],
+      "highlights"
+    ),
+    { changes: ["change"], hasMore: false }
+  )
+  assert.throws(
+    () => currentPage(first.nextState, 999, "highlights"),
+    /account changed/
+  )
+})
+
+test("bookmark state scans active pages before Trash and then finishes", () => {
+  const full = Array.from({ length: PAGE_SIZE })
+  assert.deepEqual(currentBookmarkPosition(undefined, accountId), {
+    phase: "active",
+    page: 0,
+  })
+
+  const activeFull = bookmarkPageResult(undefined, accountId, "active", full, [
+    "active",
+  ])
+  assert.deepEqual(activeFull.nextState, {
+    stateVersion: SYNC_STATE_VERSION,
+    accountId,
+    phase: "active",
+    page: 1,
+  })
+
+  const activeEnd = bookmarkPageResult(
+    activeFull.nextState,
+    accountId,
+    "active",
+    [],
+    []
+  )
+  assert.deepEqual(activeEnd, {
+    changes: [],
+    hasMore: true,
+    nextState: {
+      stateVersion: SYNC_STATE_VERSION,
+      accountId,
+      phase: "trash",
+      page: 0,
+    },
+  })
+
+  const trashEnd = bookmarkPageResult(
+    activeEnd.nextState,
+    accountId,
+    "trash",
+    [{}],
+    ["trash"]
+  )
+  assert.deepEqual(trashEnd, { changes: ["trash"], hasMore: false })
+})
+
+test("scan state rejects corrupt, incompatible, changed-account, and over-limit state", () => {
+  const invalidPage = {
+    stateVersion: SYNC_STATE_VERSION,
+    accountId,
+    page: -1,
+  } satisfies PageSyncState
+  assert.throws(
+    () => currentPage(invalidPage, accountId, "highlights"),
+    /invalid page/
+  )
+  assert.throws(
+    () =>
+      currentPage(
+        { stateVersion: 99, accountId, page: 1 } as unknown as PageSyncState,
+        accountId,
+        "highlights"
+      ),
+    /incompatible/
+  )
+
+  const trashState = {
+    stateVersion: SYNC_STATE_VERSION,
+    accountId,
+    phase: "trash",
+    page: 0,
+  } satisfies BookmarkSyncState
+  assert.throws(
+    () => currentBookmarkPosition(trashState, 999),
+    /account changed/
+  )
+  assert.throws(
+    () =>
+      bookmarkPageResult(
+        { ...trashState, page: MAX_SYNC_RECORDS / PAGE_SIZE },
+        accountId,
+        "trash",
+        [{}],
+        []
+      ),
+    /exceeds 10000 records/
+  )
+})
+
+test("client fetches and validates the authenticated account ID", async () => {
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: async () =>
+      jsonResponse({ result: true, user: { _id: accountId } }),
+    getAccessToken: () => "test-token",
+  })
+
+  const session = await client.authenticate()
+  assert.equal(session.accountId, accountId)
+})
+
+test("authenticated sessions pin one token across identity and data requests", async () => {
+  let tokenReads = 0
+  const authorizationHeaders: Array<string | null> = []
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: async (input, init) => {
+      authorizationHeaders.push(new Headers(init?.headers).get("Authorization"))
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      return url.pathname === "/rest/v1/user"
+        ? jsonResponse({ result: true, user: { _id: accountId } })
+        : jsonResponse({ result: true, items: [bookmarkPayload()] })
+    },
+    getAccessToken: () => {
+      tokenReads += 1
+      return tokenReads === 1 ? "first-token" : "different-token"
+    },
+  })
+
+  const session = await client.authenticate()
+  await session.fetchBookmarksPage("active", 0)
+
+  assert.equal(tokenReads, 1)
+  assert.deepEqual(authorizationHeaders, [
+    "Bearer first-token",
+    "Bearer first-token",
+  ])
+})
+
+test("client sends bounded GET requests and sorts active bookmarks ascending", async () => {
+  const requests: Array<{
+    url: string
+    authorization: string | null
+    init: RequestInit | undefined
+  }> = []
+  let paced = 0
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input)
+    requests.push({
+      url,
+      authorization: new Headers(init?.headers).get("Authorization"),
+      init,
+    })
+    return jsonResponse({ result: true, items: [bookmarkPayload()] })
+  }
+  const client = createRaindropClient({
+    beforeRequest: async () => {
+      paced += 1
+    },
+    fetchImpl: withAuthenticatedUser(fetchImpl),
+    getAccessToken: () => "test-token",
+  })
+
+  const session = await client.authenticate()
+  const page = await session.fetchBookmarksPage("active", 2)
+
+  assert.equal(page.items[0]._id, 42)
+  assert.equal(paced, 2)
+  assert.equal(requests[0].authorization, "Bearer test-token")
+  const requestUrl = new URL(requests[0].url)
+  assert.equal(requestUrl.pathname, "/rest/v1/raindrops/0")
+  assert.equal(requestUrl.searchParams.get("sort"), "created")
+  assert.equal(requestUrl.searchParams.get("perpage"), "50")
+  assert.equal(requestUrl.searchParams.get("page"), "2")
+  assert.equal(requests[0].init?.method, "GET")
+  assert.equal(requests[0].init?.redirect, "error")
+  assert.ok(requests[0].init?.signal instanceof AbortSignal)
+})
+
+test("client normalizes provider timestamp offsets to UTC", async () => {
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ created: "2026-06-01T15:30:00+05:30" })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+
+  const session = await client.authenticate()
+  const page = await session.fetchBookmarksPage("active", 0)
+  assert.equal(page.items[0].created, "2026-06-01T10:00:00.000Z")
+})
+
+test("client scans Trash and accepts the Trash collection relation", async () => {
+  const paths: string[] = []
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      paths.push(String(input))
+      return jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ collection: { $id: -99 } })],
+      })
+    }),
+    getAccessToken: () => "test-token",
+  })
+
+  const session = await client.authenticate()
+  const page = await session.fetchBookmarksPage("trash", 0)
+  assert.equal(page.items[0].collection.$id, -99)
+  assert.equal(new URL(paths[0]).pathname, "/rest/v1/raindrops/-99")
+})
+
+test("client fetches root, child, Unsorted, and Trash collections", async () => {
+  const requestedPaths: string[] = []
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = new URL(input instanceof Request ? input.url : String(input))
+    requestedPaths.push(url.pathname)
+    return url.pathname.endsWith("/childrens")
+      ? jsonResponse({
+          result: true,
+          items: [collectionPayload({ _id: 8, parent: { $id: 7 } })],
+        })
+      : jsonResponse({ result: true, items: [collectionPayload()] })
+  }
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(fetchImpl),
+    getAccessToken: () => "test-token",
+  })
+
+  const session = await client.authenticate()
+  const collections = await session.fetchCollections()
+
+  assert.deepEqual(
+    collections.map((item) => item._id),
+    [-1, -99, 7, 8]
+  )
+  assert.deepEqual(requestedPaths.sort(), [
+    "/rest/v1/collections",
+    "/rest/v1/collections/childrens",
+  ])
+})
+
+test("client validates highlight references and the documented color enum", async () => {
+  const validClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({ result: true, items: [highlightPayload()] })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const validSession = await validClient.authenticate()
+  const page = await validSession.fetchHighlightsPage(0)
+  assert.equal(page.items[0].raindropRef, 42)
+  assert.equal(page.items[0].color, "purple")
+
+  const invalidClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [highlightPayload({ color: "ultraviolet" })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const invalidSession = await invalidClient.authenticate()
+  await assert.rejects(
+    invalidSession.fetchHighlightsPage(0),
+    /unsupported highlight color/
+  )
+})
+
+test("client rejects duplicate IDs and malformed provider values", async () => {
+  const duplicateClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload(), bookmarkPayload()],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const duplicateSession = await duplicateClient.authenticate()
+  await assert.rejects(
+    duplicateSession.fetchBookmarksPage("active", 0),
+    /duplicate bookmark ID/
+  )
+
+  const malformedClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ link: "javascript:alert(1)" })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const malformedSession = await malformedClient.authenticate()
+  await assert.rejects(
+    malformedSession.fetchBookmarksPage("active", 0),
+    /must use HTTP or HTTPS/
+  )
+})
+
+test("client bounds declared and streamed successful response bodies", async () => {
+  const declaredOversized = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({ result: true, items: [] }, 200, {
+        "Content-Length": String(MAX_RESPONSE_BYTES + 1),
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const declaredSession = await declaredOversized.authenticate()
+  await assert.rejects(
+    declaredSession.fetchBookmarksPage("active", 0),
+    /exceeded the allowed size/
+  )
+
+  const streamedOversized = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array(MAX_RESPONSE_BYTES + 1))
+              controller.close()
+            },
+          }),
+          { status: 200 }
+        )
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const streamedSession = await streamedOversized.authenticate()
+  await assert.rejects(
+    streamedSession.fetchHighlightsPage(0),
+    /exceeded the allowed size/
+  )
+
+  const invalidJsonClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(
+      async () => new Response("not json", { status: 200 })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const invalidJsonSession = await invalidJsonClient.authenticate()
+  await assert.rejects(
+    invalidJsonSession.fetchHighlightsPage(0),
+    /invalid JSON response/
+  )
+})
+
+test("client preserves Retry-After and X-RateLimit-Reset delays", async () => {
+  const retryAfterClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({ result: false }, 429, { "Retry-After": "17" })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const retryAfterSession = await retryAfterClient.authenticate()
+  const retryAfterError = await captureError(() =>
+    retryAfterSession.fetchHighlightsPage(0)
+  )
+  assert.ok(retryAfterError instanceof RateLimitError)
+  assert.equal(retryAfterError.retryAfter, 17)
+
+  const resetAt = Math.floor(Date.now() / 1_000) + 120
+  const resetClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({ result: false }, 429, {
+        "X-RateLimit-Reset": String(resetAt),
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const resetSession = await resetClient.authenticate()
+  const resetError = await captureError(() =>
+    resetSession.fetchHighlightsPage(0)
+  )
+  assert.ok(resetError instanceof RateLimitError)
+  const resetDelay = resetError.retryAfter
+  assert.ok(resetDelay !== undefined)
+  assert.ok(resetDelay >= 119 && resetDelay <= 120)
+})
+
+test("client times out hung requests without exposing transport details", async () => {
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    requestTimeoutMs: 5,
+    fetchImpl: async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        assert.ok(signal)
+        const guard = setTimeout(
+          () => reject(new Error("timeout signal did not fire")),
+          1_000
+        )
+        if (signal.aborted) {
+          clearTimeout(guard)
+          reject(signal.reason)
+          return
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(guard)
+            reject(signal.reason)
+          },
+          { once: true }
+        )
+      }),
+    getAccessToken: () => "test-token",
+  })
+
+  await assert.rejects(client.authenticate(), /timed out after 5ms/)
+})
+
+test("client reports invalid credentials without echoing provider content", async () => {
+  let bodyCancelled = false
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode('{"secret":"must-not-leak"}')
+            )
+          },
+          cancel() {
+            bodyCancelled = true
+          },
+        }),
+        { status: 401 }
+      ),
+    getAccessToken: () => "test-token",
+  })
+
+  await assert.rejects(
+    client.authenticate(),
+    (error: unknown) =>
+      error instanceof Error &&
+      /rejected RAINDROP_ACCESS_TOKEN/.test(error.message) &&
+      !error.message.includes("must-not-leak")
+  )
+  assert.equal(bodyCancelled, true)
+})
+
+test("client rejects an empty token before consuming a request slot", async () => {
+  let paced = false
+  let fetched = false
+  const client = createRaindropClient({
+    beforeRequest: async () => {
+      paced = true
+    },
+    fetchImpl: async () => {
+      fetched = true
+      return jsonResponse({ result: true, user: { _id: accountId } })
+    },
+    getAccessToken: () => "   ",
+  })
+
+  await assert.rejects(client.authenticate(), /is not set/)
+  assert.equal(paced, false)
+  assert.equal(fetched, false)
+})

--- a/workers/raindrop-sync/test.ts
+++ b/workers/raindrop-sync/test.ts
@@ -54,6 +54,7 @@ const bookmark: RaindropBookmark = {
   collection: { $id: 7 },
   important: true,
   broken: false,
+  reminderAt: "2026-06-10T15:00:00.000Z",
   created: "2026-06-01T10:00:00.000Z",
   lastUpdate: "2026-06-02T11:00:00.000Z",
   highlights: [{ _id: "highlight-1" }],
@@ -106,6 +107,7 @@ function bookmarkPayload(overrides: Record<string, unknown> = {}) {
     collection: bookmark.collection,
     important: bookmark.important,
     broken: bookmark.broken,
+    reminder: bookmark.reminderAt ? { data: bookmark.reminderAt } : undefined,
     created: bookmark.created,
     lastUpdate: bookmark.lastUpdate,
     highlights: bookmark.highlights,
@@ -186,7 +188,7 @@ test("schemas lead with the fields used to review and connect research", () => {
   assert.deepEqual(Object.keys(collectionSchema.properties).slice(0, 6), [
     "Name",
     "Parent",
-    "Bookmarks",
+    "Bookmark count",
     "Updated",
     "Last Seen",
     "Public",
@@ -195,9 +197,9 @@ test("schemas lead with the fields used to review and connect research", () => {
     "Title",
     "URL",
     "Collection",
+    "Reminder",
+    "Created",
     "Tags",
-    "Favorite",
-    "Updated",
   ])
   assert.deepEqual(Object.keys(highlightSchema.properties).slice(0, 6), [
     "Highlight",
@@ -207,6 +209,14 @@ test("schemas lead with the fields used to review and connect research", () => {
     "Tags",
     "Created",
   ])
+  assert.equal(
+    propertyIncludes(bookmarkSchema.properties.Collection, "Bookmarks"),
+    true
+  )
+  assert.equal(
+    propertyIncludes(highlightSchema.properties.Bookmark, "Highlights"),
+    true
+  )
 })
 
 test("worker manifest uses non-destructive hourly scans behind one shared pacer", () => {
@@ -278,7 +288,8 @@ test("bookmark transform scopes keys and relations while preserving raw IDs", ()
   )
   assert.ok(propertyIncludes(change.properties.Tags, "typescript"))
   assert.ok(propertyIncludes(change.properties.Type, "Article"))
-  assert.ok(propertyIncludes(change.properties.Highlights, "1"))
+  assert.ok(propertyIncludes(change.properties["Highlight count"], "1"))
+  assert.ok(propertyIncludes(change.properties.Reminder, "2026-06-10"))
   assert.ok(propertyIncludes(change.properties.Created, "UTC"))
   assert.ok(propertyIncludes(change.properties.Updated, "UTC"))
   assert.ok(propertyIncludes(change.properties["Last Seen"], "2026-07-03"))
@@ -322,6 +333,7 @@ test("bookmark transform clears optional values without owning page content", ()
       excerpt: "",
       note: "",
       tags: [],
+      reminderAt: undefined,
     },
     false,
     observedAt
@@ -331,6 +343,7 @@ test("bookmark transform clears optional values without owning page content", ()
   assert.deepEqual(change.properties.Excerpt, [])
   assert.deepEqual(change.properties.Note, [])
   assert.deepEqual(change.properties.Tags, [])
+  assert.deepEqual(change.properties.Reminder, [])
   assert.equal("pageContentMarkdown" in change, false)
 })
 
@@ -375,6 +388,7 @@ test("collection transform scopes parent relations and exposes raw identity", ()
   )
   assert.deepEqual(root.properties.Parent, [])
   assert.ok(propertyIncludes(child.properties["Collection ID"], "7"))
+  assert.ok(propertyIncludes(child.properties["Bookmark count"], "12"))
   assert.ok(propertyIncludes(child.properties.Created, "UTC"))
   assert.ok(propertyIncludes(child.properties.Updated, "UTC"))
   assert.ok(propertyIncludes(child.properties["Last Seen"], "2026-07-03"))
@@ -704,6 +718,7 @@ test("client sends bounded GET requests and sorts active bookmarks ascending", a
   const page = await session.fetchBookmarksPage("active", 2)
 
   assert.equal(page.items[0]._id, 42)
+  assert.equal(page.items[0].reminderAt, "2026-06-10T15:00:00.000Z")
   assert.equal(paced, 2)
   assert.equal(requests[0].authorization, "Bearer test-token")
   const requestUrl = new URL(requests[0].url)
@@ -722,7 +737,12 @@ test("client normalizes provider timestamp offsets to UTC", async () => {
     fetchImpl: withAuthenticatedUser(async () =>
       jsonResponse({
         result: true,
-        items: [bookmarkPayload({ created: "2026-06-01T15:30:00+05:30" })],
+        items: [
+          bookmarkPayload({
+            created: "2026-06-01T15:30:00+05:30",
+            reminder: { data: "2026-06-10T15:30:00+05:30" },
+          }),
+        ],
       })
     ),
     getAccessToken: () => "test-token",
@@ -731,6 +751,31 @@ test("client normalizes provider timestamp offsets to UTC", async () => {
   const session = await client.authenticate()
   const page = await session.fetchBookmarksPage("active", 0)
   assert.equal(page.items[0].created, "2026-06-01T10:00:00.000Z")
+  assert.equal(page.items[0].reminderAt, "2026-06-10T10:00:00.000Z")
+})
+
+test("client treats absent or null reminders as unscheduled", async () => {
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [
+          bookmarkPayload({ _id: 42, reminder: undefined }),
+          bookmarkPayload({ _id: 43, reminder: null }),
+        ],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+
+  const page = await (
+    await client.authenticate()
+  ).fetchBookmarksPage("active", 0)
+  assert.deepEqual(
+    page.items.map((item) => item.reminderAt),
+    [undefined, undefined]
+  )
 })
 
 test("client preserves 2,000-character URLs and omits longer links", async () => {
@@ -972,6 +1017,24 @@ test("client rejects duplicate IDs and malformed provider values", async () => {
   await assert.rejects(
     malformedSession.fetchBookmarksPage("active", 0),
     /must use HTTP or HTTPS/
+  )
+
+  const malformedReminderClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ reminder: {} })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await malformedReminderClient.authenticate()).fetchBookmarksPage(
+      "active",
+      0
+    ),
+    /reminder.data must be a string/
   )
 })
 

--- a/workers/raindrop-sync/test.ts
+++ b/workers/raindrop-sync/test.ts
@@ -3,17 +3,18 @@ import { test } from "node:test"
 
 import { RateLimitError } from "@notionhq/workers"
 
-import { bookmarkToChange } from "./src/bookmarks.js"
-import { collectionToChange } from "./src/collections.js"
+import { bookmarkSchema, bookmarkToChange } from "./src/bookmarks.js"
+import { collectionSchema, collectionToChange } from "./src/collections.js"
 import {
   boundedText,
   displayLabel,
   highlightTitle,
   NOTION_TEXT_LIMIT,
   optionNames,
+  TAG_OVERFLOW_SENTINEL,
   textWasTruncated,
 } from "./src/format.js"
-import { highlightToChange } from "./src/highlights.js"
+import { highlightSchema, highlightToChange } from "./src/highlights.js"
 import worker from "./src/index.js"
 import { bookmarkKey, collectionKey, highlightKey } from "./src/keys.js"
 import {
@@ -26,12 +27,13 @@ import {
   type RaindropHighlight,
 } from "./src/raindrop.js"
 import {
+  accountState,
   bookmarkPageResult,
   currentBookmarkPosition,
   currentPage,
   MAX_SYNC_RECORDS,
   pageResult,
-  SYNC_STATE_VERSION,
+  type AccountSyncState,
   type BookmarkSyncState,
   type PageSyncState,
 } from "./src/sync-state.js"
@@ -180,6 +182,33 @@ test("worker manifest declares account-scoped relation targets in dependency ord
   )
 })
 
+test("schemas lead with the fields used to review and connect research", () => {
+  assert.deepEqual(Object.keys(collectionSchema.properties).slice(0, 6), [
+    "Name",
+    "Parent",
+    "Bookmarks",
+    "Updated",
+    "Last Seen",
+    "Public",
+  ])
+  assert.deepEqual(Object.keys(bookmarkSchema.properties).slice(0, 6), [
+    "Title",
+    "URL",
+    "Collection",
+    "Tags",
+    "Favorite",
+    "Updated",
+  ])
+  assert.deepEqual(Object.keys(highlightSchema.properties).slice(0, 6), [
+    "Highlight",
+    "Bookmark",
+    "Text",
+    "Note",
+    "Tags",
+    "Created",
+  ])
+})
+
 test("worker manifest uses non-destructive hourly scans behind one shared pacer", () => {
   type SyncConfig = {
     databaseKey: string
@@ -319,6 +348,13 @@ test("highlight transform scopes its key and bookmark relation", () => {
   assert.ok(propertyIncludes(change.properties["Last Seen"], "12:34"))
   assert.ok(propertyIncludes(change.properties["Highlight ID"], "highlight-1"))
   assert.equal("pageContentMarkdown" in change, false)
+
+  const longBookmarkTitle = highlightToChange(
+    accountId,
+    { ...highlight, title: "🧠".repeat(NOTION_TEXT_LIMIT + 1) },
+    observedAt
+  )
+  assert.ok(propertyIncludes(longBookmarkTitle.properties.Truncated, "Yes"))
 })
 
 test("collection transform scopes parent relations and exposes raw identity", () => {
@@ -344,6 +380,13 @@ test("collection transform scopes parent relations and exposes raw identity", ()
   assert.ok(propertyIncludes(child.properties["Last Seen"], "2026-07-03"))
   assert.ok(propertyIncludes(child.properties["Last Seen"], "12:34"))
   assert.equal("upstreamUpdatedAt" in child, false)
+
+  const longTitle = collectionToChange(
+    accountId,
+    { ...collection, title: "🧠".repeat(NOTION_TEXT_LIMIT + 1) },
+    observedAt
+  )
+  assert.ok(propertyIncludes(longTitle.properties.Truncated, "Yes"))
 })
 
 test("omitted source URLs are disclosed without breaking transforms", () => {
@@ -378,21 +421,23 @@ test("omitted source URLs are disclosed without breaking transforms", () => {
   assert.ok(propertyIncludes(highlightChange.properties["URL Omitted"], "Yes"))
 })
 
-test("text helpers truncate by Unicode character and disclose truncation", () => {
+test("text helpers respect Unicode and UTF-16 limits", () => {
   const source = "🧠".repeat(NOTION_TEXT_LIMIT + 1)
   const bounded = boundedText(source)
 
-  assert.equal(Array.from(bounded).length, NOTION_TEXT_LIMIT)
+  assert.ok(Array.from(bounded).length <= NOTION_TEXT_LIMIT)
+  assert.ok(bounded.length <= NOTION_TEXT_LIMIT)
   assert.equal(bounded.endsWith("…"), true)
   assert.equal(textWasTruncated(source), true)
   assert.equal(textWasTruncated("short"), false)
+  assert.equal(boundedText("x".repeat(NOTION_TEXT_LIMIT + 1)).length, 2_000)
   assert.equal(displayLabel("article"), "Article")
   assert.equal(highlightTitle("a\n  b", "fallback"), "a b")
 })
 
 test("tag options deduplicate case variants and preserve normalization collisions", () => {
   const sourceTags = [" API ", "api", "a,b", "a，b"]
-  const normalized = optionNames("bookmark tags", sourceTags)
+  const normalized = optionNames(sourceTags)
 
   assert.equal(normalized.length, 3)
   assert.equal(normalized.includes("a，b"), true)
@@ -400,29 +445,24 @@ test("tag options deduplicate case variants and preserve normalization collision
     normalized.some((name) => /^a，b.*[0-9a-f]{12}$/.test(name)),
     true
   )
-  assert.deepEqual(
-    optionNames("bookmark tags", [...sourceTags].reverse()),
-    normalized
-  )
+  assert.deepEqual(optionNames([...sourceTags].reverse()), normalized)
   assert.equal(
     normalized.filter((name) => name.toLocaleLowerCase("en-US") === "api")
       .length,
     1
   )
   assert.equal(
-    normalized.every((name) => Array.from(name).length <= 100),
+    normalized.every(
+      (name) => Array.from(name).length <= 100 && name.length <= 100
+    ),
     true
   )
 
-  const generatedName = optionNames("bookmark tags", ["a,b", "a，b"]).find(
+  const generatedName = optionNames(["a,b", "a，b"]).find(
     (name) => name !== "a，b"
   )
   assert.ok(generatedName)
-  const naturalNameCollision = optionNames("bookmark tags", [
-    "a,b",
-    "a，b",
-    generatedName,
-  ])
+  const naturalNameCollision = optionNames(["a,b", "a，b", generatedName])
   assert.equal(naturalNameCollision.length, 3)
   assert.equal(naturalNameCollision.includes(generatedName), true)
   assert.equal(
@@ -431,18 +471,48 @@ test("tag options deduplicate case variants and preserve normalization collision
     3
   )
   assert.equal(
-    naturalNameCollision.every((name) => Array.from(name).length <= 100),
+    naturalNameCollision.every(
+      (name) => Array.from(name).length <= 100 && name.length <= 100
+    ),
     true
   )
 
-  assert.equal(optionNames("bookmark tags", ["x".repeat(101)])[0].length, 100)
-  assert.throws(
-    () =>
-      optionNames(
-        "bookmark tags",
-        Array.from({ length: 101 }, (_, index) => `tag-${index}`)
-      ),
-    /supports at most 100/
+  assert.equal(optionNames(["x".repeat(101)])[0].length, 100)
+  const emojiOption = optionNames(["🧠".repeat(100)])[0]
+  assert.ok(emojiOption.length <= 100)
+
+  const overflowInput = [
+    TAG_OVERFLOW_SENTINEL,
+    TAG_OVERFLOW_SENTINEL.toLocaleUpperCase("en-US"),
+    ...Array.from({ length: 105 }, (_, index) => `tag-${index}`),
+  ]
+  const overflow = optionNames(overflowInput)
+  assert.equal(overflow.length, 100)
+  assert.equal(
+    overflow.filter((name) => name === TAG_OVERFLOW_SENTINEL).length,
+    1
+  )
+  assert.equal(
+    overflow.filter(
+      (name) =>
+        name.toLocaleLowerCase("en-US") ===
+        TAG_OVERFLOW_SENTINEL.toLocaleLowerCase("en-US")
+    ).length,
+    1
+  )
+  assert.equal(
+    overflow.filter((name) => name !== TAG_OVERFLOW_SENTINEL).length,
+    99
+  )
+  assert.deepEqual(overflow, optionNames([...overflowInput].reverse()))
+
+  const pageChanges = [
+    { ...bookmark, tags: overflowInput },
+    { ...bookmark, _id: 43, tags: ["ordinary"] },
+  ].map((item) => bookmarkToChange(accountId, item, false, observedAt))
+  assert.deepEqual(
+    pageChanges.map((change) => change.key),
+    ["raindrop:321:bookmark:42", "raindrop:321:bookmark:43"]
   )
 })
 
@@ -453,7 +523,6 @@ test("highlight scan state pins account identity and advances full pages", () =>
     changes: ["change"],
     hasMore: true,
     nextState: {
-      stateVersion: SYNC_STATE_VERSION,
       accountId,
       page: 1,
     },
@@ -466,10 +535,14 @@ test("highlight scan state pins account identity and advances full pages", () =>
       ["change"],
       "highlights"
     ),
-    { changes: ["change"], hasMore: false }
+    {
+      changes: ["change"],
+      hasMore: false,
+      nextState: { accountId, page: 0 },
+    }
   )
   assert.throws(
-    () => currentPage(first.nextState, 999, "highlights"),
+    () => currentPage({ accountId, page: 0 }, 999, "highlights"),
     /account changed/
   )
 })
@@ -485,7 +558,6 @@ test("bookmark state scans active pages before Trash and then finishes", () => {
     "active",
   ])
   assert.deepEqual(activeFull.nextState, {
-    stateVersion: SYNC_STATE_VERSION,
     accountId,
     phase: "active",
     page: 1,
@@ -502,7 +574,6 @@ test("bookmark state scans active pages before Trash and then finishes", () => {
     changes: [],
     hasMore: true,
     nextState: {
-      stateVersion: SYNC_STATE_VERSION,
       accountId,
       phase: "trash",
       page: 0,
@@ -516,12 +587,19 @@ test("bookmark state scans active pages before Trash and then finishes", () => {
     [{}],
     ["trash"]
   )
-  assert.deepEqual(trashEnd, { changes: ["trash"], hasMore: false })
+  assert.deepEqual(trashEnd, {
+    changes: ["trash"],
+    hasMore: false,
+    nextState: { accountId, phase: "active", page: 0 },
+  })
+  assert.throws(
+    () => currentBookmarkPosition(trashEnd.nextState, 999),
+    /account changed/
+  )
 })
 
-test("scan state rejects corrupt, incompatible, changed-account, and over-limit state", () => {
+test("scan state remains account-bound and rejects corrupt or over-limit state", () => {
   const invalidPage = {
-    stateVersion: SYNC_STATE_VERSION,
     accountId,
     page: -1,
   } satisfies PageSyncState
@@ -529,18 +607,14 @@ test("scan state rejects corrupt, incompatible, changed-account, and over-limit 
     () => currentPage(invalidPage, accountId, "highlights"),
     /invalid page/
   )
+  const bound = accountState(undefined, accountId, "collections")
+  assert.deepEqual(bound, { accountId } satisfies AccountSyncState)
   assert.throws(
-    () =>
-      currentPage(
-        { stateVersion: 99, accountId, page: 1 } as unknown as PageSyncState,
-        accountId,
-        "highlights"
-      ),
-    /incompatible/
+    () => accountState(bound, 999, "collections"),
+    /account changed/
   )
 
   const trashState = {
-    stateVersion: SYNC_STATE_VERSION,
     accountId,
     phase: "trash",
     page: 0,
@@ -737,6 +811,35 @@ test("client scans Trash and accepts the Trash collection relation", async () =>
   assert.equal(new URL(paths[0]).pathname, "/rest/v1/raindrops/-99")
 })
 
+test("client rejects active and Trash collection mismatches", async () => {
+  const activeClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ collection: { $id: -99 } })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await activeClient.authenticate()).fetchBookmarksPage("active", 0),
+    /active response returned a bookmark from Trash/
+  )
+
+  const trashClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({ result: true, items: [bookmarkPayload()] })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await trashClient.authenticate()).fetchBookmarksPage("trash", 0),
+    /Trash response returned a bookmark outside Trash/
+  )
+})
+
 test("client fetches root, child, Unsorted, and Trash collections", async () => {
   const requestedPaths: string[] = []
   const fetchImpl: typeof fetch = async (input) => {
@@ -747,7 +850,10 @@ test("client fetches root, child, Unsorted, and Trash collections", async () => 
           result: true,
           items: [collectionPayload({ _id: 8, parent: { $id: 7 } })],
         })
-      : jsonResponse({ result: true, items: [collectionPayload()] })
+      : jsonResponse({
+          result: true,
+          items: [collectionPayload({ parent: null })],
+        })
   }
   const client = createRaindropClient({
     beforeRequest: async () => undefined,
@@ -766,6 +872,43 @@ test("client fetches root, child, Unsorted, and Trash collections", async () => 
     "/rest/v1/collections",
     "/rest/v1/collections/childrens",
   ])
+})
+
+test("collection endpoints enforce root and child parent scopes", async () => {
+  const childClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      return url.pathname.endsWith("/childrens")
+        ? jsonResponse({
+            result: true,
+            items: [collectionPayload({ parent: null })],
+          })
+        : jsonResponse({ result: true, items: [] })
+    }),
+    getAccessToken: () => "test-token",
+  })
+
+  await assert.rejects(
+    (await childClient.authenticate()).fetchCollections(),
+    /parent is required for a child/
+  )
+
+  const rootClient = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      return url.pathname.endsWith("/childrens")
+        ? jsonResponse({ result: true, items: [] })
+        : jsonResponse({ result: true, items: [collectionPayload()] })
+    }),
+    getAccessToken: () => "test-token",
+  })
+
+  await assert.rejects(
+    (await rootClient.authenticate()).fetchCollections(),
+    /parent must be absent for a root/
+  )
 })
 
 test("client validates highlight references and the documented color enum", async () => {
@@ -829,6 +972,56 @@ test("client rejects duplicate IDs and malformed provider values", async () => {
   await assert.rejects(
     malformedSession.fetchBookmarksPage("active", 0),
     /must use HTTP or HTTPS/
+  )
+})
+
+test("client requires arrays that drive bookmark and highlight fields", async () => {
+  const missingBookmarkTags = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ tags: undefined })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await missingBookmarkTags.authenticate()).fetchBookmarksPage("active", 0),
+    /bookmark.*tags must be an array/
+  )
+
+  const missingEmbeddedHighlights = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ highlights: undefined })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await missingEmbeddedHighlights.authenticate()).fetchBookmarksPage(
+      "active",
+      0
+    ),
+    /bookmark.*highlights must be an array/
+  )
+
+  const missingHighlightTags = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [highlightPayload({ tags: undefined })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await missingHighlightTags.authenticate()).fetchHighlightsPage(0),
+    /highlight.*tags must be an array/
   )
 })
 

--- a/workers/raindrop-sync/test.ts
+++ b/workers/raindrop-sync/test.ts
@@ -19,9 +19,11 @@ import worker from "./src/index.js"
 import { bookmarkKey, collectionKey, highlightKey } from "./src/keys.js"
 import {
   createRaindropClient,
+  MAX_COLLECTIONS,
   MAX_RESPONSE_BYTES,
   NOTION_URL_LIMIT,
   PAGE_SIZE,
+  PAGES_PER_SYNC_EXECUTION,
   type RaindropBookmark,
   type RaindropCollection,
   type RaindropHighlight,
@@ -40,6 +42,7 @@ import {
 
 const accountId = 321
 const observedAt = "2026-07-03T12:34:56.000Z"
+process.env.RAINDROP_ACCOUNT_ID = String(accountId)
 
 const bookmark: RaindropBookmark = {
   _id: 42,
@@ -58,6 +61,10 @@ const bookmark: RaindropBookmark = {
   created: "2026-06-01T10:00:00.000Z",
   lastUpdate: "2026-06-02T11:00:00.000Z",
   highlights: [{ _id: "highlight-1" }],
+  contributor: {
+    id: 654,
+    fullName: "Ada Reader",
+  },
 }
 
 const highlight: RaindropHighlight = {
@@ -78,7 +85,11 @@ const collection: RaindropCollection = {
   title: "Developer tools",
   count: 12,
   public: false,
+  ownerId: accountId,
+  accessLevel: 4,
+  shared: false,
   parentId: 3,
+  parentAvailable: true,
   created: "2026-01-01T00:00:00.000Z",
   lastUpdate: "2026-06-02T11:00:00.000Z",
 }
@@ -111,6 +122,12 @@ function bookmarkPayload(overrides: Record<string, unknown> = {}) {
     created: bookmark.created,
     lastUpdate: bookmark.lastUpdate,
     highlights: bookmark.highlights,
+    creatorRef: bookmark.contributor
+      ? {
+          _id: bookmark.contributor.id,
+          fullName: bookmark.contributor.fullName,
+        }
+      : undefined,
     ...overrides,
   }
 }
@@ -125,6 +142,8 @@ function collectionPayload(overrides: Record<string, unknown> = {}) {
     title: collection.title,
     count: collection.count,
     public: collection.public,
+    user: { $id: collection.ownerId },
+    access: { level: collection.accessLevel },
     parent: { $id: collection.parentId },
     created: collection.created,
     lastUpdate: collection.lastUpdate,
@@ -191,7 +210,7 @@ test("schemas lead with the fields used to review and connect research", () => {
     "Bookmark count",
     "Updated",
     "Last Seen",
-    "Public",
+    "Raindrop access",
   ])
   assert.deepEqual(Object.keys(bookmarkSchema.properties).slice(0, 6), [
     "Title",
@@ -303,6 +322,12 @@ test("bookmark transform scopes keys and relations while preserving raw IDs", ()
     )
   )
   assert.ok(propertyIncludes(change.properties["In Trash"], "No"))
+  assert.ok(
+    propertyIncludes(change.properties["Raindrop contributor"], "Ada Reader")
+  )
+  assert.ok(
+    propertyIncludes(change.properties["Raindrop contributor ID"], "654")
+  )
 })
 
 test("trash and restored bookmark upserts use one key and explicitly flip In Trash", () => {
@@ -334,6 +359,7 @@ test("bookmark transform clears optional values without owning page content", ()
       note: "",
       tags: [],
       reminderAt: undefined,
+      contributor: undefined,
     },
     false,
     observedAt
@@ -344,6 +370,8 @@ test("bookmark transform clears optional values without owning page content", ()
   assert.deepEqual(change.properties.Note, [])
   assert.deepEqual(change.properties.Tags, [])
   assert.deepEqual(change.properties.Reminder, [])
+  assert.deepEqual(change.properties["Raindrop contributor"], [])
+  assert.deepEqual(change.properties["Raindrop contributor ID"], [])
   assert.equal("pageContentMarkdown" in change, false)
 })
 
@@ -386,14 +414,46 @@ test("collection transform scopes parent relations and exposes raw identity", ()
   assert.ok(
     propertyIncludes(child.properties.Parent, "raindrop:321:collection:3")
   )
+  assert.ok(propertyIncludes(child.properties["Parent ID"], "3"))
+  assert.ok(propertyIncludes(child.properties["Parent unavailable"], "No"))
   assert.deepEqual(root.properties.Parent, [])
   assert.ok(propertyIncludes(child.properties["Collection ID"], "7"))
   assert.ok(propertyIncludes(child.properties["Bookmark count"], "12"))
+  assert.ok(propertyIncludes(child.properties["Raindrop access"], "Owner"))
+  assert.ok(
+    propertyIncludes(child.properties["Raindrop Owner ID"], String(accountId))
+  )
+  assert.ok(propertyIncludes(child.properties["Shared in Raindrop"], "No"))
+  assert.ok(propertyIncludes(child.properties["Public in Raindrop"], "No"))
   assert.ok(propertyIncludes(child.properties.Created, "UTC"))
   assert.ok(propertyIncludes(child.properties.Updated, "UTC"))
   assert.ok(propertyIncludes(child.properties["Last Seen"], "2026-07-03"))
   assert.ok(propertyIncludes(child.properties["Last Seen"], "12:34"))
   assert.equal("upstreamUpdatedAt" in child, false)
+
+  const shared = collectionToChange(
+    accountId,
+    { ...collection, accessLevel: 2, shared: true },
+    observedAt
+  )
+  assert.ok(
+    propertyIncludes(shared.properties["Raindrop access"], "Collaborator: view")
+  )
+  assert.ok(propertyIncludes(shared.properties["Shared in Raindrop"], "Yes"))
+
+  const system = collectionToChange(
+    accountId,
+    {
+      _id: -1,
+      title: "Unsorted",
+      public: false,
+      shared: false,
+      parentAvailable: true,
+    },
+    observedAt
+  )
+  assert.deepEqual(system.properties["Raindrop access"], [])
+  assert.deepEqual(system.properties["Raindrop Owner ID"], [])
 
   const longTitle = collectionToChange(
     accountId,
@@ -530,27 +590,48 @@ test("tag options deduplicate case variants and preserve normalization collision
   )
 })
 
-test("highlight scan state pins account identity and advances full pages", () => {
-  const full = Array.from({ length: PAGE_SIZE })
-  const first = pageResult(undefined, accountId, full, ["change"], "highlights")
-  assert.deepEqual(first, {
-    changes: ["change"],
-    hasMore: true,
-    nextState: {
-      accountId,
-      page: 1,
-    },
-  })
+test("highlight state advances three pages and preserves a bounded drift guard", () => {
+  const firstPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `h-${index}`
+  )
+  const secondPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `h-${PAGE_SIZE + index}`
+  )
+  const thirdPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `h-${PAGE_SIZE * 2 + index}`
+  )
+  const changes = [...firstPage, ...secondPage, ...thirdPage]
+  const first = pageResult(
+    undefined,
+    accountId,
+    [firstPage, secondPage, thirdPage],
+    changes,
+    "highlights"
+  )
+  assert.equal(first.hasMore, true)
+  assert.equal(first.nextState.page, PAGES_PER_SYNC_EXECUTION)
+  assert.equal(first.nextState.guard?.firstPageDigest?.length, 64)
+  assert.equal(
+    first.nextState.guard?.previousPageFingerprints?.length,
+    PAGE_SIZE
+  )
+  assert.ok(JSON.stringify(first.nextState).length < 8 * 1_024)
+
+  const finalIds = ["h-150"]
   assert.deepEqual(
     pageResult(
       first.nextState,
       accountId,
-      full.slice(1),
-      ["change"],
-      "highlights"
+      [finalIds],
+      finalIds,
+      "highlights",
+      [...firstPage].reverse()
     ),
     {
-      changes: ["change"],
+      changes: finalIds,
       hasMore: false,
       nextState: { accountId, page: 0 },
     }
@@ -561,31 +642,47 @@ test("highlight scan state pins account identity and advances full pages", () =>
   )
 })
 
-test("bookmark state scans active pages before Trash and then finishes", () => {
-  const full = Array.from({ length: PAGE_SIZE })
+test("bookmark state scans three active pages before Trash and then finishes", () => {
+  const firstPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `b-${index}`
+  )
+  const secondPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `b-${PAGE_SIZE + index}`
+  )
+  const thirdPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `b-${PAGE_SIZE * 2 + index}`
+  )
   assert.deepEqual(currentBookmarkPosition(undefined, accountId), {
     phase: "active",
     page: 0,
   })
 
-  const activeFull = bookmarkPageResult(undefined, accountId, "active", full, [
-    "active",
-  ])
-  assert.deepEqual(activeFull.nextState, {
+  const activeChanges = [...firstPage, ...secondPage, ...thirdPage]
+  const activeFull = bookmarkPageResult(
+    undefined,
     accountId,
-    phase: "active",
-    page: 1,
-  })
+    "active",
+    [firstPage, secondPage, thirdPage],
+    activeChanges
+  )
+  assert.equal(activeFull.hasMore, true)
+  assert.equal(activeFull.nextState.phase, "active")
+  assert.equal(activeFull.nextState.page, PAGES_PER_SYNC_EXECUTION)
 
+  const activeFinalIds = ["b-150"]
   const activeEnd = bookmarkPageResult(
     activeFull.nextState,
     accountId,
     "active",
-    [],
-    []
+    [activeFinalIds],
+    activeFinalIds,
+    firstPage
   )
   assert.deepEqual(activeEnd, {
-    changes: [],
+    changes: activeFinalIds,
     hasMore: true,
     nextState: {
       accountId,
@@ -594,21 +691,252 @@ test("bookmark state scans active pages before Trash and then finishes", () => {
     },
   })
 
+  const trashIds = ["trash-1"]
   const trashEnd = bookmarkPageResult(
     activeEnd.nextState,
     accountId,
     "trash",
-    [{}],
-    ["trash"]
+    [trashIds],
+    trashIds,
+    trashIds
   )
   assert.deepEqual(trashEnd, {
-    changes: ["trash"],
+    changes: trashIds,
     hasMore: false,
     nextState: { accountId, phase: "active", page: 0 },
   })
   assert.throws(
     () => currentBookmarkPosition(trashEnd.nextState, 999),
     /account changed/
+  )
+})
+
+test("pagination drift restarts once without permanently stranding state", () => {
+  const firstPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `d-${index}`
+  )
+  const shiftedPage = [
+    firstPage.at(-1)!,
+    ...Array.from({ length: PAGE_SIZE - 1 }, (_, index) => `e-${index}`),
+  ]
+  const thirdPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `f-${index}`
+  )
+  const changes = [...firstPage, ...shiftedPage, ...thirdPage]
+  const restarted = pageResult(
+    undefined,
+    accountId,
+    [firstPage, shiftedPage, thirdPage],
+    changes,
+    "highlights"
+  )
+  assert.deepEqual(restarted, {
+    changes: [],
+    hasMore: true,
+    nextState: {
+      accountId,
+      page: 0,
+      guard: { restartUsed: true },
+    },
+  })
+
+  const continued = pageResult(
+    restarted.nextState,
+    accountId,
+    [firstPage, shiftedPage, thirdPage],
+    changes,
+    "highlights"
+  )
+  assert.equal(continued.hasMore, true)
+  assert.equal(continued.changes.length, PAGE_SIZE * 3)
+  assert.equal(continued.nextState.page, 3)
+  assert.equal(continued.nextState.guard?.restartUsed, true)
+})
+
+test("terminal page-zero drift uses the same single bounded restart", () => {
+  const firstPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `p-${index}`
+  )
+  const secondPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `q-${index}`
+  )
+  const thirdPage = Array.from(
+    { length: PAGE_SIZE },
+    (_, index) => `r-${index}`
+  )
+  const first = pageResult(
+    undefined,
+    accountId,
+    [firstPage, secondPage, thirdPage],
+    [...firstPage, ...secondPage, ...thirdPage],
+    "highlights"
+  )
+  const drifted = pageResult(
+    first.nextState,
+    accountId,
+    [[]],
+    [],
+    "highlights",
+    [...firstPage.slice(1), "new-id"]
+  )
+  assert.deepEqual(drifted, {
+    changes: [],
+    hasMore: true,
+    nextState: {
+      accountId,
+      page: 0,
+      guard: { restartUsed: true },
+    },
+  })
+
+  const restartedFull = pageResult(
+    drifted.nextState,
+    accountId,
+    [firstPage, secondPage, thirdPage],
+    [...firstPage, ...secondPage, ...thirdPage],
+    "highlights"
+  )
+  const completedBestEffort = pageResult(
+    restartedFull.nextState,
+    accountId,
+    [[]],
+    [],
+    "highlights",
+    [...firstPage.slice(1), "another-new-id"]
+  )
+  assert.deepEqual(completedBestEffort, {
+    changes: [],
+    hasMore: false,
+    nextState: { accountId, page: 0 },
+  })
+})
+
+test("bookmark drift allowance resets between active and Trash", () => {
+  const sameId = ["bookmark-1"]
+  const activeEnd = bookmarkPageResult(
+    undefined,
+    accountId,
+    "active",
+    [sameId],
+    sameId,
+    sameId
+  )
+  assert.deepEqual(activeEnd.nextState, {
+    accountId,
+    phase: "trash",
+    page: 0,
+  })
+
+  const trashEnd = bookmarkPageResult(
+    activeEnd.nextState,
+    accountId,
+    "trash",
+    [sameId],
+    sameId,
+    sameId
+  )
+  assert.deepEqual(trashEnd, {
+    changes: sameId,
+    hasMore: false,
+    nextState: { accountId, phase: "active", page: 0 },
+  })
+})
+
+test("maximum inventories stay inside Worker execution and output budgets", () => {
+  const providerPagesIncludingEmptyProbe = MAX_SYNC_RECORDS / PAGE_SIZE + 1
+  const paginatedExecutions = Math.ceil(
+    providerPagesIncludingEmptyProbe / PAGES_PER_SYNC_EXECUTION
+  )
+  const stableCycleExecutions = 1 + paginatedExecutions * 3
+  const cycleWithEveryBoundedRestart =
+    stableCycleExecutions + paginatedExecutions * 3
+  assert.equal(stableCycleExecutions, 202)
+  assert.equal(cycleWithEveryBoundedRestart, 403)
+  assert.ok(cycleWithEveryBoundedRestart < 600)
+
+  const largestCollectionBatch = Array.from(
+    { length: MAX_COLLECTIONS + 2 },
+    (_, index) =>
+      collectionToChange(
+        accountId,
+        {
+          ...collection,
+          _id: index + 1,
+          title: "x".repeat(NOTION_TEXT_LIMIT),
+        },
+        observedAt
+      )
+  )
+  assert.ok(
+    Buffer.byteLength(JSON.stringify({ changes: largestCollectionBatch })) <
+      10 * 1_024 * 1_024
+  )
+
+  const maximalTags = Array.from(
+    { length: 100 },
+    (_, index) => `${index}-${"t".repeat(95)}`
+  )
+  const largestBookmarkBatch = Array.from(
+    { length: PAGE_SIZE * PAGES_PER_SYNC_EXECUTION },
+    (_, index) =>
+      bookmarkToChange(
+        accountId,
+        {
+          ...bookmark,
+          _id: index + 1,
+          title: "x".repeat(NOTION_TEXT_LIMIT),
+          note: "n".repeat(NOTION_TEXT_LIMIT),
+          excerpt: "e".repeat(NOTION_TEXT_LIMIT),
+          tags: maximalTags,
+          contributor: {
+            id: 654,
+            fullName: "a".repeat(NOTION_TEXT_LIMIT),
+          },
+        },
+        false,
+        observedAt
+      )
+  )
+  assert.ok(
+    Buffer.byteLength(
+      JSON.stringify({
+        changes: largestBookmarkBatch,
+        hasMore: true,
+        nextState: { accountId, phase: "active", page: 3 },
+      })
+    ) <
+      10 * 1_024 * 1_024
+  )
+
+  const largestHighlightBatch = Array.from(
+    { length: PAGE_SIZE * PAGES_PER_SYNC_EXECUTION },
+    (_, index) =>
+      highlightToChange(
+        accountId,
+        {
+          ...highlight,
+          _id: `highlight-${index}`,
+          text: "t".repeat(NOTION_TEXT_LIMIT),
+          note: "n".repeat(NOTION_TEXT_LIMIT),
+          title: "b".repeat(NOTION_TEXT_LIMIT),
+          tags: maximalTags,
+        },
+        observedAt
+      )
+  )
+  assert.ok(
+    Buffer.byteLength(
+      JSON.stringify({
+        changes: largestHighlightBatch,
+        hasMore: true,
+        nextState: { accountId, page: 3 },
+      })
+    ) <
+      10 * 1_024 * 1_024
   )
 })
 
@@ -621,13 +949,25 @@ test("scan state remains account-bound and rejects corrupt or over-limit state",
     () => currentPage(invalidPage, accountId, "highlights"),
     /invalid page/
   )
+  assert.throws(
+    () =>
+      currentPage(
+        {
+          accountId,
+          page: 0,
+          guard: { previousPageFingerprints: ["not-a-fingerprint"] },
+        },
+        accountId,
+        "highlights"
+      ),
+    /invalid page fingerprints/
+  )
   const bound = accountState(undefined, accountId, "collections")
   assert.deepEqual(bound, { accountId } satisfies AccountSyncState)
   assert.throws(
     () => accountState(bound, 999, "collections"),
     /account changed/
   )
-
   const trashState = {
     accountId,
     phase: "trash",
@@ -643,8 +983,8 @@ test("scan state remains account-bound and rejects corrupt or over-limit state",
         { ...trashState, page: MAX_SYNC_RECORDS / PAGE_SIZE },
         accountId,
         "trash",
-        [{}],
-        []
+        [["over-limit"]],
+        ["over-limit"]
       ),
     /exceeds 10000 records/
   )
@@ -660,6 +1000,38 @@ test("client fetches and validates the authenticated account ID", async () => {
 
   const session = await client.authenticate()
   assert.equal(session.accountId, accountId)
+})
+
+test("client enforces one deployment-wide Raindrop account", async () => {
+  let requests = 0
+  const mismatched = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: async () => {
+      requests += 1
+      return jsonResponse({ result: true, user: { _id: accountId } })
+    },
+    getAccessToken: () => "test-token",
+    getExpectedAccountId: () => 999,
+  })
+  await assert.rejects(
+    mismatched.authenticate(),
+    /different account than RAINDROP_ACCOUNT_ID/
+  )
+  assert.equal(requests, 1)
+
+  let paced = false
+  const invalid = createRaindropClient({
+    beforeRequest: async () => {
+      paced = true
+    },
+    fetchImpl: async () => {
+      assert.fail("invalid account configuration must fail before fetch")
+    },
+    getAccessToken: () => "test-token",
+    getExpectedAccountId: () => 0,
+  })
+  await assert.rejects(invalid.authenticate(), /positive integer account ID/)
+  assert.equal(paced, false)
 })
 
 test("authenticated sessions pin one token across identity and data requests", async () => {
@@ -719,6 +1091,10 @@ test("client sends bounded GET requests and sorts active bookmarks ascending", a
 
   assert.equal(page.items[0]._id, 42)
   assert.equal(page.items[0].reminderAt, "2026-06-10T15:00:00.000Z")
+  assert.deepEqual(page.items[0].contributor, {
+    id: 654,
+    fullName: "Ada Reader",
+  })
   assert.equal(paced, 2)
   assert.equal(requests[0].authorization, "Bearer test-token")
   const requestUrl = new URL(requests[0].url)
@@ -729,6 +1105,63 @@ test("client sends bounded GET requests and sorts active bookmarks ascending", a
   assert.equal(requests[0].init?.method, "GET")
   assert.equal(requests[0].init?.redirect, "error")
   assert.ok(requests[0].init?.signal instanceof AbortSignal)
+})
+
+test("client fetches up to three provider pages per Worker execution", async () => {
+  const pages: string[] = []
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      const page = url.searchParams.get("page") ?? "0"
+      pages.push(page)
+      const items =
+        page === "4" || page === "5"
+          ? Array.from({ length: PAGE_SIZE }, (_, index) =>
+              bookmarkPayload({ _id: Number(page) * 1_000 + index })
+            )
+          : [bookmarkPayload({ _id: 6_000 })]
+      return jsonResponse({ result: true, items })
+    }),
+    getAccessToken: () => "test-token",
+  })
+
+  const batch = await (
+    await client.authenticate()
+  ).fetchBookmarksBatch("active", 4)
+  assert.deepEqual(pages, ["4", "5", "6"])
+  assert.deepEqual(
+    batch.pages.map((page) => page.length),
+    [PAGE_SIZE, PAGE_SIZE, 1]
+  )
+  assert.equal(batch.items.length, PAGE_SIZE * 2 + 1)
+})
+
+test("client never requests beyond the terminal record-cap probe", async () => {
+  const pages: string[] = []
+  const client = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      pages.push(url.searchParams.get("page") ?? "0")
+      return jsonResponse({
+        result: true,
+        items: Array.from({ length: PAGE_SIZE }, (_, index) =>
+          highlightPayload({ _id: `over-limit-${index}` })
+        ),
+      })
+    }),
+    getAccessToken: () => "test-token",
+  })
+
+  const batch = await (
+    await client.authenticate()
+  ).fetchHighlightsBatch(MAX_SYNC_RECORDS / PAGE_SIZE)
+  assert.deepEqual(pages, [String(MAX_SYNC_RECORDS / PAGE_SIZE)])
+  assert.deepEqual(
+    batch.pages.map((page) => page.length),
+    [PAGE_SIZE]
+  )
 })
 
 test("client normalizes provider timestamp offsets to UTC", async () => {
@@ -893,7 +1326,14 @@ test("client fetches root, child, Unsorted, and Trash collections", async () => 
     return url.pathname.endsWith("/childrens")
       ? jsonResponse({
           result: true,
-          items: [collectionPayload({ _id: 8, parent: { $id: 7 } })],
+          items: [
+            collectionPayload({
+              _id: 8,
+              parent: { $id: 7 },
+              access: { level: 2 },
+              collaborators: {},
+            }),
+          ],
         })
       : jsonResponse({
           result: true,
@@ -912,6 +1352,19 @@ test("client fetches root, child, Unsorted, and Trash collections", async () => 
   assert.deepEqual(
     collections.map((item) => item._id),
     [-1, -99, 7, 8]
+  )
+  assert.deepEqual(
+    collections.map(({ ownerId, accessLevel, shared }) => ({
+      ownerId,
+      accessLevel,
+      shared,
+    })),
+    [
+      { ownerId: undefined, accessLevel: undefined, shared: false },
+      { ownerId: undefined, accessLevel: undefined, shared: false },
+      { ownerId: accountId, accessLevel: 4, shared: false },
+      { ownerId: accountId, accessLevel: 2, shared: true },
+    ]
   )
   assert.deepEqual(requestedPaths.sort(), [
     "/rest/v1/collections",
@@ -954,6 +1407,114 @@ test("collection endpoints enforce root and child parent scopes", async () => {
     (await rootClient.authenticate()).fetchCollections(),
     /parent must be absent for a root/
   )
+})
+
+test("collection inventory marks unavailable parents, rejects cycles, and stays bounded", async () => {
+  function clientForCollections(rootItems: unknown[], childItems: unknown[]) {
+    return createRaindropClient({
+      beforeRequest: async () => undefined,
+      fetchImpl: withAuthenticatedUser(async (input) => {
+        const url = new URL(
+          input instanceof Request ? input.url : String(input)
+        )
+        return jsonResponse({
+          result: true,
+          items: url.pathname.endsWith("/childrens") ? childItems : rootItems,
+        })
+      }),
+      getAccessToken: () => "test-token",
+    })
+  }
+
+  const missingParent = clientForCollections(
+    [],
+    [collectionPayload({ _id: 8, parent: { $id: 999 } })]
+  )
+  const missingParentItems = await (
+    await missingParent.authenticate()
+  ).fetchCollections()
+  const orphan = missingParentItems.find((item) => item._id === 8)
+  assert.equal(orphan?.parentId, 999)
+  assert.equal(orphan?.parentAvailable, false)
+  const orphanChange = collectionToChange(accountId, orphan!, observedAt)
+  assert.deepEqual(orphanChange.properties.Parent, [])
+  assert.ok(propertyIncludes(orphanChange.properties["Parent ID"], "999"))
+  assert.ok(
+    propertyIncludes(orphanChange.properties["Parent unavailable"], "Yes")
+  )
+
+  const cycle = clientForCollections(
+    [],
+    [
+      collectionPayload({ _id: 8, parent: { $id: 9 } }),
+      collectionPayload({ _id: 9, parent: { $id: 8 } }),
+    ]
+  )
+  await assert.rejects(
+    (await cycle.authenticate()).fetchCollections(),
+    /cyclic collection hierarchy/
+  )
+
+  const oversized = clientForCollections(
+    Array.from({ length: MAX_COLLECTIONS + 1 }, (_, index) =>
+      collectionPayload({ _id: index + 1, parent: null })
+    ),
+    []
+  )
+  await assert.rejects(
+    (await oversized.authenticate()).fetchCollections(),
+    /more than 1000 collections/
+  )
+})
+
+test("client fails closed on malformed collaboration provenance", async () => {
+  const malformedCollection = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      return url.pathname.endsWith("/childrens")
+        ? jsonResponse({ result: true, items: [] })
+        : jsonResponse({
+            result: true,
+            items: [collectionPayload({ collaborators: null })],
+          })
+    }),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await malformedCollection.authenticate()).fetchCollections(),
+    /collaborators must be an object/
+  )
+
+  const malformedAuthor = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ creatorRef: { _id: 654 } })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  await assert.rejects(
+    (await malformedAuthor.authenticate()).fetchBookmarksPage("active", 0),
+    /creatorRef.fullName must be a string/
+  )
+
+  const absentAuthor = createRaindropClient({
+    beforeRequest: async () => undefined,
+    fetchImpl: withAuthenticatedUser(async () =>
+      jsonResponse({
+        result: true,
+        items: [bookmarkPayload({ creatorRef: undefined })],
+      })
+    ),
+    getAccessToken: () => "test-token",
+  })
+  const page = await (
+    await absentAuthor.authenticate()
+  ).fetchBookmarksPage("active", 0)
+  assert.equal(page.items[0].contributor, undefined)
 })
 
 test("client validates highlight references and the documented color enum", async () => {

--- a/workers/raindrop-sync/tsconfig.json
+++ b/workers/raindrop-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/raindrop-sync/tsconfig.test.json
+++ b/workers/raindrop-sync/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- sync Raindrop.io Collections, Bookmarks, Trash, Reminders, and Highlights into three related managed databases
- turn exact passages into a bidirectional source graph: Collection ↔ Bookmark ↔ Highlight
- lead the schema and guide with project evidence, research provenance, scheduled processing, and insight-to-output workflows
- show which synced table and fields answer each core question, and which workspace-specific properties users add in Notion

## Main workflows

- **Project evidence:** Highlight Text and Note retain the exact passage; Bookmark identifies the source; users add a Project, Claim, or Decision relation to their own database
- **Research provenance:** natural Bookmarks and Highlights reciprocal relations make the source trail navigable in either direction; Bookmark count and Highlight count remain unambiguous
- **Processing queue:** the Worker now validates and syncs Raindrop Reminder dates alongside Created, Collection, and source metadata
- **Insights awaiting output:** the guide provides an exact Synthesis Status and optional Used in setup while the Worker preserves those user-owned properties

## Safety and data model

- preserve hard-deleted or unavailable records as last-known archive rows; the Worker never emits deletes
- scope every key and relation to the immutable Raindrop account ID
- persist account binding after completed runs, allowing token rotation only for the same account
- import Collections, Bookmarks, and Highlights in dependency order so relations have targets
- validate provider identity, reminder values, collection scope, active/Trash membership, required fields, pagination bounds, timeouts, response sizes, redirects, and retry timing
- degrade oversized text, URLs, and tag sets visibly and deterministically instead of blocking a sync page
- preserve user-added properties and page bodies

## Validation

- `npm run check`
- `npm test` (33 tests)
- `npm run build`
- `npm run catalog:validate` (34 projects)
- Raindrop README Markdown lint
- Prettier checks for the Worker and edited catalog files
- `git diff --check`
