### PR TITLE
[Custom blocks] Remove obsolete `notionCustomBlock` Vite plugin from cookbook recipes

### DIFF
--- a/workers/custom-blocks/custom/blocks/custom/vite.config.ts
+++ b/workers/custom-blocks/custom/blocks/custom/vite.config.ts
@@ -1,7 +1,6 @@
-import { notionCustomBlock } from "@notionhq/custom-blocks/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [react(), notionCustomBlock()],
+  plugins: [react()],
 })

--- a/workers/custom-blocks/custom/package.json
+++ b/workers/custom-blocks/custom/package.json
@@ -22,7 +22,7 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@notionhq/custom-blocks": "^0.1.2",
+    "@notionhq/custom-blocks": "^0.1.13",
     "@notionhq/workers": ">=0.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/workers/custom-blocks/habit-tracker/blocks/habit-tracker/vite.config.ts
+++ b/workers/custom-blocks/habit-tracker/blocks/habit-tracker/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
-import { notionCustomBlock } from "@notionhq/custom-blocks/vite"
 
 export default defineConfig({
-  plugins: [react(), notionCustomBlock()],
+  plugins: [react()],
 })

--- a/workers/custom-blocks/habit-tracker/package.json
+++ b/workers/custom-blocks/habit-tracker/package.json
@@ -23,7 +23,7 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@notionhq/custom-blocks": "^0.1.2",
+    "@notionhq/custom-blocks": "^0.1.13",
     "@notionhq/workers": ">=0.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/workers/custom-blocks/org-chart/blocks/org-chart/vite.config.ts
+++ b/workers/custom-blocks/org-chart/blocks/org-chart/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
-import { notionCustomBlock } from "@notionhq/custom-blocks/vite"
 
 export default defineConfig({
-  plugins: [react(), notionCustomBlock()],
+  plugins: [react()],
 })

--- a/workers/custom-blocks/org-chart/package.json
+++ b/workers/custom-blocks/org-chart/package.json
@@ -23,7 +23,7 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@notionhq/custom-blocks": "^0.1.2",
+    "@notionhq/custom-blocks": "^0.1.13",
     "@notionhq/workers": ">=0.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/workers/custom-blocks/whiteboard/blocks/whiteboard/vite.config.ts
+++ b/workers/custom-blocks/whiteboard/blocks/whiteboard/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
-import { notionCustomBlock } from "@notionhq/custom-blocks/vite"
 
 export default defineConfig({
-  plugins: [react(), notionCustomBlock()],
+  plugins: [react()],
 })

--- a/workers/custom-blocks/whiteboard/package.json
+++ b/workers/custom-blocks/whiteboard/package.json
@@ -23,7 +23,7 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@notionhq/custom-blocks": "^0.1.2",
+    "@notionhq/custom-blocks": "^0.1.13",
     "@notionhq/workers": ">=0.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"


### PR DESCRIPTION
## Summary

This PR updates our templates based on the removal of `notionCustomBlock()` in https://github.com/makenotion/custom-blocks/pull/213:
- Removes `notionCustomBlock()` from all cookbook Vite configs
- Requires the upcoming `@notionhq/custom-blocks` `0.1.13` release version

## Test plan
- [x] `npm run check` (whiteboard)
- [x] `npm run check` (habit-tracker)