### PR TITLE
docs(custom-blocks): route local testing through the dev shell

### DIFF
--- a/workers/custom-blocks/custom/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/custom/.agents/INSTRUCTIONS.md
@@ -22,17 +22,15 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
-#### Test blocks in the dev shell before deploying
-
-Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+Use the custom blocks dev shell to test locally:
 
 ```shell
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
+This builds the worker, serves each block with the project's Vite server, and renders in a mock Notion host with sample data sources to bind.
 
-The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
+See docs in `node_modules/@notionhq/custom-blocks-dev-shell/docs` for information on data bindings and sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/custom/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/custom/.agents/INSTRUCTIONS.md
@@ -20,7 +20,7 @@
 
 `worker.customBlock()` declares a front-end web app that Notion serves in an iframe. It is a build-time/deploy-time capability with no `execute` handler, so it cannot be run with `ntn workers exec`. A custom block has two SDK surfaces: `@notionhq/workers` declares how the block is built and which data-source schemas it expects, while `@notionhq/custom-blocks` allows the the iframe frontend code to communicate with the Notion host at runtime.
 
-Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
+Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
 #### Test blocks in the dev shell before deploying
 
@@ -30,11 +30,9 @@ Because a custom block has no `execute` handler, `ntn workers exec` cannot exerc
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
 
-To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
-
-The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/custom/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/custom/.agents/INSTRUCTIONS.md
@@ -22,6 +22,20 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
 
+#### Test blocks in the dev shell before deploying
+
+Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+
+```shell
+ntn customblocks dev
+```
+
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+
+To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
+
+The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+
 #### Custom block sources
 
 A project source is the default. `path` points to a buildable project directory relative to the worker root. The deploy pipeline runs `npm run build` in that directory and serves its `dist` output by default:
@@ -400,6 +414,7 @@ When `ntn datasources query <id>` returns 404 or "Could not find data source", t
 - `ntn login`: connect to a Notion workspace.
 - `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
 - `ntn workers exec <capability>`: run a sync or tool.
+- `ntn customblocks dev`: render custom blocks locally in the dev shell; test there before deploying.
 - `ntn workers sync status`: monitor sync health (live-updating).
 - `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
 - `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
@@ -476,6 +491,7 @@ ntn workers sync state reset <key>
 ## Testing Guidelines
 
 - No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Custom blocks are exercised in the dev shell (`ntn customblocks dev`), not with `ntn workers exec`.
 - Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
 
 **Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.

--- a/workers/custom-blocks/custom/README.md
+++ b/workers/custom-blocks/custom/README.md
@@ -12,6 +12,14 @@ From the repository root:
 cd workers/custom-blocks/custom
 npm install
 npm run check
+ntn customblocks dev
+```
+
+Open http://localhost:9873 to preview the block in the custom blocks dev
+shell — a mock Notion host that serves the block from this project. When it
+looks right, deploy:
+
+```zsh
 ntn login
 ntn workers deploy --name custom
 ```
@@ -21,15 +29,12 @@ because it does not need a database mapping.
 
 ## Local development
 
-Run the view with Vite:
-
-```zsh
-cd blocks/custom
-npx vite
-```
-
-Edit `blocks/custom/src/index.tsx` to change the rendered content. Add
-data-source definitions to `src/index.ts` when the block needs Notion data.
+The dev shell (`ntn customblocks dev`, above) is the local test loop: it
+builds the worker, serves the block with this project's Vite, and renders it
+in a mock Notion host. Edit `blocks/custom/src/index.tsx` to change the
+rendered content; edits hot-reload. Add data-source definitions to
+`src/index.ts` when the block needs Notion data, then restart the dev shell
+to pick up the new manifest and bind sample data.
 
 ## Project structure
 

--- a/workers/custom-blocks/custom/package.json
+++ b/workers/custom-blocks/custom/package.json
@@ -13,6 +13,7 @@
     "npm": ">=10.9.2"
   },
   "devDependencies": {
+    "@notionhq/custom-blocks-dev-shell": "^0.1.16",
     "@types/node": "^22.9.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/workers/custom-blocks/habit-tracker/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/habit-tracker/.agents/INSTRUCTIONS.md
@@ -22,17 +22,15 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
-#### Test blocks in the dev shell before deploying
-
-Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+Use the custom blocks dev shell to test locally:
 
 ```shell
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
+This builds the worker, serves each block with the project's Vite server, and renders in a mock Notion host with sample data sources to bind.
 
-The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
+See docs in `node_modules/@notionhq/custom-blocks-dev-shell/docs` for information on data bindings and sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/habit-tracker/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/habit-tracker/.agents/INSTRUCTIONS.md
@@ -20,7 +20,7 @@
 
 `worker.customBlock()` declares a front-end web app that Notion serves in an iframe. It is a build-time/deploy-time capability with no `execute` handler, so it cannot be run with `ntn workers exec`. A custom block has two SDK surfaces: `@notionhq/workers` declares how the block is built and which data-source schemas it expects, while `@notionhq/custom-blocks` allows the the iframe frontend code to communicate with the Notion host at runtime.
 
-Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
+Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
 #### Test blocks in the dev shell before deploying
 
@@ -30,11 +30,9 @@ Because a custom block has no `execute` handler, `ntn workers exec` cannot exerc
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
 
-To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
-
-The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/habit-tracker/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/habit-tracker/.agents/INSTRUCTIONS.md
@@ -22,6 +22,20 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
 
+#### Test blocks in the dev shell before deploying
+
+Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+
+```shell
+ntn customblocks dev
+```
+
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+
+To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
+
+The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+
 #### Custom block sources
 
 A project source is the default. `path` points to a buildable project directory relative to the worker root. The deploy pipeline runs `npm run build` in that directory and serves its `dist` output by default:
@@ -400,6 +414,7 @@ When `ntn datasources query <id>` returns 404 or "Could not find data source", t
 - `ntn login`: connect to a Notion workspace.
 - `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
 - `ntn workers exec <capability>`: run a sync or tool.
+- `ntn customblocks dev`: render custom blocks locally in the dev shell; test there before deploying.
 - `ntn workers sync status`: monitor sync health (live-updating).
 - `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
 - `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
@@ -476,6 +491,7 @@ ntn workers sync state reset <key>
 ## Testing Guidelines
 
 - No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Custom blocks are exercised in the dev shell (`ntn customblocks dev`), not with `ntn workers exec`.
 - Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
 
 **Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.

--- a/workers/custom-blocks/habit-tracker/README.md
+++ b/workers/custom-blocks/habit-tracker/README.md
@@ -14,6 +14,14 @@ cd workers/custom-blocks/habit-tracker
 npm install
 npm run check
 npm test
+ntn customblocks dev
+```
+
+Open http://localhost:9873 to preview the block in the custom blocks dev
+shell — a mock Notion host with sample data sources to bind. When it looks
+right, deploy:
+
+```zsh
 ntn login
 ntn workers deploy --name habit-tracker
 ```
@@ -62,7 +70,12 @@ scroller.
 
 ## Local development
 
-The view renders standalone with seeded sample data, no Notion host required:
+Test the block in the custom blocks dev shell (`ntn customblocks dev`,
+above), which renders it in a mock Notion host with sample data sources to
+bind against, before any deploy.
+
+The view also renders standalone with seeded sample data, no Notion host
+required:
 
 ```zsh
 cd blocks/habit-tracker

--- a/workers/custom-blocks/habit-tracker/package.json
+++ b/workers/custom-blocks/habit-tracker/package.json
@@ -13,6 +13,7 @@
     "npm": ">=10.9.2"
   },
   "devDependencies": {
+    "@notionhq/custom-blocks-dev-shell": "^0.1.16",
     "@types/node": "^22.9.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/workers/custom-blocks/org-chart/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/org-chart/.agents/INSTRUCTIONS.md
@@ -22,17 +22,15 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
-#### Test blocks in the dev shell before deploying
-
-Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+Use the custom blocks dev shell to test locally:
 
 ```shell
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
+This builds the worker, serves each block with the project's Vite server, and renders in a mock Notion host with sample data sources to bind.
 
-The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
+See docs in `node_modules/@notionhq/custom-blocks-dev-shell/docs` for information on data bindings and sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/org-chart/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/org-chart/.agents/INSTRUCTIONS.md
@@ -20,7 +20,7 @@
 
 `worker.customBlock()` declares a front-end web app that Notion serves in an iframe. It is a build-time/deploy-time capability with no `execute` handler, so it cannot be run with `ntn workers exec`. A custom block has two SDK surfaces: `@notionhq/workers` declares how the block is built and which data-source schemas it expects, while `@notionhq/custom-blocks` allows the the iframe frontend code to communicate with the Notion host at runtime.
 
-Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
+Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
 #### Test blocks in the dev shell before deploying
 
@@ -30,11 +30,9 @@ Because a custom block has no `execute` handler, `ntn workers exec` cannot exerc
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
 
-To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
-
-The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/org-chart/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/org-chart/.agents/INSTRUCTIONS.md
@@ -22,6 +22,20 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
 
+#### Test blocks in the dev shell before deploying
+
+Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+
+```shell
+ntn customblocks dev
+```
+
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+
+To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
+
+The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+
 #### Custom block sources
 
 A project source is the default. `path` points to a buildable project directory relative to the worker root. The deploy pipeline runs `npm run build` in that directory and serves its `dist` output by default:
@@ -400,6 +414,7 @@ When `ntn datasources query <id>` returns 404 or "Could not find data source", t
 - `ntn login`: connect to a Notion workspace.
 - `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
 - `ntn workers exec <capability>`: run a sync or tool.
+- `ntn customblocks dev`: render custom blocks locally in the dev shell; test there before deploying.
 - `ntn workers sync status`: monitor sync health (live-updating).
 - `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
 - `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
@@ -476,6 +491,7 @@ ntn workers sync state reset <key>
 ## Testing Guidelines
 
 - No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Custom blocks are exercised in the dev shell (`ntn customblocks dev`), not with `ntn workers exec`.
 - Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
 
 **Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.

--- a/workers/custom-blocks/org-chart/README.md
+++ b/workers/custom-blocks/org-chart/README.md
@@ -14,6 +14,14 @@ cd workers/custom-blocks/org-chart
 npm install
 npm run check
 npm test
+ntn customblocks dev
+```
+
+Open http://localhost:9873 to preview the block in the custom blocks dev
+shell — a mock Notion host with sample data sources to bind. When it looks
+right, deploy:
+
+```zsh
 ntn login
 ntn workers deploy --name org-chart
 ```
@@ -51,7 +59,11 @@ otherwise.
 
 ## Local development
 
-The view renders standalone with a seeded 12-person org, no Notion host
+Test the block in the custom blocks dev shell (`ntn customblocks dev`,
+above), which renders it in a mock Notion host with sample data sources to
+bind against, before any deploy.
+
+The view also renders standalone with a seeded 12-person org, no Notion host
 required:
 
 ```zsh

--- a/workers/custom-blocks/org-chart/package.json
+++ b/workers/custom-blocks/org-chart/package.json
@@ -13,6 +13,7 @@
     "npm": ">=10.9.2"
   },
   "devDependencies": {
+    "@notionhq/custom-blocks-dev-shell": "^0.1.16",
     "@types/node": "^22.9.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/workers/custom-blocks/whiteboard/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/whiteboard/.agents/INSTRUCTIONS.md
@@ -22,17 +22,15 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
-#### Test blocks in the dev shell before deploying
-
-Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+Use the custom blocks dev shell to test locally:
 
 ```shell
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
+This builds the worker, serves each block with the project's Vite server, and renders in a mock Notion host with sample data sources to bind.
 
-The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
+See docs in `node_modules/@notionhq/custom-blocks-dev-shell/docs` for information on data bindings and sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/whiteboard/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/whiteboard/.agents/INSTRUCTIONS.md
@@ -20,7 +20,7 @@
 
 `worker.customBlock()` declares a front-end web app that Notion serves in an iframe. It is a build-time/deploy-time capability with no `execute` handler, so it cannot be run with `ntn workers exec`. A custom block has two SDK surfaces: `@notionhq/workers` declares how the block is built and which data-source schemas it expects, while `@notionhq/custom-blocks` allows the the iframe frontend code to communicate with the Notion host at runtime.
 
-Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
+Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
 
 #### Test blocks in the dev shell before deploying
 
@@ -30,11 +30,9 @@ Because a custom block has no `execute` handler, `ntn workers exec` cannot exerc
 ntn customblocks dev
 ```
 
-Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host with sample data sources to bind.
 
-To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
-
-The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+The dev shell package's reference docs are installed with it: read `node_modules/@notionhq/custom-blocks-dev-shell/docs/bindings.md` (connecting blocks to data sources) and `node_modules/@notionhq/custom-blocks-dev-shell/docs/data-sources.md` (the `src/data/*.json` sample-data format) before authoring sample data.
 
 #### Custom block sources
 

--- a/workers/custom-blocks/whiteboard/.agents/INSTRUCTIONS.md
+++ b/workers/custom-blocks/whiteboard/.agents/INSTRUCTIONS.md
@@ -22,6 +22,20 @@
 
 Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json` and install it from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed package's README and docs for the current client API.
 
+#### Test blocks in the dev shell before deploying
+
+Because a custom block has no `execute` handler, `ntn workers exec` cannot exercise it. The custom blocks dev shell is the local test loop: always render the block there and confirm it initializes with its data sources bound before running `ntn workers deploy`.
+
+```shell
+ntn customblocks dev
+```
+
+Run it from anywhere inside the worker project and open http://localhost:9873. The dev shell builds the worker, reads the manifest declared by the `worker.customBlock(...)` calls, serves each block with the project's own Vite (edits hot-reload), and renders it in a mock Notion host.
+
+To give a block data, open **Connect data** in the shell toolbar and bind each of the block's data-source slots. The sources on offer are JSON files in the worker's `src/data/` directory; the shell materializes missing ones from the schemas declared in `dataSources`. The shell reads `src/data/*.json` and the worker manifest once at spin-up, so restart the command after editing sample data or `worker.customBlock(...)` options.
+
+The `@notionhq/custom-blocks-dev-shell` package ships the reference docs: `docs/bindings.md` (connecting sources, auto-mapping rules) and `docs/data-sources.md` (the `src/data/*.json` file format).
+
 #### Custom block sources
 
 A project source is the default. `path` points to a buildable project directory relative to the worker root. The deploy pipeline runs `npm run build` in that directory and serves its `dist` output by default:
@@ -400,6 +414,7 @@ When `ntn datasources query <id>` returns 404 or "Could not find data source", t
 - `ntn login`: connect to a Notion workspace.
 - `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
 - `ntn workers exec <capability>`: run a sync or tool.
+- `ntn customblocks dev`: render custom blocks locally in the dev shell; test there before deploying.
 - `ntn workers sync status`: monitor sync health (live-updating).
 - `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
 - `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
@@ -476,6 +491,7 @@ ntn workers sync state reset <key>
 ## Testing Guidelines
 
 - No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Custom blocks are exercised in the dev shell (`ntn customblocks dev`), not with `ntn workers exec`.
 - Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
 
 **Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.

--- a/workers/custom-blocks/whiteboard/README.md
+++ b/workers/custom-blocks/whiteboard/README.md
@@ -15,6 +15,14 @@ cd workers/custom-blocks/whiteboard
 npm install
 npm run check
 npm test
+ntn customblocks dev
+```
+
+Open http://localhost:9873 to preview the block in the custom blocks dev
+shell — a mock Notion host with sample data sources to bind. When it looks
+right, deploy:
+
+```zsh
 ntn login
 ntn workers deploy --name whiteboard
 ```
@@ -58,7 +66,12 @@ edits a selected sticky, and Shift snaps lines and arrows to 45°.
 
 ## Local development
 
-The view renders standalone with seeded sample data, no Notion host required:
+Test the block in the custom blocks dev shell (`ntn customblocks dev`,
+above), which renders it in a mock Notion host with sample data sources to
+bind against, before any deploy.
+
+The view also renders standalone with seeded sample data, no Notion host
+required:
 
 ```zsh
 cd blocks/whiteboard

--- a/workers/custom-blocks/whiteboard/package.json
+++ b/workers/custom-blocks/whiteboard/package.json
@@ -13,6 +13,7 @@
     "npm": ">=10.9.2"
   },
   "devDependencies": {
+    "@notionhq/custom-blocks-dev-shell": "^0.1.16",
     "@types/node": "^22.9.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## Summary of changes

- **Agent instructions (all 4 templates, shared `.agents/INSTRUCTIONS.md`)** — the scaffolding sentence now installs `@notionhq/custom-blocks-dev-shell` as a devDependency alongside the SDK. A slim "Test blocks in the dev shell before deploying" section gives the command, the test-before-deploy directive, and pointers to the shell's reference docs, which the install places at `node_modules/@notionhq/custom-blocks-dev-shell/docs/`. Behavior depth stays in those shipped docs; the section stays thin. Same text as the canonical makenotion/workers-template#55.
- **Template devDependencies (all 4)** — `@notionhq/custom-blocks-dev-shell@^0.1.16` added, so the docs pointer resolves from first install. Lockfiles are repo-gitignored.
- **READMEs (all 4 templates)** — quickstart restructured to preview-in-dev-shell first, then `ntn login` + deploy; "Local development" leads with the dev shell (standalone `npx vite` mock harnesses stay as the secondary path where they exist).
- **Gitignore (all 4 templates)** — adds `.dev-shell/`; the shell writes per-block Vite configs and the extracted worker manifest there and assumes it's ignored.

## Verification

Verified end-to-end that this kind of instruction section changes agent behavior: two headless coding agents in a fresh worker copied from the modified `custom` template — one with full user config, one generic (`--setting-sources project,local`, prompt explicitly asking to deploy) — both spun up `ntn customblocks dev` unprompted and only attempted a deploy after verifying the rendered block in the shell. An independent verifier agent re-derived the transcript ordering and confirmed.

- [Run REPORT.md](https://github.com/makenotion/mjycho-verification-bundles/blob/0dfcfd19e4c19430b8ed5d80b13f0acf87f933bd/%5B2026-08-04%5D%5Bnotion-cookbook%5D%20dev%20shell%20discoverability%20docs/REPORT.md) (transcripts, screenshots, exact prompts)
- [Notion run page](https://app.notion.com/p/3b2efdeead05819cbef1d6ed08a6fed1)

The devDependency amendment was exercised directly: `npm install` in the modified `custom` template places `docs/bindings.md` and `docs/data-sources.md` in the worker's `node_modules`, and with the installed version matching `latest`, `npx --yes @notionhq/custom-blocks-dev-shell@latest` runs the worker's local binary with no download (one cache-revalidated registry metadata request).

Companion PRs: makenotion/workers-template#55 (canonical instructions), makenotion/custom-blocks#191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)