### PR TITLE
Fix habit tracker empty state scrolling the host page

### DIFF
--- a/workers/custom-blocks/habit-tracker/blocks/habit-tracker/src/components/Tracker.tsx
+++ b/workers/custom-blocks/habit-tracker/blocks/habit-tracker/src/components/Tracker.tsx
@@ -146,31 +146,10 @@ function Cell(props: CellProps) {
 	);
 }
 
-function NewHabitRow({
-	onCreate,
-	autoOpen,
-}: {
-	onCreate: (name: string) => Promise<boolean>;
-	autoOpen?: boolean;
-}) {
-	const [editing, setEditing] = useState(Boolean(autoOpen));
+function NewHabitRow({ onCreate }: { onCreate: (name: string) => Promise<boolean> }) {
+	// The editor always starts closed and without focus.
+	const [editing, setEditing] = useState(false);
 	const [value, setValue] = useState("");
-	const inputRef = useRef<HTMLInputElement>(null);
-	// Only editors the user opened take focus. Focusing on mount would pull the
-	// caret into the block's iframe, and the host page scrolls the iframe into
-	// view to follow it.
-	const focusOnOpen = useRef(false);
-
-	useEffect(() => {
-		if (!editing || !focusOnOpen.current) return;
-		focusOnOpen.current = false;
-		inputRef.current?.focus();
-	}, [editing]);
-
-	const openEditor = () => {
-		focusOnOpen.current = true;
-		setEditing(true);
-	};
 
 	const submit = () => {
 		const name = value.trim();
@@ -184,7 +163,7 @@ function NewHabitRow({
 
 	if (!editing) {
 		return (
-			<button type="button" className="ht-newhabit" onClick={openEditor}>
+			<button type="button" className="ht-newhabit" onClick={() => setEditing(true)}>
 				<span className="ht-plus" aria-hidden="true">
 					＋
 				</span>
@@ -196,7 +175,7 @@ function NewHabitRow({
 	return (
 		<span className="ht-newhabit-edit">
 			<input
-				ref={inputRef}
+				autoFocus
 				className="ht-newhabit-input"
 				type="text"
 				placeholder="Habit name"
@@ -418,7 +397,7 @@ export function Tracker({ store, readOnly }: { store: HabitStore; readOnly?: boo
 				<p className="ht-empty-sub">
 					Each habit becomes a row, each day a dot — check off the days you follow through.
 				</p>
-				{!readOnly ? <NewHabitRow onCreate={store.createHabit} autoOpen /> : null}
+				{!readOnly ? <NewHabitRow onCreate={store.createHabit} /> : null}
 				{store.lastError ? (
 					<span className="ht-error" role="alert">
 						{store.lastError}

--- a/workers/custom-blocks/habit-tracker/blocks/habit-tracker/src/components/Tracker.tsx
+++ b/workers/custom-blocks/habit-tracker/blocks/habit-tracker/src/components/Tracker.tsx
@@ -156,10 +156,21 @@ function NewHabitRow({
 	const [editing, setEditing] = useState(Boolean(autoOpen));
 	const [value, setValue] = useState("");
 	const inputRef = useRef<HTMLInputElement>(null);
+	// Only editors the user opened take focus. Focusing on mount would pull the
+	// caret into the block's iframe, and the host page scrolls the iframe into
+	// view to follow it.
+	const focusOnOpen = useRef(false);
 
 	useEffect(() => {
-		if (editing) inputRef.current?.focus();
+		if (!editing || !focusOnOpen.current) return;
+		focusOnOpen.current = false;
+		inputRef.current?.focus();
 	}, [editing]);
+
+	const openEditor = () => {
+		focusOnOpen.current = true;
+		setEditing(true);
+	};
 
 	const submit = () => {
 		const name = value.trim();
@@ -173,7 +184,7 @@ function NewHabitRow({
 
 	if (!editing) {
 		return (
-			<button type="button" className="ht-newhabit" onClick={() => setEditing(true)}>
+			<button type="button" className="ht-newhabit" onClick={openEditor}>
 				<span className="ht-plus" aria-hidden="true">
 					＋
 				</span>


### PR DESCRIPTION
## Description

#### Problem

The habit tracker's empty state rendered its new-habit editor already open and focused it on mount. Because a custom block runs inside an iframe, taking focus makes the host Notion page scroll down to the block — so opening a page containing an empty tracker yanked the reader to it. This came up during a Brainlabs demo, reported as the page repeatedly jumping to the tracker.

#### Solution

The editor now always starts closed, so the input is only ever mounted — and autofocused via React's `autoFocus` — in response to a user click. This removes the `autoOpen` prop along with the ref and focus effect that existed only to serve it.

#### Result

- With the block iframed 2500px down a tall page, loading it now produces zero scroll events on the host and leaves focus on the host document. Before, the host scrolled to the block and focus landed on the tracker's input.
- Focus continuity is unchanged where it matters: clicking "New habit" still focuses the field, so keyboard users can type immediately.
- The empty state now shows the collapsed `＋ New habit` button instead of a pre-opened text field.

#### Details

The block's `scroll` listener and its scroll-today-into-view effect were the initial suspects and were both cleared: they only read and set the grid's own `scrollLeft`, which never propagates to ancestors or the host frame. Left unchanged.

Fixes TASK-369652

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Ran the block's dev harness (`npx vite` in `blocks/habit-tracker`, `/?mock=1&empty`) inside an iframe placed 2500px down a tall host page, then measured the host's scroll position and focused element on load, and confirmed clicking "New habit" still focuses the input. `npm run check`, `npm test`, and `npm run build` pass in `workers/custom-blocks/habit-tracker`.

## Is this feature gated? (Optional)

- [ ] Yes (provide feature gate name or instructions to enable/disable)
- [x] No

## Screenshots

**Before:**
<img width="1440" height="480" alt="image" src="https://github.com/user-attachments/assets/c10d7f7e-411e-499f-bd85-01045b61d578" />


**After:**
<img width="1440" height="480" alt="image" src="https://github.com/user-attachments/assets/f0d1b6b0-965a-4b8c-825e-20493cdbb913" />
