### PR TITLE
feat(agents): symlink .claude/skills in worker templates

### DIFF
--- a/scripts/sync-agent-files.mjs
+++ b/scripts/sync-agent-files.mjs
@@ -58,9 +58,12 @@ const OVERRIDE_GROUPS = {
   },
 }
 
+// A link target resolves against the directory holding the link, not the
+// template root, so a nested link climbs out before naming `.agents/`.
 const AGENT_SYMLINKS = [
   { name: "AGENTS.md", target: ".agents/INSTRUCTIONS.md" },
   { name: "CLAUDE.md", target: ".agents/INSTRUCTIONS.md" },
+  { name: ".claude/skills", target: "../.agents/skills" },
 ]
 
 // Returns [] when the directory is absent, so a template with no `.agents/`
@@ -211,7 +214,8 @@ for (const group of groups.values()) {
         }
         continue
       }
-      await rm(linkPath, { force: true })
+      await rm(linkPath, { recursive: true, force: true })
+      await mkdir(dirname(linkPath), { recursive: true })
       await symlink(link.target, linkPath)
     }
   }

--- a/scripts/sync-agent-files.mjs
+++ b/scripts/sync-agent-files.mjs
@@ -98,6 +98,28 @@ function fail(message) {
   process.exit(1)
 }
 
+// Recipe paths are resolved lexically, so the confinement check below cannot
+// see a symlink standing in for a real directory. A recursive delete follows
+// such a parent outside the repository, so refuse to remove through one. The
+// canonical root is passed in, never a recipe path, so a symlinked recipe
+// directory cannot redefine the boundary.
+async function assertNoSymlinkParents(root, target) {
+  const rootPath = resolve(root)
+  let current = dirname(target)
+  while (current.startsWith(rootPath + sep)) {
+    let stat
+    try {
+      stat = await lstat(current)
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error
+    }
+    if (stat?.isSymbolicLink()) {
+      fail(`Refusing to remove through symlinked parent: ${current}`)
+    }
+    current = dirname(current)
+  }
+}
+
 const catalog = JSON.parse(
   await readFile(resolve(repoRoot, "catalog.json"), "utf8")
 )
@@ -191,6 +213,7 @@ for (const group of groups.values()) {
         }
       }
     } else {
+      await assertNoSymlinkParents(templatesRoot, agentsRoot)
       await rm(agentsRoot, { recursive: true, force: true })
       for (const [file, expected] of contents) {
         const target = join(agentsRoot, file)
@@ -212,6 +235,7 @@ for (const group of groups.values()) {
         }
         continue
       }
+      await assertNoSymlinkParents(templatesRoot, linkPath)
       await rm(linkPath, { recursive: true, force: true })
       await mkdir(dirname(linkPath), { recursive: true })
       await symlink(link.target, linkPath)

--- a/scripts/sync-agent-files.mjs
+++ b/scripts/sync-agent-files.mjs
@@ -58,8 +58,6 @@ const OVERRIDE_GROUPS = {
   },
 }
 
-// A link target resolves against the directory holding the link, not the
-// template root, so a nested link climbs out before naming `.agents/`.
 const AGENT_SYMLINKS = [
   { name: "AGENTS.md", target: ".agents/INSTRUCTIONS.md" },
   { name: "CLAUDE.md", target: ".agents/INSTRUCTIONS.md" },

--- a/workers/templates/airflow/.claude/skills
+++ b/workers/templates/airflow/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/chart-generator/.claude/skills
+++ b/workers/templates/chart-generator/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/cloudwatch-logs/.claude/skills
+++ b/workers/templates/cloudwatch-logs/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/custom-blocks/custom/.claude/skills
+++ b/workers/templates/custom-blocks/custom/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/custom-blocks/habit-tracker/.claude/skills
+++ b/workers/templates/custom-blocks/habit-tracker/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/custom-blocks/org-chart/.claude/skills
+++ b/workers/templates/custom-blocks/org-chart/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/custom-blocks/whiteboard/.claude/skills
+++ b/workers/templates/custom-blocks/whiteboard/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/duckdb-query/.claude/skills
+++ b/workers/templates/duckdb-query/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/duckdb-sync/.claude/skills
+++ b/workers/templates/duckdb-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/github-draft-release-tools/.claude/skills
+++ b/workers/templates/github-draft-release-tools/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/github-stars-sync/.claude/skills
+++ b/workers/templates/github-stars-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/github-sync/.claude/skills
+++ b/workers/templates/github-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/hubspot-sync/.claude/skills
+++ b/workers/templates/hubspot-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/intercom-sync/.claude/skills
+++ b/workers/templates/intercom-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/jira-sync/.claude/skills
+++ b/workers/templates/jira-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/linear-sync/.claude/skills
+++ b/workers/templates/linear-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/pagerduty-sync/.claude/skills
+++ b/workers/templates/pagerduty-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/postgres-query/.claude/skills
+++ b/workers/templates/postgres-query/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/powerpoint-creator/.claude/skills
+++ b/workers/templates/powerpoint-creator/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/raindrop-sync/.claude/skills
+++ b/workers/templates/raindrop-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/readwise-sync/.claude/skills
+++ b/workers/templates/readwise-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/salesforce-sync/.claude/skills
+++ b/workers/templates/salesforce-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/sentry-pagerduty-incident-tools/.claude/skills
+++ b/workers/templates/sentry-pagerduty-incident-tools/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/sentry-sync/.claude/skills
+++ b/workers/templates/sentry-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/snowflake-query/.claude/skills
+++ b/workers/templates/snowflake-query/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/snowflake-sync/.claude/skills
+++ b/workers/templates/snowflake-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/sqlite-query/.claude/skills
+++ b/workers/templates/sqlite-query/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/todoist-sync/.claude/skills
+++ b/workers/templates/todoist-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/vercel-production-deployment-tools/.claude/skills
+++ b/workers/templates/vercel-production-deployment-tools/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/workday-sync/.claude/skills
+++ b/workers/templates/workday-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/workers-default/.claude/skills
+++ b/workers/templates/workers-default/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/zendesk-sync/.claude/skills
+++ b/workers/templates/zendesk-sync/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/workers/templates/zendesk-webhook/.claude/skills
+++ b/workers/templates/zendesk-webhook/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary of changes

**Ship `.claude/skills` in every worker template.**

`makenotion/workers-template` carries a `.claude/skills` symlink that points at `../.agents/skills`. This adds the same link to the canonical set, so Claude Code finds each template's skills at the path it expects.

The link joins `AGENT_SYMLINKS` in `scripts/sync-agent-files.mjs`. No new file. `agents:sync` writes it, and `agents:check` reports drift on it.

The link follows each template's own skill set. `workers-default` resolves to 5 skills. `custom-blocks/whiteboard` resolves to 6.

**Support a nested link in the writer.**

Every earlier link sat at the template root. A link inside `.claude/` needs two adjustments:

| Change | Reason |
| --- | --- |
| `mkdir(dirname(linkPath), { recursive: true })` | `.claude/` does not exist, so `symlink()` fails with `ENOENT` |
| `rm(..., { recursive: true, force: true })` | A real directory at the link path throws `ERR_FS_EISDIR` under `force` alone |

## Verification

**The link matches upstream byte for byte.** The committed blob SHA is `2b7a412b8fa0fb7e985b0793321bd4e698f2b6cd`. That is the same SHA as `.claude/skills` in `makenotion/workers-template`.

**Coverage.** 33 templates get the link. All 33 resolve to a real directory. All 33 store as git mode `120000`; none store as a directory.

**Drift detection works in both directions.** Before `agents:sync`, `agents:check` reported all 33 links missing and exited 1. After sync, it exits 0.

**Adversarial repair.** Each failure mode was introduced, detected, then repaired by `agents:sync`:

1. Delete the link.
2. Repoint the link at a wrong target.
3. Replace the link with a real directory holding a file.

**The `recursive` flag is required, not cosmetic.** A standalone Node script reproduced `ERR_FS_EISDIR` when `rm` ran with `{ force: true }` against a non-empty directory.

**Rebase preserved #83.** Before the rebase this branch would have reverted #83 across 239 files. It now modifies one file, `scripts/sync-agent-files.mjs`, and adds 33 symlinks. `git diff origin/main HEAD -- workers/agents/` is empty.

**Left for you to run:** no `/verify` bundle backs this change. The evidence above comes from direct command output, not from a run bundle. Tell me if you want a `/verify` run before merge.
