### PR TITLE
[AJAX-629] [Workflows] Clarify Notion API authentication

### DIFF
--- a/workers/agents/instructions/workflow/INSTRUCTIONS.md
+++ b/workers/agents/instructions/workflow/INSTRUCTIONS.md
@@ -66,9 +66,13 @@ keys, an upsert, or a duplicate check when retries could cause harm.
 
 ## Notion API access
 
-`context.notion` provides the Notion SDK client. Set `NOTION_API_TOKEN` in
-`.env` before a Workflow makes a Notion API request. Push environment values
-after deployment with `ntn workers env push`. Never commit or log credentials.
+`context.notion` provides the Notion SDK client. Deployed Workflows receive
+Notion API credentials automatically. Do not ask for, configure, or push a
+`NOTION_API_TOKEN` for a deployed Workflow.
+
+Local Workflow execution needs `NOTION_API_TOKEN` in `.env` before making a
+Notion API request. Never ask the user to paste the token into chat, and never
+commit or log credentials.
 
 ## Commands
 

--- a/workers/templates/workflows/workflow/.agents/INSTRUCTIONS.md
+++ b/workers/templates/workflows/workflow/.agents/INSTRUCTIONS.md
@@ -66,9 +66,13 @@ keys, an upsert, or a duplicate check when retries could cause harm.
 
 ## Notion API access
 
-`context.notion` provides the Notion SDK client. Set `NOTION_API_TOKEN` in
-`.env` before a Workflow makes a Notion API request. Push environment values
-after deployment with `ntn workers env push`. Never commit or log credentials.
+`context.notion` provides the Notion SDK client. Deployed Workflows receive
+Notion API credentials automatically. Do not ask for, configure, or push a
+`NOTION_API_TOKEN` for a deployed Workflow.
+
+Local Workflow execution needs `NOTION_API_TOKEN` in `.env` before making a
+Notion API request. Never ask the user to paste the token into chat, and never
+commit or log credentials.
 
 ## Commands
 

--- a/workers/templates/workflows/workflow/README.md
+++ b/workers/templates/workflows/workflow/README.md
@@ -58,9 +58,10 @@ Completed steps replay their saved results after a retry. A side effect can
 still run more than once if it succeeds before its result is recorded. Make
 writes idempotent or use an equivalent duplicate guard.
 
-Use `context.notion` for Notion API calls. Add `NOTION_API_TOKEN` to `.env`
-for local development, then run `ntn workers env push` after deployment. Do
-not commit `.env` or credentials.
+Use `context.notion` for Notion API calls. Deployed Workflows receive Notion
+API credentials automatically, so do not configure or push
+`NOTION_API_TOKEN`. Local Workflow execution needs the token in `.env` before
+making a Notion API request. Do not commit `.env` or credentials.
 
 ## Verification
 


### PR DESCRIPTION
## Description

#### Attribution
- Notion user: Jonathan Clem (jclem@makenotion.com)
- Notion thread: [View thread](https://app.dev.notion.com/chat?t=3ceb35e6e67f8090b8f700a919319f7c)

The alpha Workflow template now explains that deployed Workflows receive Notion API credentials automatically. Only local Workflow runs should ask for `NOTION_API_TOKEN`; other Worker template prompts are unchanged.

part of AJAX-629

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

## Is this feature gated? (Optional)

- [ ] Yes (provide feature gate name or instructions to enable/disable)
- [x] No
