### PR TITLE
[AJAX-632] [Apps] Use latest SDK in Cookbook template

### DIFF
--- a/apps/templates/apps-default/package.json
+++ b/apps/templates/apps-default/package.json
@@ -12,7 +12,7 @@
     "node": ">=26.0.0"
   },
   "dependencies": {
-    "@notionhq/apps": "^0.0.4"
+    "@notionhq/apps": "latest"
   },
   "devDependencies": {
     "@types/node": "^26.0.0",


### PR DESCRIPTION
## Description

#### Attribution
- Notion user: Jonathan Clem (jclem@makenotion.com)
- Notion thread: [View thread](https://app.dev.notion.com/chat?t=3ceb35e6e67f80d39b0300a95dc65d2d)

The default Cookbook Apps template now uses the npm `latest` tag for `@notionhq/apps` instead of pinning a release. New template installs will use the current Apps SDK.

Part of AJAX-632.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

## Is this feature gated? (Optional)

- [x] Yes — Notion Apps alpha
- [ ] No
