### PR TITLE
fix(custom-blocks): keep build script worker-only

### DIFF
--- a/workers/custom-blocks/custom/package.json
+++ b/workers/custom-blocks/custom/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build blocks/custom",
+    "build": "tsc",
     "check": "tsc --noEmit && tsc -p blocks/custom/tsconfig.json --noEmit",
     "test": "node --test test/*.test.mjs"
   },

--- a/workers/custom-blocks/habit-tracker/package.json
+++ b/workers/custom-blocks/habit-tracker/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build blocks/habit-tracker",
+    "build": "tsc",
     "check": "tsc --noEmit && tsc -p blocks/habit-tracker/tsconfig.json --noEmit",
     "test": "tsx --test test/*.test.ts"
   },

--- a/workers/custom-blocks/org-chart/package.json
+++ b/workers/custom-blocks/org-chart/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build blocks/org-chart",
+    "build": "tsc",
     "check": "tsc --noEmit && tsc -p blocks/org-chart/tsconfig.json --noEmit",
     "test": "tsx --test test/*.test.ts"
   },

--- a/workers/custom-blocks/whiteboard/package.json
+++ b/workers/custom-blocks/whiteboard/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build blocks/whiteboard",
+    "build": "tsc",
     "check": "tsc --noEmit && tsc -p blocks/whiteboard/tsconfig.json --noEmit",
     "test": "tsx --test test/*.test.ts"
   },


### PR DESCRIPTION
## Summary of changes

- **Build scripts** — in all four custom-block templates (`custom`, `habit-tracker`, `org-chart`, `whiteboard`), trim `scripts.build` from `tsc && vite build blocks/<name>` to `tsc`, matching workers-template and every other cookbook worker. The custom-blocks dev shell runs `npm run build` at every spin-up solely to extract the worker manifest from `dist/index.js`; the fused script ran a redundant block build there, and misled authors who duplicated the block into retargeting `scripts.build` at one block — after which the dev shell imports a stale worker bundle and manifest changes silently stop appearing. Deploy is unaffected: every template's `customBlock()` already declares `command: "npx vite build"`, which is what a deploy actually runs to build the block.

## Verification

Ran the dev shell against the modified `custom` template (`npx @notionhq/custom-blocks-dev-shell@latest --worker .`) — manifest extraction now runs only `tsc`:

```text
[custom] Extracting worker manifest...
> @notion-cookbook/custom@0.0.0 build
> tsc
[custom] Wrote .../custom/.dev-shell/worker_manifest.json
Dev shell
  [dev-shell] http://localhost:9973
Blocks
  [custom] http://localhost:9976
```

Both endpoints returned 200 and the block server answered `/custom_blocks.json` with the block's manifest slice (`{"version":1,"dataSources":{}}`). In all four templates, `npm run build` emits `dist/index.js`, and the block's production build still works standalone (`npx vite build blocks/<name>` from the worker root, i.e. the declared `command`).

Context: this pattern surfaced when a user duplicated the `custom` template's block into two blocks and had to fight `scripts.build` to get `ntn customblocks dev` running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
