### PR TITLE
Fix query-large-data-sources typecheck against current @notionhq/client

### DIFF
--- a/examples/query-large-data-sources/index.ts
+++ b/examples/query-large-data-sources/index.ts
@@ -41,10 +41,18 @@ type DataSourceRow = QueryDataSourceResponse["results"][number]
 // one row at a time so you never hold the whole data source in memory.
 async function streamFirstRows(limit: number): Promise<void> {
   let shown = 0
-  for await (const row of iteratePaginatedAPI(notion.dataSources.query, {
-    data_source_id: dataSourceId,
-    page_size: Math.min(limit, 100),
-  })) {
+  // The pagination helpers only thread start_cursor, and dataSources.query also
+  // needs data_source_id, so bind the id and page_size in a wrapper; the helper
+  // supplies the cursor on each call.
+  for await (const row of iteratePaginatedAPI(
+    (args) =>
+      notion.dataSources.query({
+        data_source_id: dataSourceId,
+        page_size: Math.min(limit, 100),
+        ...args,
+      }),
+    {}
+  )) {
     console.log(`  ${row.id}`)
     shown += 1
     if (shown >= limit) break
@@ -54,9 +62,12 @@ async function streamFirstRows(limit: number): Promise<void> {
 // Also the simple way: collectPaginatedAPI gathers every row into an array.
 // Only use it when you know the result fits in memory and under the limit.
 async function collectAll(): Promise<DataSourceRow[]> {
-  return collectPaginatedAPI(notion.dataSources.query, {
-    data_source_id: dataSourceId,
-  })
+  // Same wrapper as above so the helper's paginated calls carry data_source_id.
+  return collectPaginatedAPI(
+    (args) =>
+      notion.dataSources.query({ data_source_id: dataSourceId, ...args }),
+    {}
+  )
 }
 
 // Get every row, even when the data source exceeds the per-query limit.


### PR DESCRIPTION
## Problem

`verify-projects` fails on `examples/query-large-data-sources` for every PR (and would fail `main` on its next push). A recent `@notionhq/client` release tightened the data-source query types: `dataSources.query` now requires a `data_source_id` path param, so passing it directly to the pagination helpers (`iteratePaginatedAPI` / `collectPaginatedAPI`, whose `PaginatedArgs` only thread `start_cursor`) no longer type-checks. Because examples install unpinned, fresh CI installs now resolve the newer SDK and hit `TS2345`.

## Fix

Wrap `dataSources.query` in a small adapter that binds `data_source_id` (and `page_size`) and forwards the cursor the helper supplies. **Runtime behavior is unchanged** — it's a type-level correction, and arguably a better example of using the helpers with an endpoint that has a required path param.

## Verification

- `examples/query-large-data-sources`: `tsc --noEmit` now passes.
- Checked `examples/web-form-with-express` too (the only example CI hadn't reached) — passes; the other examples already type-check on the new SDK, and workers use `@notionhq/workers` (unaffected).

Separate from #44 (the patent-portfolio example); this unblocks CI repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
