### PR TITLE
chore(custom-blocks): ignore .dev-shell artifacts

### DIFF
--- a/workers/custom-blocks/custom/.gitignore
+++ b/workers/custom-blocks/custom/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 workers.*.json
 workers.json
+.dev-shell/

--- a/workers/custom-blocks/habit-tracker/.gitignore
+++ b/workers/custom-blocks/habit-tracker/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 workers.*.json
 workers.json
+.dev-shell/

--- a/workers/custom-blocks/org-chart/.gitignore
+++ b/workers/custom-blocks/org-chart/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 workers.*.json
 workers.json
+.dev-shell/

--- a/workers/custom-blocks/whiteboard/.gitignore
+++ b/workers/custom-blocks/whiteboard/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 workers.*.json
 workers.json
+.dev-shell/


### PR DESCRIPTION
## Summary of changes

- Add `.dev-shell/` to the `.gitignore` of all four custom-blocks examples (`custom`, `habit-tracker`, `org-chart`, `whiteboard`). The custom-blocks dev shell writes generated artifacts into the worker's `.dev-shell/` dir at spin-up. It writes the extracted `worker_manifest.json` and one Vite config wrapper per block. The dev shell regenerates these files on every run. Authors who copy an example must not commit them.

Companion to makenotion/workers-template#54, which makes the same fix in the scaffold. #68 carries the same four gitignore lines; the change is identical line-for-line, so these merge cleanly in either order.

## Verification

`git check-ignore -v` on a representative dev-shell artifact, with the new rule in place:

```
workers/custom-blocks/org-chart/.gitignore:7:.dev-shell/	workers/custom-blocks/org-chart/.dev-shell/worker_manifest.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)