### PR TITLE
Bind custom block Vite servers to IPv4

### DIFF
--- a/workers/templates/custom-blocks/custom/blocks/custom/vite.config.ts
+++ b/workers/templates/custom-blocks/custom/blocks/custom/vite.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from "vite"
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+  },
 })

--- a/workers/templates/custom-blocks/habit-tracker/blocks/habit-tracker/vite.config.ts
+++ b/workers/templates/custom-blocks/habit-tracker/blocks/habit-tracker/vite.config.ts
@@ -3,4 +3,7 @@ import react from "@vitejs/plugin-react"
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+  },
 })

--- a/workers/templates/custom-blocks/org-chart/blocks/org-chart/vite.config.ts
+++ b/workers/templates/custom-blocks/org-chart/blocks/org-chart/vite.config.ts
@@ -3,4 +3,7 @@ import react from "@vitejs/plugin-react"
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+  },
 })

--- a/workers/templates/custom-blocks/whiteboard/blocks/whiteboard/vite.config.ts
+++ b/workers/templates/custom-blocks/whiteboard/blocks/whiteboard/vite.config.ts
@@ -3,4 +3,7 @@ import react from "@vitejs/plugin-react"
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+  },
 })


### PR DESCRIPTION
## Summary

The custom block dev shell's serve-ui.js  starts it with server.listen(port, "127.0.0.1", ...).

The `vite.config.ts` for custom block templates do not explicitly use 127.0.0.1. This means Vite’s implicit `localhost` can resolve to IPv6 (`::1`) in certain environments while the dev-shell UI always binds to IPv4 loopback.

As a result, the block server port could be unreachable through the local port exposure.

## Validation

- `npm run check` in each template: custom, habit-tracker, org-chart, and whiteboard.
- `git diff --check`.


[comparison (14).webm](https://github.com/user-attachments/assets/00d2581d-c43a-4e61-ab0f-6ebb8d9af052)
