### PR TITLE
[P2] [R] feat(agents): add default instruction set and fan out to all workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,5 @@ if ! git diff --quiet -- workers/agents/; then
   exit 1
 fi
 npm run --silent agents:sync
-git add workers/custom-blocks/*/.agents
+git add 'workers/*/.agents/*' 'workers/*/AGENTS.md' 'workers/*/CLAUDE.md'
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,8 @@
+if ! git diff --quiet -- workers/agents/; then
+  echo "pre-commit: workers/agents/ has unstaged changes; the sync would embed them in generated copies."
+  echo "Stage or stash your workers/agents/ edits, then commit again."
+  exit 1
+fi
+npm run --silent agents:sync
+git add workers/custom-blocks/*/.agents
 npx lint-staged
-

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "projects:typecheck": "./scripts/typecheck-projects.sh",
     "projects:test": "./scripts/test-projects.sh",
     "catalog:validate": "node scripts/validate-catalog.mjs",
+    "agents:sync": "node scripts/sync-agents.mjs",
+    "agents:check": "node scripts/sync-agents.mjs --check",
     "lint:markdown": "markdownlint \"**/*.md\" --ignore node_modules --ignore \"**/node_modules/**\" --config .markdownlint.jsonc",
     "format": "prettier --write \"**/*.{md,json,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{md,json,yml,yaml}\"",
-    "verify": "npm run catalog:validate && npm run projects:typecheck && npm run projects:test && npm run lint:markdown && npm run format:check",
+    "verify": "npm run catalog:validate && npm run agents:check && npm run projects:typecheck && npm run projects:test && npm run lint:markdown && npm run format:check",
     "verify:all": "npm run projects:install && npm run verify",
     "prepare": "husky"
   },

--- a/scripts/sync-agents.mjs
+++ b/scripts/sync-agents.mjs
@@ -1,9 +1,21 @@
-// Copies `workers/agents/<group>/` into every matching template's `.agents/`.
-// The per-template copies are generated, so hand edits there are overwritten;
-// edit the canonical files instead. `--check` exits non-zero on drift so CI and
-// the pre-commit hook can catch copies that were edited or never regenerated.
+// Copies a canonical agent file set into every worker template's `.agents/`.
+// Every `worker-*` recipe in `catalog.json` gets DEFAULT_GROUP unless its kind
+// is listed in OVERRIDE_GROUPS, so a new kind inherits the default instead of
+// being silently skipped. The per-template copies are generated, so hand edits
+// there are overwritten; edit the canonical files instead. `--check` exits
+// non-zero on drift so CI and the pre-commit hook catch copies that were edited
+// or never regenerated.
 
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises"
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -11,11 +23,18 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const checkMode = process.argv.includes("--check")
 
 const CANONICAL_ROOT = "workers/agents"
-const GROUPS = [
-  {
-    canonicalDir: `${CANONICAL_ROOT}/custom-blocks`,
-    kind: "worker-custom-block",
-  },
+const DEFAULT_GROUP = `${CANONICAL_ROOT}/default`
+
+// A catalog kind listed here takes its agent files from the named directory
+// instead of DEFAULT_GROUP. Custom blocks are a private alpha capability, so
+// their templates document what the default set tells agents not to use.
+const OVERRIDE_GROUPS = {
+  "worker-custom-block": `${CANONICAL_ROOT}/custom-blocks`,
+}
+
+const ENTRY_LINKS = [
+  { name: "AGENTS.md", target: ".agents/INSTRUCTIONS.md" },
+  { name: "CLAUDE.md", target: ".agents/INSTRUCTIONS.md" },
 ]
 
 async function collectFiles(dir, prefix = "") {
@@ -40,31 +59,76 @@ async function readIfExists(path) {
   }
 }
 
+async function lstatIfExists(path) {
+  try {
+    return await lstat(path)
+  } catch {
+    return null
+  }
+}
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}
+
 const catalog = JSON.parse(
   await readFile(resolve(repoRoot, "catalog.json"), "utf8")
 )
 
+const workerRecipes = catalog.recipes.filter((recipe) =>
+  recipe.kind.startsWith("worker-")
+)
+if (workerRecipes.length === 0) {
+  fail("No catalog recipes with a worker- kind")
+}
+
+const kinds = new Set(workerRecipes.map((recipe) => recipe.kind))
+for (const kind of Object.keys(OVERRIDE_GROUPS)) {
+  if (!kinds.has(kind)) {
+    fail(
+      `OVERRIDE_GROUPS lists kind ${JSON.stringify(kind)}, which no recipe uses`
+    )
+  }
+}
+
+// One entry per canonical directory, so each group's files are read once.
+const groups = new Map()
+for (const recipe of workerRecipes) {
+  const canonicalDir = OVERRIDE_GROUPS[recipe.kind] ?? DEFAULT_GROUP
+  const group = groups.get(canonicalDir)
+  if (group) group.recipes.push(recipe)
+  else groups.set(canonicalDir, { canonicalDir, recipes: [recipe] })
+}
+
 let drifted = []
 let synced = 0
 
-for (const group of GROUPS) {
+for (const group of groups.values()) {
   const canonicalPath = resolve(repoRoot, group.canonicalDir)
-  const files = await collectFiles(canonicalPath)
+  let files
+  try {
+    files = await collectFiles(canonicalPath)
+  } catch {
+    fail(`Canonical directory ${group.canonicalDir} does not exist`)
+  }
   if (files.length === 0) {
-    console.error(`No canonical files found in ${group.canonicalDir}`)
-    process.exit(1)
+    fail(`No canonical files found in ${group.canonicalDir}`)
   }
 
-  const recipes = catalog.recipes.filter((recipe) => recipe.kind === group.kind)
-  if (recipes.length === 0) {
-    console.error(`No catalog recipes with kind ${JSON.stringify(group.kind)}`)
-    process.exit(1)
-  }
+  // Directories that appear in the canonical set. The sweep only deletes
+  // inside these, so template-specific files elsewhere in .agents/ survive.
+  const managedDirs = new Set(
+    files.map((file) => dirname(file)).filter((dir) => dir !== ".")
+  )
+  const canonicalSet = new Set(files)
 
-  for (const recipe of recipes) {
+  for (const recipe of group.recipes) {
+    const agentsRoot = resolve(repoRoot, recipe.path, ".agents")
+
     for (const file of files) {
       const source = join(canonicalPath, file)
-      const target = resolve(repoRoot, recipe.path, ".agents", file)
+      const target = join(agentsRoot, file)
       const expected = await readFile(source, "utf8")
       const actual = await readIfExists(target)
       if (actual === expected) continue
@@ -77,6 +141,46 @@ for (const group of GROUPS) {
         console.log(`synced ${relative(repoRoot, target)}`)
         synced += 1
       }
+    }
+
+    for (const managedDir of managedDirs) {
+      const targetDir = join(agentsRoot, managedDir)
+      let entries
+      try {
+        entries = await readdir(targetDir, { withFileTypes: true })
+      } catch {
+        continue
+      }
+      for (const entry of entries) {
+        if (entry.isDirectory()) continue
+        const relPath = join(managedDir, entry.name)
+        if (canonicalSet.has(relPath)) continue
+        const stale = join(agentsRoot, relPath)
+        if (checkMode) {
+          drifted.push(`${relative(repoRoot, stale)} (stale, not in canonical)`)
+        } else {
+          await rm(stale)
+          console.log(`removed ${relative(repoRoot, stale)}`)
+          synced += 1
+        }
+      }
+    }
+
+    for (const link of ENTRY_LINKS) {
+      const linkPath = resolve(repoRoot, recipe.path, link.name)
+      const stat = await lstatIfExists(linkPath)
+      const current = stat?.isSymbolicLink() ? await readlink(linkPath) : null
+      if (current === link.target) continue
+      if (checkMode) {
+        drifted.push(
+          `${relative(repoRoot, linkPath)} (not a symlink to ${link.target})`
+        )
+        continue
+      }
+      if (stat) await rm(linkPath)
+      await symlink(link.target, linkPath)
+      console.log(`linked ${relative(repoRoot, linkPath)} -> ${link.target}`)
+      synced += 1
     }
   }
 }
@@ -95,5 +199,5 @@ console.log(
     ? `Template agent files match ${CANONICAL_ROOT}/.`
     : synced === 0
       ? "Template agent files already up to date."
-      : `Synced ${synced} file(s).`
+      : `Synced ${synced} change(s).`
 )

--- a/scripts/sync-agents.mjs
+++ b/scripts/sync-agents.mjs
@@ -1,0 +1,99 @@
+// Copies `workers/agents/<group>/` into every matching template's `.agents/`.
+// The per-template copies are generated, so hand edits there are overwritten;
+// edit the canonical files instead. `--check` exits non-zero on drift so CI and
+// the pre-commit hook can catch copies that were edited or never regenerated.
+
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const checkMode = process.argv.includes("--check")
+
+const CANONICAL_ROOT = "workers/agents"
+const GROUPS = [
+  {
+    canonicalDir: `${CANONICAL_ROOT}/custom-blocks`,
+    kind: "worker-custom-block",
+  },
+]
+
+async function collectFiles(dir, prefix = "") {
+  const files = []
+  const entries = await readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const relPath = join(prefix, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(join(dir, entry.name), relPath)))
+    } else {
+      files.push(relPath)
+    }
+  }
+  return files.sort()
+}
+
+async function readIfExists(path) {
+  try {
+    return await readFile(path, "utf8")
+  } catch {
+    return null
+  }
+}
+
+const catalog = JSON.parse(
+  await readFile(resolve(repoRoot, "catalog.json"), "utf8")
+)
+
+let drifted = []
+let synced = 0
+
+for (const group of GROUPS) {
+  const canonicalPath = resolve(repoRoot, group.canonicalDir)
+  const files = await collectFiles(canonicalPath)
+  if (files.length === 0) {
+    console.error(`No canonical files found in ${group.canonicalDir}`)
+    process.exit(1)
+  }
+
+  const recipes = catalog.recipes.filter((recipe) => recipe.kind === group.kind)
+  if (recipes.length === 0) {
+    console.error(`No catalog recipes with kind ${JSON.stringify(group.kind)}`)
+    process.exit(1)
+  }
+
+  for (const recipe of recipes) {
+    for (const file of files) {
+      const source = join(canonicalPath, file)
+      const target = resolve(repoRoot, recipe.path, ".agents", file)
+      const expected = await readFile(source, "utf8")
+      const actual = await readIfExists(target)
+      if (actual === expected) continue
+
+      if (checkMode) {
+        drifted.push(relative(repoRoot, target))
+      } else {
+        await mkdir(dirname(target), { recursive: true })
+        await writeFile(target, expected)
+        console.log(`synced ${relative(repoRoot, target)}`)
+        synced += 1
+      }
+    }
+  }
+}
+
+if (checkMode && drifted.length > 0) {
+  console.error(`Template agent files drifted from ${CANONICAL_ROOT}/:`)
+  for (const file of drifted) {
+    console.error(`  ${file}`)
+  }
+  console.error("Run `npm run agents:sync` and commit the result.")
+  process.exit(1)
+}
+
+console.log(
+  checkMode
+    ? `Template agent files match ${CANONICAL_ROOT}/.`
+    : synced === 0
+      ? "Template agent files already up to date."
+      : `Synced ${synced} file(s).`
+)

--- a/workers/agents/README.md
+++ b/workers/agents/README.md
@@ -3,12 +3,21 @@
 This directory is the single source of truth for the agent files that worker
 templates ship in their `.agents/` directory.
 
-Each subdirectory here mirrors the `.agents/` contents for one group of
-templates:
+Every `catalog.json` recipe with a `worker-` kind gets the `default/` set. A
+kind listed in `OVERRIDE_GROUPS` in `scripts/sync-agents.mjs` gets that
+directory instead. A new kind therefore inherits the default set, rather than
+being silently skipped.
 
-| Directory        | Copied into                                                       |
-| ---------------- | ----------------------------------------------------------------- |
-| `custom-blocks/` | every recipe in `catalog.json` with `kind: "worker-custom-block"` |
+| Directory        | Applies to                                 |
+| ---------------- | ------------------------------------------ |
+| `default/`       | every `worker-` recipe with no override    |
+| `custom-blocks/` | recipes with `kind: "worker-custom-block"` |
+
+The default set tells agents that custom blocks are a private alpha and must
+not be used. Custom-block templates need the opposite, so they override it.
+
+Each template also gets an `AGENTS.md` and a `CLAUDE.md` symlink pointing at
+`.agents/INSTRUCTIONS.md`, so both discovery conventions resolve to one file.
 
 ## Editing agent files
 
@@ -20,9 +29,11 @@ templates:
    put the regenerated copies in a separate stacked PR to keep review easy.
 
 CI runs `npm run agents:check` and fails when any per-template copy drifts from
-this directory.
+this directory. The check also fails on a stale file inside a generated
+subdirectory, and on a missing or wrong entry symlink.
 
-## Adding a template group
+## Adding an override
 
-Add a subdirectory here, then map it to a `catalog.json` `kind` in
-`scripts/sync-agents.mjs`.
+Add a subdirectory here, then map a `catalog.json` kind to it in
+`OVERRIDE_GROUPS` in `scripts/sync-agents.mjs`. The sync fails when an override
+names a kind that no recipe uses, so dead entries surface immediately.

--- a/workers/agents/README.md
+++ b/workers/agents/README.md
@@ -1,0 +1,28 @@
+# Canonical worker agent files
+
+This directory is the single source of truth for the agent files that worker
+templates ship in their `.agents/` directory.
+
+Each subdirectory here mirrors the `.agents/` contents for one group of
+templates:
+
+| Directory        | Copied into                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `custom-blocks/` | every recipe in `catalog.json` with `kind: "worker-custom-block"` |
+
+## Editing agent files
+
+1. Edit the files here — never the per-template copies under
+   `workers/*/.agents/`. Those copies are generated.
+2. Run `npm run agents:sync` (the pre-commit hook also runs it) to regenerate
+   the per-template copies.
+3. Commit the canonical change and the regenerated copies. For large changes,
+   put the regenerated copies in a separate stacked PR to keep review easy.
+
+CI runs `npm run agents:check` and fails when any per-template copy drifts from
+this directory.
+
+## Adding a template group
+
+Add a subdirectory here, then map it to a `catalog.json` `kind` in
+`scripts/sync-agents.mjs`.

--- a/workers/agents/custom-blocks/INSTRUCTIONS.md
+++ b/workers/agents/custom-blocks/INSTRUCTIONS.md
@@ -1,0 +1,531 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/` has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. The CLI's `--alpha` flag does not grant access. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects, including projects that use `--alpha`.
+
+### Custom block capability
+
+`worker.customBlock()` declares a front-end web app that Notion serves in an iframe. It is a build-time/deploy-time capability with no `execute` handler, so it cannot be run with `ntn workers exec`. A custom block has two SDK surfaces: `@notionhq/workers` declares how the block is built and which data-source schemas it expects, while `@notionhq/custom-blocks` allows the the iframe frontend code to communicate with the Notion host at runtime.
+
+Before scaffolding a custom block frontend, add `@notionhq/custom-blocks` to the worker's existing root `package.json`, add `@notionhq/custom-blocks-dev-shell` to its `devDependencies`, and install from the worker root. The block frontend shares that package and its `node_modules`. Do not create a second `package.json` inside the Vite app. Read the installed packages' READMEs and docs for the current client API.
+
+Use the custom blocks dev shell to test locally:
+
+```shell
+ntn customblocks dev
+```
+
+This builds the worker, serves each block with the project's Vite server, and renders in a mock Notion host with sample data sources to bind.
+
+See docs in `node_modules/@notionhq/custom-blocks-dev-shell/docs` for information on data bindings and sample data.
+
+#### Custom block sources
+
+A project source is the default. `path` points to a buildable project directory relative to the worker root. The deploy pipeline runs `npm run build` in that directory and serves its `dist` output by default:
+
+```ts
+worker.customBlock("issueBoard", {
+  path: "./blocks/issue-board",
+})
+```
+
+Use `command` and `output` to override those build defaults:
+
+```ts
+worker.customBlock("issueBoard", {
+  path: "./blocks/issue-board",
+  command: "npm run build-prod",
+  output: "build",
+})
+```
+
+Use a static source when the directory already contains browser assets that should be served as-is:
+
+```ts
+worker.customBlock("issueBoard", {
+  type: "static",
+  path: "./blocks/issue-board/dist",
+})
+```
+
+#### Custom block data-source schemas
+
+The optional `dataSources` field declares the schema a block expects. It does not bind the block to a concrete database. Schema keys and property keys are author-defined identifiers.
+
+```ts
+worker.customBlock("issueBoard", {
+  path: "./blocks/issue-board",
+  version: 1,
+  dataSources: {
+    issues: {
+      name: "Issues",
+      description: "The team's issues",
+      icon: { type: "emoji", emoji: "🐛" },
+      properties: {
+        title: {
+          name: "Title",
+          type: "title",
+        },
+        status: {
+          name: "Status",
+          description: "Workflow state",
+          type: "status",
+        },
+      },
+    },
+  },
+})
+```
+
+Property types use Public API names such as `title`, `rich_text`, `number`, `select`, `multi_select`, `status`, `date`, `people`, `files`, `checkbox`, `url`, `email`, `phone_number`, `formula`, `relation`, and `rollup`.
+
+At render time, the block maps its configured bindings to the matching `dataSources` keys. Read the example source above with `useDataSource("issues")` from `@notionhq/custom-blocks/react`.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+worker.sync("tasksSync", {
+  primaryKeyProperty: "ID",
+  schema: {
+    defaultName: "Tasks",
+    properties: { Name: Schema.title(), ID: Schema.richText() },
+  },
+  execute: async (_state, { notion }) => ({
+    changes: [
+      {
+        type: "upsert",
+        key: "1",
+        properties: {
+          Name: Builder.title("Write docs"),
+          ID: Builder.richText("1"),
+        },
+      },
+    ],
+    hasMore: false,
+  }),
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.automation("sendWelcomeEmail", {
+  title: "Send Welcome Email",
+  description: "Runs from a database automation",
+  execute: async (event, { notion }) => {},
+})
+
+worker.oauth("googleAuth", { name: "my-google-auth", provider: "google" })
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth, supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+- **OAuth setup order:** Deploy → `ntn workers env push` → set redirect URL → `ntn workers oauth start`. Secrets must be pushed before starting the OAuth flow because the deployed worker needs the client secret to exchange the authorization code for tokens.
+
+### Sync
+
+#### Strategy and Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`. By default, syncs run every 30 minutes. Set `schedule` to an interval like `"15m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`), or `"continuous"` to run as fast as possible.
+
+- Always use pagination, when available. Returning too many changes in one execution will fail. Start with batch sizes of ~100 changes.
+- `mode=replace` is simpler — use it when the API has no change tracking (no `updated_at` filter, no event feed)
+- Use `mode=incremental` when the API supports change tracking (e.g. `updated_since`, event streams), which enterprise APIs like Salesforce, Stripe, and Linear typically do
+- When using `mode=incremental`, emit delete markers as needed if easy to do (below)
+
+**Sync strategy (`mode`):**
+
+- `replace`: each sync cycle must return the full dataset. After the final `hasMore: false`, any records not seen during that cycle are deleted.
+- `incremental`: each sync cycle returns a subset of the full dataset (usually the changes since the last run). Deletions must be explicit via `{ type: "delete", key: "..." }`. Records not mentioned are left unchanged.
+
+**How pagination works:**
+
+1. Return a batch of changes with `hasMore: true` and a `nextState` value
+2. The runtime calls `execute` again with that state
+3. Continue until you return `hasMore: false`
+
+**Example replace sync:**
+
+```ts
+worker.sync("paginatedSync", {
+  mode: "replace",
+  primaryKeyProperty: "ID",
+  schema: {
+    defaultName: "Records",
+    properties: { Name: Schema.title(), ID: Schema.richText() },
+  },
+  execute: async (state, { notion }) => {
+    const page = state?.page ?? 1
+    const pageSize = 100
+    const { items, hasMore } = await fetchPage(page, pageSize)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert",
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+**State types:** The `nextState` can be any serializable value—a cursor string, page number, timestamp, or complex object. Type your execute function's `state` to match.
+
+**Incremental example (changes only, with deletes):**
+
+```ts
+worker.sync("incrementalSync", {
+  primaryKeyProperty: "ID",
+  mode: "incremental",
+  schema: {
+    defaultName: "Records",
+    properties: { Name: Schema.title(), ID: Schema.richText() },
+  },
+  execute: async (state, { notion }) => {
+    const { upserts, deletes, nextCursor } = await fetchChanges(state?.cursor)
+    return {
+      changes: [
+        ...upserts.map((item) => ({
+          type: "upsert",
+          key: item.id,
+          properties: {
+            Name: Builder.title(item.name),
+            ID: Builder.richText(item.id),
+          },
+        })),
+        ...deletes.map((id) => ({ type: "delete", key: id })),
+      ],
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Relations
+
+Two syncs can relate to one another using `Schema.relation(relatedSyncKey)` and `Builder.relation(primaryKey)` entries inside an array.
+
+```ts
+worker.sync("projectsSync", {
+  primaryKeyProperty: "Project ID",
+  ...
+});
+
+// Example sync worker that syncs sample tasks to a database
+worker.sync("tasksSync", {
+  primaryKeyProperty: "Task ID",
+  ...
+  schema: {
+    ...
+    properties: {
+      ...
+      Project: Schema.relation("projectsSync", {
+        // Optionally configure a two-way relation. This will automatically create the
+        // "Tasks" property on the project synced database: there is no need
+        // to configure "Tasks" on the projectSync capability.
+        twoWay: true, relatedPropertyName: "Tasks"
+      }),
+    },
+  },
+
+  execute: async () => {
+    // Return sample tasks as database entries
+    const tasks = fetchTasks()
+    const changes = tasks.map((task) => ({
+      type: "upsert" as const,
+      key: task.id,
+      properties: {
+        ...
+        Project: [Builder.relation(task.projectId)],
+      },
+    }));
+
+    return {
+      changes,
+      hasMore: false,
+    };
+  },
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `notion workers webhooks ls` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw WebhookVerificationError if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn customblocks dev`: render custom blocks locally in the dev shell; test there before deploying.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Custom blocks are exercised in the dev shell (`ntn customblocks dev`), not with `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/agents/default/INSTRUCTIONS.md
+++ b/workers/agents/default/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/airflow/.agents/INSTRUCTIONS.md
+++ b/workers/airflow/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/airflow/AGENTS.md
+++ b/workers/airflow/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/airflow/CLAUDE.md
+++ b/workers/airflow/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/chart-generator/.agents/INSTRUCTIONS.md
+++ b/workers/chart-generator/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/chart-generator/AGENTS.md
+++ b/workers/chart-generator/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/chart-generator/CLAUDE.md
+++ b/workers/chart-generator/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/cloudwatch-logs/.agents/INSTRUCTIONS.md
+++ b/workers/cloudwatch-logs/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/cloudwatch-logs/AGENTS.md
+++ b/workers/cloudwatch-logs/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/cloudwatch-logs/CLAUDE.md
+++ b/workers/cloudwatch-logs/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/duckdb-query/.agents/INSTRUCTIONS.md
+++ b/workers/duckdb-query/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/duckdb-query/AGENTS.md
+++ b/workers/duckdb-query/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/duckdb-query/CLAUDE.md
+++ b/workers/duckdb-query/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/duckdb-sync/.agents/INSTRUCTIONS.md
+++ b/workers/duckdb-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/duckdb-sync/AGENTS.md
+++ b/workers/duckdb-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/duckdb-sync/CLAUDE.md
+++ b/workers/duckdb-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/github-draft-release-tools/.agents/INSTRUCTIONS.md
+++ b/workers/github-draft-release-tools/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/github-draft-release-tools/AGENTS.md
+++ b/workers/github-draft-release-tools/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/github-draft-release-tools/CLAUDE.md
+++ b/workers/github-draft-release-tools/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/github-stars-sync/.agents/INSTRUCTIONS.md
+++ b/workers/github-stars-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/github-stars-sync/AGENTS.md
+++ b/workers/github-stars-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/github-stars-sync/CLAUDE.md
+++ b/workers/github-stars-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/github-sync/.agents/INSTRUCTIONS.md
+++ b/workers/github-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/github-sync/AGENTS.md
+++ b/workers/github-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/github-sync/CLAUDE.md
+++ b/workers/github-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/hubspot-sync/.agents/INSTRUCTIONS.md
+++ b/workers/hubspot-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/hubspot-sync/AGENTS.md
+++ b/workers/hubspot-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/hubspot-sync/CLAUDE.md
+++ b/workers/hubspot-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/intercom-sync/.agents/INSTRUCTIONS.md
+++ b/workers/intercom-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/intercom-sync/AGENTS.md
+++ b/workers/intercom-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/intercom-sync/CLAUDE.md
+++ b/workers/intercom-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/jira-sync/.agents/INSTRUCTIONS.md
+++ b/workers/jira-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/jira-sync/AGENTS.md
+++ b/workers/jira-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/jira-sync/CLAUDE.md
+++ b/workers/jira-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/linear-sync/.agents/INSTRUCTIONS.md
+++ b/workers/linear-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/linear-sync/AGENTS.md
+++ b/workers/linear-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/linear-sync/CLAUDE.md
+++ b/workers/linear-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/pagerduty-sync/.agents/INSTRUCTIONS.md
+++ b/workers/pagerduty-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/pagerduty-sync/AGENTS.md
+++ b/workers/pagerduty-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/pagerduty-sync/CLAUDE.md
+++ b/workers/pagerduty-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/postgres-query/.agents/INSTRUCTIONS.md
+++ b/workers/postgres-query/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/postgres-query/AGENTS.md
+++ b/workers/postgres-query/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/postgres-query/CLAUDE.md
+++ b/workers/postgres-query/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/powerpoint-creator/.agents/INSTRUCTIONS.md
+++ b/workers/powerpoint-creator/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/powerpoint-creator/AGENTS.md
+++ b/workers/powerpoint-creator/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/powerpoint-creator/CLAUDE.md
+++ b/workers/powerpoint-creator/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/raindrop-sync/.agents/INSTRUCTIONS.md
+++ b/workers/raindrop-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/raindrop-sync/AGENTS.md
+++ b/workers/raindrop-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/raindrop-sync/CLAUDE.md
+++ b/workers/raindrop-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/readwise-sync/.agents/INSTRUCTIONS.md
+++ b/workers/readwise-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/readwise-sync/AGENTS.md
+++ b/workers/readwise-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/readwise-sync/CLAUDE.md
+++ b/workers/readwise-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/salesforce-sync/.agents/INSTRUCTIONS.md
+++ b/workers/salesforce-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/salesforce-sync/AGENTS.md
+++ b/workers/salesforce-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/salesforce-sync/CLAUDE.md
+++ b/workers/salesforce-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/sentry-pagerduty-incident-tools/.agents/INSTRUCTIONS.md
+++ b/workers/sentry-pagerduty-incident-tools/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/sentry-pagerduty-incident-tools/AGENTS.md
+++ b/workers/sentry-pagerduty-incident-tools/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/sentry-pagerduty-incident-tools/CLAUDE.md
+++ b/workers/sentry-pagerduty-incident-tools/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/sentry-sync/.agents/INSTRUCTIONS.md
+++ b/workers/sentry-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/sentry-sync/AGENTS.md
+++ b/workers/sentry-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/sentry-sync/CLAUDE.md
+++ b/workers/sentry-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/snowflake-query/.agents/INSTRUCTIONS.md
+++ b/workers/snowflake-query/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/snowflake-query/AGENTS.md
+++ b/workers/snowflake-query/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/snowflake-query/CLAUDE.md
+++ b/workers/snowflake-query/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/snowflake-sync/.agents/INSTRUCTIONS.md
+++ b/workers/snowflake-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/snowflake-sync/AGENTS.md
+++ b/workers/snowflake-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/snowflake-sync/CLAUDE.md
+++ b/workers/snowflake-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/sqlite-query/.agents/INSTRUCTIONS.md
+++ b/workers/sqlite-query/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/sqlite-query/AGENTS.md
+++ b/workers/sqlite-query/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/sqlite-query/CLAUDE.md
+++ b/workers/sqlite-query/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/todoist-sync/.agents/INSTRUCTIONS.md
+++ b/workers/todoist-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/todoist-sync/AGENTS.md
+++ b/workers/todoist-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/todoist-sync/CLAUDE.md
+++ b/workers/todoist-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/vercel-production-deployment-tools/.agents/INSTRUCTIONS.md
+++ b/workers/vercel-production-deployment-tools/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/vercel-production-deployment-tools/AGENTS.md
+++ b/workers/vercel-production-deployment-tools/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/vercel-production-deployment-tools/CLAUDE.md
+++ b/workers/vercel-production-deployment-tools/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/workday-sync/.agents/INSTRUCTIONS.md
+++ b/workers/workday-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/workday-sync/AGENTS.md
+++ b/workers/workday-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/workday-sync/CLAUDE.md
+++ b/workers/workday-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/zendesk-sync/.agents/INSTRUCTIONS.md
+++ b/workers/zendesk-sync/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/zendesk-sync/AGENTS.md
+++ b/workers/zendesk-sync/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/zendesk-sync/CLAUDE.md
+++ b/workers/zendesk-sync/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/zendesk-webhook/.agents/INSTRUCTIONS.md
+++ b/workers/zendesk-webhook/.agents/INSTRUCTIONS.md
@@ -1,0 +1,594 @@
+# Repository Guidelines
+
+Overall workers documentation lives at https://developers.notion.com/workers/get-started/overview.md.
+
+## Project Structure & Module Organization
+
+- `src/index.ts` defines the worker and capabilities.
+- `.examples/`, when present, has focused samples (sync, tool, automation, OAuth, webhook).
+- Shared agent skills, when present, live in `.agents/skills/`. `.claude/skills` is kept as a compatibility symlink for Claude-specific discovery.
+- Generated: `dist/` build output, `workers.json` CLI config.
+
+## Worker & Capability API (SDK)
+
+- `@notionhq/workers` provides `Worker`, schema helpers, and builders; the `ntn` CLI powers worker management.
+- Capability keys are unique strings used by the CLI (e.g., `ntn workers exec tasksSync`).
+
+### Workflow capability availability
+
+`worker.workflow()` is in a private alpha and is not available to any users. Do not mention workflow capabilities to users, even to explain their availability. Do not suggest, scaffold, or use them in user projects.
+
+### Custom block capability availability
+
+`worker.customBlock()` is in a private alpha and is not available to most users. It may be present in the installed SDK, but its presence does not grant access. Do not suggest, scaffold, or use custom blocks in user projects. Do not add the `@notionhq/custom-blocks` dependency or custom block frontend code.
+
+```ts
+import { Worker } from "@notionhq/workers"
+import * as Builder from "@notionhq/workers/builder"
+import * as Schema from "@notionhq/workers/schema"
+
+const worker = new Worker()
+export default worker
+
+// Declare a sync target database (only written to by syncs — not for general-purpose storage)
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+// Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Declare a sync that writes to the database
+worker.sync("tasksSync", {
+  database: tasks,
+  execute: async (state) => {
+    await myApi.wait()
+    const items = await fetchItems(state?.page ?? 1)
+    return {
+      changes: items.map((i) => ({
+        type: "upsert" as const,
+        key: i.id,
+        properties: { Name: Builder.title(i.name), ID: Builder.richText(i.id) },
+      })),
+      hasMore: false,
+    }
+  },
+})
+
+worker.tool("sayHello", {
+  title: "Say Hello",
+  description: "Return a greeting",
+  schema: {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  execute: ({ name }, { notion }) => `Hello, ${name}`,
+})
+
+worker.oauth("googleAuth", {
+  name: "my-google-auth",
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  scope: "openid email",
+  clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+})
+
+worker.webhook("onGithubPush", {
+  title: "GitHub Push Webhook",
+  description: "Handles push events from GitHub",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Push:", event.body)
+    }
+  },
+})
+```
+
+### Notion API access (`context.notion`)
+
+All `execute` handlers receive a `context.notion` object (a `@notionhq/client` SDK instance). You can use this to make API requests to Notion.
+
+However, `context.notion` is only **pre-authenticated** when it's a tool capability invoked by a Custom Agent. In that case, the platform sets `NOTION_API_TOKEN` automatically, using the permissions of the Custom Agent — no setup required.
+
+For all other capabilities (syncs, automations, webhooks), `context.notion` is **not** pre-authenticated. The user must set the `NOTION_API_TOKEN` environment variable themselves by:
+
+1. Creating a connection at https://app.notion.com/developers/connections
+2. Giving that connection access to the relevant pages and databases in Notion
+3. Adding the token to `.env` locally, or pushing it with `ntn workers env push` for deployed workers
+
+Before writing code that uses `context.notion` in a non-tool capability, check whether `NOTION_API_TOKEN` is configured: look for it in `.env` (e.g. `grep -q '^NOTION_API_TOKEN=' .env`). If it is not set, prompt the user to create a connection at https://app.notion.com/developers/connections and add the token to `.env`.
+
+- For user-managed OAuth (shown above), supply `name`, `authorizationEndpoint`, `tokenEndpoint`, `clientId`, `clientSecret`, and `scope` (optional: `authorizationParams`, `callbackUrl`, `accessTokenExpireMs`).
+- **Note:** A Notion-managed OAuth shorthand (`{ provider: "google" }`) also exists but is in alpha and most users will not have access. Use the user-managed configuration above.
+- After deploying a worker with an OAuth capability, the user must configure their OAuth provider's redirect URL to match the one assigned by Notion. Run `ntn workers oauth show-redirect-url` to get the redirect URL, then set it in the provider's OAuth app settings. **Always remind the user of this step after deploying any OAuth capability.**
+
+### Sync
+
+#### Databases, Pacers, and Syncs
+
+`worker.database()` declares a sync target — a Notion database that syncs write into. **Databases are read-only from the worker's perspective: the only way to write to them is through syncs.** Do not use `worker.database()` to create general-purpose databases (e.g., for storing webhook payloads, tool results, or scratch data). For non-sync writes to Notion, use `context.notion` (the Notion SDK client) directly.
+
+Databases are declared separately and referenced by handle:
+
+```ts
+// 1. Declare a database
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+// 2. Declare a pacer for the upstream API
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// 3. Declare a sync
+worker.sync("tasksSync", {
+  database: tasks,
+  schedule: "30m",
+  execute: async (state) => {
+    await myApi.wait()
+    const { items, hasMore } = await fetchTasks(state?.page ?? 1)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: (state?.page ?? 1) + 1 } : undefined,
+    }
+  },
+})
+```
+
+Multiple syncs can write to the same database. Multiple syncs can share a pacer — the server apportions the budget evenly across all syncs that use it.
+
+#### Pacers (Rate Limiting)
+
+**Always declare a pacer** for any sync that calls an external API. Research the API's rate limits before implementing. If the limits are variable (e.g. Salesforce, where you can purchase more API calls), ask the user what budget to allocate.
+
+- Call `await pacer.wait()` before **every** API request inside `execute`.
+- The pacer ensures requests are evenly spaced over the interval window.
+- If 4 syncs share a pacer with `allowedRequests: 100, intervalMs: 60_000`, each sync gets ~25 requests/minute.
+
+```ts
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+// Inside execute:
+await myApi.wait()
+const data = await fetchFromApi()
+```
+
+#### Choosing a Sync Strategy
+
+**Simple replace sync** — For truly small data sources (<1k records) or APIs with no change-tracking support. One sync, replace mode. Every cycle returns the full dataset; records not returned are deleted via mark-and-sweep.
+
+**Backfill + delta pair** — For everything else (recommended for most real integrations). Two syncs writing to the same database:
+
+- **Backfill** (replace mode, `schedule: "manual"`): Paginates the entire upstream dataset. Triggered manually via CLI. Cleans up drift, backfills new schema properties, catches deletes the delta can't detect.
+- **Delta** (incremental mode, frequent schedule like `"5m"` or `"30m"`): Fetches only recent changes via `updated_since`, change feeds, etc. Keeps Notion current with minimal API usage.
+
+Use backfill + delta whenever the upstream API supports any form of change tracking (`updated_since`, `modified_after`, change feeds, webhooks). Most enterprise APIs do (Salesforce, Jira, Linear, Stripe, GitHub, etc.).
+
+##### Delete handling
+
+- **API supports delta deletes** (returns deleted records in change feed): Emit `{ type: "delete", key }` in the delta sync.
+- **API doesn't, but deletes are rare or irrelevant** (e.g. Stripe subscriptions are canceled not deleted, Jira issues are closed not deleted): No action needed — the upstream record still exists, just in a different state.
+- **API doesn't, and deletes matter**: The backfill sync handles this. Its replace-mode mark-and-sweep deletes records no longer present upstream.
+
+#### Simple Replace Sync Example
+
+```ts
+const records = worker.database("records", {
+  type: "managed",
+  initialTitle: "Records",
+  primaryKeyProperty: "ID",
+  schema: { properties: { Name: Schema.title(), ID: Schema.richText() } },
+})
+
+const myApi = worker.pacer("myApi", { allowedRequests: 10, intervalMs: 1000 })
+
+worker.sync("recordsSync", {
+  database: records,
+  mode: "replace",
+  schedule: "1h",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await myApi.wait()
+    const { items, hasMore } = await fetchPage(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          Name: Builder.title(item.name),
+          ID: Builder.richText(item.id),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+```
+
+#### Backfill + Delta Example
+
+```ts
+const tasks = worker.database("tasks", {
+  type: "managed",
+  initialTitle: "Tasks",
+  primaryKeyProperty: "Task ID",
+  schema: {
+    properties: {
+      "Task Name": Schema.title(),
+      "Task ID": Schema.richText(),
+      Status: Schema.select([
+        { name: "Open" },
+        { name: "Done", color: "green" },
+      ]),
+    },
+  },
+})
+
+const taskApi = worker.pacer("taskApi", {
+  allowedRequests: 10,
+  intervalMs: 1000,
+})
+
+// Backfill: paginates full dataset, runs manually.
+// To re-backfill: ntn workers sync state reset tasksBackfill && ntn workers sync trigger tasksBackfill
+worker.sync("tasksBackfill", {
+  database: tasks,
+  mode: "replace",
+  schedule: "manual",
+  execute: async (state) => {
+    const page = state?.page ?? 1
+    await taskApi.wait()
+    const { items, hasMore } = await fetchAllTasks(page, 100)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore,
+      nextState: hasMore ? { page: page + 1 } : undefined,
+    }
+  },
+})
+
+// Delta: fetches recent changes, runs every 5 minutes.
+worker.sync("tasksDelta", {
+  database: tasks,
+  mode: "incremental",
+  schedule: "5m",
+  execute: async (state) => {
+    const cursor = state?.cursor
+    await taskApi.wait()
+    const { items, nextCursor } = await fetchTaskChanges(cursor)
+    return {
+      changes: items.map((item) => ({
+        type: "upsert" as const,
+        key: item.id,
+        properties: {
+          "Task Name": Builder.title(item.name),
+          "Task ID": Builder.richText(item.id),
+          Status: Builder.select(item.status),
+        },
+      })),
+      hasMore: Boolean(nextCursor),
+      nextState: nextCursor ? { cursor: nextCursor } : undefined,
+    }
+  },
+})
+```
+
+#### Pagination
+
+Syncs run in a "sync cycle": a back-to-back chain of `execute` calls that starts at a scheduled trigger and ends when an execution returns `hasMore: false`.
+
+- Always paginate. Returning too many changes in one execution will fail. Start with batch sizes of ~100.
+- Return `hasMore: true` and `nextState` to continue; `hasMore: false` to finish.
+- `nextState` can be any serializable value: cursor string, page number, timestamp, or complex object.
+
+#### Schedule
+
+Set `schedule` on a sync to control how often it runs:
+
+- `"continuous"`: run as fast as possible
+- `"manual"`: only via CLI trigger
+- Interval string: `"5m"`, `"30m"`, `"1h"`, `"1d"` (min `"1m"`, max `"7d"`)
+- Default: `"30m"`
+
+#### Relations
+
+Two databases can relate to one another using `Schema.relation(syncKey)` and `Builder.relation(primaryKey)`:
+
+```ts
+const projects = worker.database("projects", {
+ type: "managed",
+ initialTitle: "Projects",
+ primaryKeyProperty: "Project ID",
+ schema: { properties: { "Project Name": Schema.title(), "Project ID": Schema.richText() } },
+});
+
+const tasks = worker.database("tasks", {
+ type: "managed",
+ initialTitle: "Tasks",
+ primaryKeyProperty: "Task ID",
+ schema: {
+  properties: {
+   "Task Name": Schema.title(),
+   "Task ID": Schema.richText(),
+   // Reference the sync key that populates the related database
+   Project: Schema.relation("projectsSync", { twoWay: true, relatedPropertyName: "Tasks" }),
+  },
+ },
+});
+
+worker.sync("projectsSync", { database: projects, execute: async () => { ... } });
+worker.sync("tasksSync", {
+ database: tasks,
+ execute: async () => ({
+  changes: [{
+   type: "upsert" as const,
+   key: "task-1",
+   properties: {
+    "Task Name": Builder.title("Write docs"),
+    "Task ID": Builder.richText("task-1"),
+    Project: [Builder.relation("proj-1")], // array of relation refs
+   },
+  }],
+  hasMore: false,
+ }),
+});
+```
+
+### Webhooks
+
+Webhooks expose HTTP endpoints that external services can call. After deploying, the CLI prints the webhook URL. Use `ntn workers webhooks list` to see URLs at any time.
+
+The execute handler receives an array of `WebhookEvent` objects. Each event contains `deliveryId` (stable idempotency key across retries), `body` (parsed JSON), `rawBody` (string, for signature verification), `headers`, and `method`.
+
+```ts
+worker.webhook("onExternalEvent", {
+  title: "External Event Handler",
+  description: "Processes incoming webhook requests",
+  execute: async (events, { notion }) => {
+    for (const event of events) {
+      console.log("Method:", event.method)
+      console.log("Body:", JSON.stringify(event.body))
+      // Use event.headers to access request headers
+    }
+  },
+})
+```
+
+**Security:** Each webhook gets a unique ID in the URL path that acts as a shared secret. The URL format is:
+
+```text
+https://www.notion.so/webhooks/worker/{spaceId}/{workerId}/{uniqueWebhookId}/{webhookName}
+```
+
+This full URL can be retrieved using the `ntn workers webhooks list` command.
+
+It is also the responsibility of the worker to verify the webhook. Throw `WebhookVerificationError` if the payload is not valid. 5 invalid payloads in a row will cause webhooks to short circuit until redeployed.
+
+### Sync Management (CLI)
+
+**Monitor sync status:**
+
+```shell
+ntn workers sync status              # live-updating watch mode (polls every 5s)
+ntn workers sync status <key>        # filter to a specific sync capability
+ntn workers sync status --no-watch   # print once and exit
+ntn workers sync status --interval 10 # custom poll interval in seconds
+```
+
+Status labels:
+
+- **HEALTHY** — last run succeeded
+- **INITIALIZING** — deployed but hasn't succeeded yet
+- **WARNING** — 1–2 consecutive failures
+- **ERROR** — 3+ consecutive failures
+- **DISABLED** — capability is disabled
+
+**Preview a sync (inspect output without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview                   # run execute, show objects, don't write to the database
+ntn workers sync trigger <key> --preview --context '{"page":2}'  # resume from a previous preview's nextContext
+```
+
+Preview calls your sync's `execute` function and shows the objects it would produce, but **does not write anything to the Notion database**. Use it to verify your sync logic and inspect the data before committing to a real run. When piped, outputs raw JSON.
+
+**Trigger a sync (write immediately, bypass schedule):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+Trigger starts a **real** sync cycle that writes to the database, bypassing the normal schedule. Use it to push changes immediately rather than waiting for the next scheduled run.
+
+**Reset sync state (restart from scratch):**
+
+```shell
+ntn workers sync state reset <key>
+```
+
+Clears the cursor and stats so the next run starts from the beginning.
+
+**Enable / disable a sync:**
+
+```shell
+ntn workers capabilities list            # show all capabilities
+ntn workers capabilities disable <key>   # pause a sync
+ntn workers capabilities enable <key>    # resume a sync
+```
+
+> **Note:** `ntn workers deploy` does **not** reset sync state. Syncs resume from their last cursor position after a deploy. Use `ntn workers sync state reset <key>` to explicitly restart from scratch.
+
+### Querying a database
+
+Use `ntn datasources query <data-source-id>` to list pages in a database. **The argument is a data source ID, not a database ID** — a database in Notion is a container for one or more data sources, and the public API queries data sources directly.
+
+If you only have a database ID, run `ntn datasources resolve <database-id>` first to list the data sources it contains:
+
+```shell
+ntn datasources resolve <database-id>
+```
+
+If exactly one data source is returned, retry the query with that ID. If multiple are returned, pick the one whose name matches what you want.
+
+When `ntn datasources query <id>` returns 404 or "Could not find data source", the ID is most likely a database ID — run `resolve` against it and retry with one of the data source IDs it lists.
+
+## Build, Test, and Development Commands
+
+- Node >= 22 and npm >= 10.9.2 (see `package.json` engines).
+- `npm run build`: compile TypeScript to `dist/`.
+- `npm run check`: type-check only (no emit).
+- `ntn login`: connect to a Notion workspace.
+- `ntn workers deploy`: build and publish capabilities. Does not reset sync state.
+- `ntn workers exec <capability>`: run a sync or tool.
+- `ntn workers sync status`: monitor sync health (live-updating).
+- `ntn workers sync trigger <key> --preview`: preview sync output without writing to the database.
+- `ntn workers sync trigger <key>`: trigger a real sync immediately (writes to the database).
+
+## Debugging & Monitoring Runs
+
+Use `ntn workers runs` to inspect run history and logs.
+
+**List recent runs:**
+
+```shell
+ntn workers runs list
+```
+
+**Get logs for a specific run:**
+
+```shell
+ntn workers runs logs <runId>
+```
+
+**Get logs for the latest run (any capability):**
+
+```shell
+ntn workers runs list --plain | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+**Get logs for the latest run of a specific capability:**
+
+```shell
+ntn workers runs list --plain | grep tasksSync | head -n1 | cut -f1 | xargs -I{} ntn workers runs logs {}
+```
+
+The `--plain` flag outputs tab-separated values without formatting, making it easy to pipe to other commands.
+
+### Debugging Syncs
+
+**Check sync health:**
+
+```shell
+ntn workers sync status
+```
+
+Look at failure counts, error messages, and last succeeded times.
+
+**Sync not running?** Check if the capability is disabled:
+
+```shell
+ntn workers capabilities list
+```
+
+**Preview what a sync would produce (without writing):**
+
+```shell
+ntn workers sync trigger <key> --preview
+```
+
+**Retry a failed sync (writes to the database):**
+
+```shell
+ntn workers sync trigger <key>
+```
+
+**Sync in a bad state?** Reset the cursor and restart:
+
+```shell
+ntn workers sync state reset <key>
+```
+
+## Coding Style & Naming Conventions
+
+- TypeScript with `strict` enabled; keep types explicit when shaping I/O.
+- Use tabs for indentation; capability keys in lowerCamelCase.
+
+## Testing Guidelines
+
+- No test runner configured; validate with `npm run check` and end-to-end testing via `ntn workers exec`.
+- Write a test script that exercises each tool capability using `ntn workers exec`. This can be a bash script (`test.sh`) or a TypeScript script (`test.ts`, run via `npx tsx test.ts`). Use the `--local` flag for local execution or omit it to run against the deployed worker.
+
+**Local execution** runs your worker code directly on your machine. Any `.env` file in the project root is automatically loaded, so secrets and config values are available via `process.env`.
+
+**Remote execution** (without `--local`) runs against the deployed worker. Any required secrets must be pushed to the remote environment first using `ntn workers env push`.
+
+**Example bash test script (`test.sh`):**
+
+```shell
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run locally (uses .env automatically):
+ntn workers exec sayHello --local -d '{"name": "World"}'
+
+# Or run against the deployed worker (requires `ntn workers deploy` and `ntn workers env push` first):
+# ntn workers exec sayHello -d '{"name": "World"}'
+```
+
+**Example TypeScript test script (`test.ts`, run with `npx tsx test.ts`):**
+
+```ts
+import { execSync } from "child_process"
+
+function exec(capability: string, input: Record<string, unknown>) {
+  const result = execSync(
+    `ntn workers exec ${capability} --local -d '${JSON.stringify(input)}'`,
+    { encoding: "utf-8" }
+  )
+  console.log(result)
+}
+
+exec("sayHello", { name: "World" })
+```
+
+Use this pattern to build up a suite of exec calls that covers each tool with representative inputs.
+
+## Commit & Pull Request Guidelines
+
+- Messages typically use `feat(scope): ...`, `TASK-123: ...`, or version bumps.
+- PRs should describe changes, list commands run, and update examples if behavior changes.

--- a/workers/zendesk-webhook/AGENTS.md
+++ b/workers/zendesk-webhook/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md

--- a/workers/zendesk-webhook/CLAUDE.md
+++ b/workers/zendesk-webhook/CLAUDE.md
@@ -1,0 +1,1 @@
+.agents/INSTRUCTIONS.md


### PR DESCRIPTION
## Summary of changes

**Default instruction set.** `workers/agents/default/INSTRUCTIONS.md` is the non-alpha set. It tells agents that custom blocks and workflows are a private alpha and must not be used.

**Default plus overrides.** `scripts/sync-agents.mjs` now resolves one canonical group per recipe:

```js
const DEFAULT_GROUP = `${CANONICAL_ROOT}/default`
const OVERRIDE_GROUPS = {
  "worker-custom-block": `${CANONICAL_ROOT}/custom-blocks`,
}
```

Every `catalog.json` recipe with a `worker-` kind gets `DEFAULT_GROUP`. A kind listed in `OVERRIDE_GROUPS` gets that directory instead. `worker-custom-block` is the only override today, because those templates must document the alpha capability the default set forbids.

This inverts the previous shape, which listed kinds per group. There, an unlisted kind was silently skipped and shipped no agent files. Now a new kind inherits the default set, and you opt into an override. The sync fails when an override names a kind that no recipe uses, so a dead entry cannot sit unnoticed.

**Fan-out.** The 28 worker templates that shipped no agent files now get the default set. Each template also gets `AGENTS.md` and `CLAUDE.md` symlinks to `.agents/INSTRUCTIONS.md`. The 4 custom-block templates already did this on `main`; this makes it uniform.

**Stronger check.** The sync sweeps stale files from generated subdirectories, and repairs an entry link that is missing or points elsewhere. `--check` reports both.

Stacked on #78. Review that one first.

## Verification

No `/verify` run backs this PR yet. I plan one run for the finished stack.

I exercised the new logic directly. Each case below ran against this branch:

| Case | Result |
|---|---|
| Edit `workers/airflow/.agents/INSTRUCTIONS.md` | `agents:check` exits 1, names the file |
| Replace `workers/duckdb-query/AGENTS.md` with a real file | exits 1, reports `not a symlink to .agents/INSTRUCTIONS.md` |
| Add a stray file in a generated subdirectory | exits 1, reports `stale, not in canonical` |
| Add a stray file in a subdirectory not in the canonical set | ignored, by design |
| Point `OVERRIDE_GROUPS` at a kind no recipe uses | exits 1, names the kind |
| Remove `workers/agents/default/` | exits 1, names the directory |
| Run `agents:sync` after each | restores the tree, `agents:check` passes |

`catalog:validate`, `format:check`, and `lint:markdown` pass. The commit ran the pre-commit hook end to end, including the widened `git add` pathspecs.

**Reviewer note on the diff size.** 88 files, but only 4 are hand-written: the default instructions, the script, the hook, and the directory README. The other 84 are generated. `npm run agents:sync` reproduces them exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
