### PR TITLE
fix(generate-random-data): handle unsupported formula results

### DIFF
--- a/examples/generate-random-data/index.ts
+++ b/examples/generate-random-data/index.ts
@@ -191,6 +191,8 @@ function extractPropertyItemValueToString(
             new Date(property.formula.date.start).toISOString()) ||
           "???"
         )
+      } else if (property.formula.type === "unsupported") {
+        return "???"
       } else {
         return assertUnreachable(property.formula)
       }


### PR DESCRIPTION
## Summary of changes

- Handle the `unsupported` formula variant in the `generate-random-data` example. `@notionhq/client` 5.24.0 added `UnsupportedFormulaPropertyResponse` to the `FormulaPropertyResponse` union. The example installs the latest 5.x at CI time, so the exhaustive formula check stopped typechecking. `unsupported` formula results now render as `???`, like other empty values.

This break fails `verify-projects` for every open PR (see #71); main last ran CI on 2026-07-28, before the client release.

## Verification

- Reproduced the CI failure locally with a fresh install (client 5.24.0): `index.ts(195,34): error TS2345`.
- Full `npm run verify:all` passes locally with this fix: catalog validation, typecheck across all projects, 27 tests passed / 0 failed, markdownlint, prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)